### PR TITLE
Moved all internal listeners to our plugin_v1 interface

### DIFF
--- a/cmd/secretless/main.go
+++ b/cmd/secretless/main.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"log"
 
-	"github.com/conjurinc/secretless/internal/app/secretless"
 	"github.com/conjurinc/secretless/internal/pkg/plugin"
 	"github.com/conjurinc/secretless/pkg/secretless/config"
 	yaml "gopkg.in/yaml.v1"
@@ -32,13 +31,19 @@ func main() {
 		}
 	}
 
-	err = plugin.GetManager().LoadPlugins(*pluginDir, configuration)
+	log.Println("Loading internal plugins...")
+	err = plugin.GetManager().LoadInternalPlugins(configuration)
+	if err != nil {
+		log.Println(err)
+	}
+
+	log.Println("Loading external library plugins...")
+	err = plugin.GetManager().LoadLibraryPlugins(*pluginDir, configuration)
 	if err != nil {
 		log.Println(err)
 	}
 
 	plugin.GetManager().RegisterSignalHandlers()
 
-	p := secretless.Proxy{Config: configuration}
-	p.Run()
+	plugin.GetManager().Run(configuration)
 }

--- a/internal/app/secretless/mysql/backend.go
+++ b/internal/app/secretless/mysql/backend.go
@@ -15,7 +15,7 @@ func (h *Handler) ConfigureBackend() (err error) {
 	result := BackendConfig{Options: make(map[string]string)}
 
 	var values map[string][]byte
-	if values, err = variable.Resolve(h.Config.Credentials); err != nil {
+	if values, err = variable.Resolve(h.Config.Credentials, h.EventNotifier); err != nil {
 		return
 	}
 

--- a/internal/app/secretless/pg/backend.go
+++ b/internal/app/secretless/pg/backend.go
@@ -15,7 +15,7 @@ func (h *Handler) ConfigureBackend() (err error) {
 	result := BackendConfig{Options: make(map[string]string)}
 
 	var values map[string][]byte
-	if values, err = variable.Resolve(h.Config.Credentials); err != nil {
+	if values, err = variable.Resolve(h.Config.Credentials, h.EventNotifier); err != nil {
 		return
 	}
 

--- a/internal/app/secretless/pg/listener.go
+++ b/internal/app/secretless/pg/listener.go
@@ -10,14 +10,14 @@ import (
 	"github.com/conjurinc/secretless/pkg/secretless/config"
 	"github.com/conjurinc/secretless/pkg/secretless/plugin_v1"
 	validation "github.com/go-ozzo/ozzo-validation"
-	"github.com/conjurinc/secretless/internal/pkg/plugin"
 )
 
 // Listener listens for and handles new connections.
 type Listener struct {
-	Config   config.Listener
-	Handlers []config.Handler
-	Listener net.Listener
+	Config         config.Listener
+	HandlerConfigs []config.Handler
+	NetListener    net.Listener
+	EventNotifier  plugin_v1.EventNotifier
 }
 
 // HandlerHasCredentials validates that a handler has all necessary credentials.
@@ -45,8 +45,8 @@ func (hhc handlerHasCredentials) Validate(value interface{}) error {
 // Validate verifies the completeness and correctness of the Listener.
 func (l Listener) Validate() error {
 	return validation.ValidateStruct(&l,
-		validation.Field(&l.Handlers, validation.Required),
-		validation.Field(&l.Handlers, handlerHasCredentials{}),
+		validation.Field(&l.HandlerConfigs, validation.Required),
+		validation.Field(&l.HandlerConfigs, handlerHasCredentials{}),
 	)
 }
 
@@ -60,10 +60,14 @@ func (l *Listener) Listen() {
 		}
 
 		// Serve the first Handler which is attached to this listener
-		if len(l.Handlers) > 0 {
-			handler := &Handler{Config: l.Handlers[0], Client: client}
+		if len(l.HandlerConfigs) > 0 {
+			handler := &Handler{
+				Config:        l.HandlerConfigs[0],
+				Client:        client,
+				EventNotifier: l.EventNotifier,
+			}
 			// TODO: there's a better way to do this
-			plugin.GetManager().CreateHandler(handler, client)
+			l.EventNotifier.CreateHandler(handler, client)
 
 			handler.Run()
 		} else {
@@ -77,22 +81,36 @@ func (l *Listener) Listen() {
 	}
 }
 
-// GetConfig implements secretless.Listener
+// GetConfig implements plugin_v1.Listener
 func (l *Listener) GetConfig() config.Listener {
 	return l.Config
 }
 
-// GetListener implements secretless.Listener
+// GetListener implements plugin_v1.Listener
 func (l *Listener) GetListener() net.Listener {
-	return l.Listener
+	return l.NetListener
 }
 
-// GetHandlers implements secretless.Listener
+// GetHandlers implements plugin_v1.Listener
 func (l *Listener) GetHandlers() []plugin_v1.Handler {
 	return nil
 }
 
-// GetConnections implements secretless.Listener
+// GetConnections implements plugin_v1.Listener
 func (l *Listener) GetConnections() []net.Conn {
 	return nil
+}
+
+// GetNotifier implements plugin_v1.Listener
+func (l *Listener) GetNotifier() plugin_v1.EventNotifier {
+	return l.EventNotifier
+}
+
+func ListenerFactory(options plugin_v1.ListenerOptions) plugin_v1.Listener {
+	return &Listener{
+		Config:         options.ListenerConfig,
+		HandlerConfigs: options.HandlerConfigs,
+		NetListener:    options.NetListener,
+		EventNotifier:  options.EventNotifier,
+	}
 }

--- a/internal/app/secretless/plugins.go
+++ b/internal/app/secretless/plugins.go
@@ -1,0 +1,18 @@
+package secretless
+
+import (
+	"github.com/conjurinc/secretless/internal/app/secretless/http"
+	"github.com/conjurinc/secretless/internal/app/secretless/mysql"
+	"github.com/conjurinc/secretless/internal/app/secretless/pg"
+	"github.com/conjurinc/secretless/internal/app/secretless/ssh"
+	"github.com/conjurinc/secretless/internal/app/secretless/sshagent"
+	"github.com/conjurinc/secretless/pkg/secretless/plugin_v1"
+)
+
+var InternalListeners = map[string]func(plugin_v1.ListenerOptions) plugin_v1.Listener{
+	"http":      http.ListenerFactory,
+	"mysql":     mysql.ListenerFactory,
+	"pg":        pg.ListenerFactory,
+	"ssh":       ssh.ListenerFactory,
+	"ssh-agent": sshagent.ListenerFactory,
+}

--- a/internal/app/secretless/ssh/handler.go
+++ b/internal/app/secretless/ssh/handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/conjurinc/secretless/internal/app/secretless/variable"
 	"github.com/conjurinc/secretless/pkg/secretless/config"
+	"github.com/conjurinc/secretless/pkg/secretless/plugin_v1"
 )
 
 type ServerConfig struct {
@@ -18,8 +19,9 @@ type ServerConfig struct {
 }
 
 type Handler struct {
-	Config   config.Handler
-	Channels <-chan ssh.NewChannel
+	Config        config.Handler
+	Channels      <-chan ssh.NewChannel
+	EventNotifier plugin_v1.EventNotifier
 }
 
 func (h *Handler) serverConfig() (config ServerConfig, err error) {
@@ -27,7 +29,7 @@ func (h *Handler) serverConfig() (config ServerConfig, err error) {
 
 	log.Printf("%s", h.Config.Credentials)
 
-	if values, err = variable.Resolve(h.Config.Credentials); err != nil {
+	if values, err = variable.Resolve(h.Config.Credentials, h.EventNotifier); err != nil {
 		return
 	}
 

--- a/internal/app/secretless/ssh/listener.go
+++ b/internal/app/secretless/ssh/listener.go
@@ -19,10 +19,12 @@ import (
 //
 // NOTE: This MITM approach to SSH is experimental. The ssh-agent approach is
 // better validated and probably better all-around.
+
 type Listener struct {
-	Config   config.Listener
-	Handlers []config.Handler
-	Listener net.Listener
+	Config         config.Listener
+	HandlerConfigs []config.Handler
+	NetListener    net.Listener
+	EventNotifier  plugin_v1.EventNotifier
 }
 
 // HandlerHasCredentials validates that a handler has all necessary credentials.
@@ -47,8 +49,8 @@ func (hhc handlerHasCredentials) Validate(value interface{}) error {
 // Validate verifies the completeness and correctness of the Listener.
 func (l Listener) Validate() error {
 	return validation.ValidateStruct(&l,
-		validation.Field(&l.Handlers, validation.Required),
-		validation.Field(&l.Handlers, handlerHasCredentials{}),
+		validation.Field(&l.HandlerConfigs, validation.Required),
+		validation.Field(&l.HandlerConfigs, handlerHasCredentials{}),
 	)
 }
 
@@ -98,31 +100,49 @@ func (l *Listener) Listen() {
 		}()
 
 		// Serve the first Handler which is attached to this listener
-		if len(l.Handlers) == 0 {
+		if len(l.HandlerConfigs) == 0 {
 			log.Panicf("No ssh handler is available")
 		}
 
-		handler := &Handler{Config: l.Handlers[0], Channels: chans}
+		handler := &Handler{
+			Config:        l.HandlerConfigs[0],
+			Channels:      chans,
+			EventNotifier: l.EventNotifier,
+		}
 		handler.Run()
 	}
 }
 
-// GetConfig implements secretless.Listener
+// GetConfig implements plugin_v1.Listener
 func (l *Listener) GetConfig() config.Listener {
 	return l.Config
 }
 
-// GetListener implements secretless.Listener
+// GetListener implements plugin_v1.Listener
 func (l *Listener) GetListener() net.Listener {
-	return l.Listener
+	return l.NetListener
 }
 
-// GetHandlers implements secretless.Listener
+// GetHandlers implements plugin_v1.Listener
 func (l *Listener) GetHandlers() []plugin_v1.Handler {
 	return nil
 }
 
-// GetConnections implements secretless.Listener
+// GetConnections implements plugin_v1.Listener
 func (l *Listener) GetConnections() []net.Conn {
 	return nil
+}
+
+// GetNotifier implements plugin_v1.Listener
+func (l *Listener) GetNotifier() plugin_v1.EventNotifier {
+	return l.EventNotifier
+}
+
+func ListenerFactory(options plugin_v1.ListenerOptions) plugin_v1.Listener {
+	return &Listener{
+		Config:         options.ListenerConfig,
+		HandlerConfigs: options.HandlerConfigs,
+		NetListener:    options.NetListener,
+		EventNotifier:  options.EventNotifier,
+	}
 }

--- a/internal/app/secretless/sshagent/handler.go
+++ b/internal/app/secretless/sshagent/handler.go
@@ -12,12 +12,14 @@ import (
 
 	"github.com/conjurinc/secretless/internal/app/secretless/variable"
 	"github.com/conjurinc/secretless/pkg/secretless/config"
+	"github.com/conjurinc/secretless/pkg/secretless/plugin_v1"
 )
 
 // Handler implements an ssh-agent which holds a single key.
 type Handler struct {
-	Config     config.Handler
-	Connection net.Conn
+	Config        config.Handler
+	Connection    net.Conn
+	EventNotifier plugin_v1.EventNotifier
 }
 
 func parseKey(pemStr []byte) (rawkey interface{}, err error) {
@@ -45,7 +47,7 @@ func parseKey(pemStr []byte) (rawkey interface{}, err error) {
 func (h *Handler) LoadKeys(keyring agent.Agent) (err error) {
 	var values map[string][]byte
 
-	if values, err = variable.Resolve(h.Config.Credentials); err != nil {
+	if values, err = variable.Resolve(h.Config.Credentials, h.EventNotifier); err != nil {
 		return
 	}
 

--- a/internal/app/secretless/variable/resolve.go
+++ b/internal/app/secretless/variable/resolve.go
@@ -1,15 +1,15 @@
 package variable
 
 import (
-	"github.com/conjurinc/secretless/internal/pkg/plugin"
 	providerPkg "github.com/conjurinc/secretless/internal/pkg/provider"
 	"github.com/conjurinc/secretless/pkg/secretless"
 	"github.com/conjurinc/secretless/pkg/secretless/config"
+	"github.com/conjurinc/secretless/pkg/secretless/plugin_v1"
 )
 
 // Resolve accepts an list of Providers and a list of Variables and
 // attempts to obtain the value of each Variable from the appropriate Provider.
-func Resolve(variables []config.Variable) (result map[string][]byte, err error) {
+func Resolve(variables []config.Variable, eventNotifier plugin_v1.EventNotifier) (result map[string][]byte, err error) {
 	result = make(map[string][]byte)
 
 	for _, v := range variables {
@@ -25,7 +25,7 @@ func Resolve(variables []config.Variable) (result map[string][]byte, err error) 
 		}
 		result[v.Name] = value
 
-		plugin.GetManager().ResolveVariable(provider, v.Name, value)
+		eventNotifier.ResolveVariable(provider, v.Name, value)
 	}
 
 	return

--- a/internal/pkg/util/util.go
+++ b/internal/pkg/util/util.go
@@ -3,7 +3,6 @@ package util
 import (
 	"net"
 
-	"github.com/conjurinc/secretless/internal/pkg/plugin"
 	"github.com/conjurinc/secretless/pkg/secretless/plugin_v1"
 )
 
@@ -12,7 +11,7 @@ import (
 func Accept(l plugin_v1.Listener) (net.Conn, error) {
 	conn, err := l.GetListener().Accept()
 	if conn != nil && err == nil {
-		plugin.GetManager().NewConnection(l, conn)
+		l.GetNotifier().NewConnection(l, conn)
 	}
 	return conn, err
 }

--- a/pkg/secretless/config/config.go
+++ b/pkg/secretless/config/config.go
@@ -92,7 +92,6 @@ func (l Listener) SelectHandlers(handlers []Handler) []Handler {
 func (l Listener) Validate() (err error) {
 	err = validation.ValidateStruct(&l,
 		validation.Field(&l.Name, validation.Required),
-		validation.Field(&l.Protocol, validation.Required, validation.In("pg", "http", "ssh", "ssh-agent", "mysql")),
 	)
 
 	return

--- a/pkg/secretless/plugin_v1/connection_manager.go
+++ b/pkg/secretless/plugin_v1/connection_manager.go
@@ -7,9 +7,9 @@ import (
 	"github.com/conjurinc/secretless/pkg/secretless/config"
 )
 
-// Manager is an interface to be implemented by plugins that want to
+// ConnectionManager is an interface to be implemented by plugins that want to
 // manage connections for handlers and listeners.
-type Manager interface {
+type ConnectionManager interface {
 	// Initialize is called before proxy initialization
 	Initialize(config.Config) error
 

--- a/pkg/secretless/plugin_v1/event_notifier.go
+++ b/pkg/secretless/plugin_v1/event_notifier.go
@@ -1,0 +1,30 @@
+package plugin_v1
+
+import (
+	"net"
+
+	"github.com/conjurinc/secretless/pkg/secretless"
+)
+
+// EventNotifier is the interface which is used to pass event up from handlers/
+// listeners/managers back up to the main plugin manager
+type EventNotifier interface {
+	// NewConnection is called for each new client connection before being
+	// passed to a handler
+	NewConnection(Listener, net.Conn)
+
+	// ClientData is called for each inbound packet from clients
+	ClientData(net.Conn, []byte)
+
+	// CreateHandler is called after listener creates a new handler
+	CreateHandler(Handler, net.Conn)
+
+	// CreateListener is called for every listener created by Proxy
+	CreateListener(Listener)
+
+	// ResolveVariable is called when a provider resolves a variable
+	ResolveVariable(p secretless.Provider, id string, value []byte)
+
+	// ServerData is called for each inbound packet from the backend
+	ServerData(net.Conn, []byte)
+}

--- a/pkg/secretless/plugin_v1/listener.go
+++ b/pkg/secretless/plugin_v1/listener.go
@@ -6,11 +6,21 @@ import (
 	"github.com/conjurinc/secretless/pkg/secretless/config"
 )
 
+type ListenerOptions struct {
+	EventNotifier  EventNotifier
+	ListenerConfig config.Listener
+	HandlerConfigs []config.Handler
+	NetListener    net.Listener
+}
+
 // Listener is the interface which accepts client connections and passes them
 // to a handler
 type Listener interface {
+	Validate() error
 	GetConfig() config.Listener
+	GetNotifier() EventNotifier
 	GetListener() net.Listener
 	GetHandlers() []Handler
 	GetConnections() []net.Conn
+	Listen()
 }


### PR DESCRIPTION
Partially implements #64 

[Jenkins Build](https://jenkins.conjur.net/view/conjurinc/job/conjurinc--secretless/job/64-handlers-as-plugins-v3/)

Sister PR: https://github.com/conjurinc/secretless-server/pull/86

What this PR does:
- Moves all internal plugins to common plugin interfaces
- Abstracts plugin manager into a Notify interface
- Eliminates circular dependencies
- Adds loading of plugins from external plugins