### PR TITLE
Containerize build

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -3,7 +3,8 @@
 # Builds secretless binaries
 # usage: ./build/build.sh [OPTIONAL LIST OS] [OPTIONAL LIST ARCH]
 # If OS/arch arguments are unspecified, builds binaries for all supported 
-# operating systems and architectures
+# operating systems and architectures. Set KEEP_ALIVE=1 to keep the build
+# container running after this script exits.
 set -ex
 
 on_error () {


### PR DESCRIPTION
It's now run in docker. It supports parameterized list of OS/arch and the environment variable `KEEP_ALIVE` will keep the build context container running after the build script exits.

To mimic old behavior:
`./bin/build linux amd64`