### PR TITLE
Secretless now loads plugins in modular ways

### DIFF
--- a/pkg/secretless/plugin/plugin.go
+++ b/pkg/secretless/plugin/plugin.go
@@ -41,3 +41,19 @@ type Plugin interface {
 	// Shutdown is called when secretless caught a signal to exit
 	Shutdown()
 }
+
+// ----------------- V1 interfaces -----------------
+// Listener v1 interface
+// TODO: Move this to its own folder
+// TODO: Really define this interface
+type Listener_v1 = Plugin
+
+// Handler v1 interface
+// TODO: Move this to its own folder
+// TODO: Really define this interface
+type Handler_v1 = Plugin
+
+// Manager v1 interface
+// TODO: Move this to its own folder
+// TODO: Really define this interface
+type Manager_v1 = Plugin


### PR DESCRIPTION
Partially resolves https://github.com/conjurinc/secretless/issues/64

[Jenkins build](https://jenkins.conjur.net/view/conjurinc/job/conjurinc--secretless/job/64-handlers-as-plugins/)

What this PR does:
- Changes plugin API interface to be versioned
- Adds new interfaces (currently just copies of `plugin.Plugin`) to separate functionality of each modular piece (manager, handler, and listener).
- Adds methods to plugins for loading individually managers, handlers, and listeners (last two are pending integration with https://github.com/conjurinc/secretless-server/pull/59.

How to test:
- Build server plugin with changes from https://github.com/conjurinc/secretless-server/pull/70 and start secretless.
