### PR TITLE
Updated and pinned all Golang Docker images to 1.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10-stretch as secretless-builder
+FROM golang:1.10.3-stretch as secretless-builder
 MAINTAINER Conjur Inc.
 LABEL builder="secretless-builder"
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.10-stretch
+FROM golang:1.10.3-stretch
 MAINTAINER Conjur Inc.
 
 RUN apt-get update && \

--- a/doc/full-demo/src/client/Dockerfile
+++ b/doc/full-demo/src/client/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:16.04
 
-RUN apt-get update && apt-get install -y vim curl jq postgresql-client
+RUN apt-get update && \
+    apt-get install -y curl \
+                       jq \
+                       postgresql-client \
+                       vim
 
 COPY . .

--- a/doc/full-demo/src/myapp/Dockerfile
+++ b/doc/full-demo/src/myapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.10.3
 
 RUN apt-get update && apt-get install -y vim curl jq postgresql-client
 

--- a/doc/full-demo/src/proxy_tls/Dockerfile
+++ b/doc/full-demo/src/proxy_tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8
+FROM golang:1.10.3
 
 WORKDIR /go/src/proxy_tls
 


### PR DESCRIPTION
Partial PR for: https://github.com/conjurinc/secretless-server/issues/71

https://jenkins.conjur.net/view/conjurinc/job/conjurinc--secretless/job/71-pin-golang-version/

What this PR does:
- Hard-pins all images that use Golang to 1.10.3.
- Minor cleanup in Dockerfiles