### PR TITLE
Dockerfile now derives from alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.7
 MAINTAINER CyberArk Software, Inc.
 
-RUN mkdir -p /var/www /lib64 \
+RUN mkdir -p /lib64 \
     && ln -fs /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
 COPY ./bin/linux/amd64/secretless /


### PR DESCRIPTION
reduces docker image size from ~750MB to 27.3MB