### PR TITLE
Add pipeline step to run golint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ doc/**/proxy_tls
 doc/**/myapp
 !doc/**/src/myapp
 test/junit.*
+test/*.xml
 test/plugin/out/
 
 # Remove common editors' swapfiles

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,11 +15,19 @@ pipeline {
       }
     }
 
+    stage('Static analysis - code linting') {
+      steps {
+        sh './bin/check_style'
+
+        checkstyle pattern: 'test/golint.xml', canComputeNew: false, unstableTotalAll: '0', healthy: '0', failedTotalAll: '20',  unHealthy: '10'
+      }
+    }
+
     stage('Run tests') {
       steps {
         sh './bin/test'
 
-        junit 'test/*.xml'
+        junit 'test/junit.xml'
       }
     }
 

--- a/bin/check_style
+++ b/bin/check_style
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+project_root="/go/src/github.com/conjurinc/secretless/"
+root_dir_length=${#project_root}
+
+# accepts an input string of style errs and outputs XML
+# the style err string is a newline-delimited list of
+# style errors of the form "file:line:[0-9]*: error"
+# the output is checkstyle-format XML, with a list of
+# errors for each file
+output_xml() {
+  style_errs="${1}"
+
+  echo "<checkstyle>"
+  if [[ ! -z "$style_errs" ]]; then
+    current_file=""
+
+    # loop through each file with errors
+    while IFS= read -r err_line; do
+
+      # get the filename and line # of the error
+      file_and_line_length=$(expr index "$err_line" " ")-2
+      file_and_line=${err_line:0:file_and_line_length}
+
+      IFS=":" read -r -a file_data <<< "$file_and_line"
+      file=${file_data[0]:$root_dir_length}
+      line=${file_data[1]}
+
+      # get the error
+      error=${err_line:$file_and_line_length+2}
+
+      # output the file (if haven't already) and error
+      if [ "$current_file" != "$file" ]; then
+        if [[ ! -z "$current_file" ]]; then
+          echo "  </file>"
+        fi
+        echo "  <file name=\"$file\">"
+        current_file=$file
+      fi
+
+      echo "    <error line=\"$line\" message=\"$error\"></error>"
+    done <<< "$style_errs"
+
+    echo "  </file>"
+  fi
+  echo "</checkstyle>"
+}
+
+style_errs=$(docker run \
+  --rm \
+  secretless-dev \
+  bash -c "
+    go get -u golang.org/x/lint/golint
+    golint /go/src/github.com/conjurinc/secretless/cmd/...
+    golint /go/src/github.com/conjurinc/secretless/internal/...
+    golint /go/src/github.com/conjurinc/secretless/pkg/...
+    golint /go/src/github.com/conjurinc/secretless/test/...
+  ")
+
+output_xml "$style_errs" 2>&1 | tee ./test/golint.xml


### PR DESCRIPTION
Resolves #119 

This PR updates the Jenkins pipeline to run `golint`

[Jenkins build](https://jenkins.conjur.net/job/conjurinc--secretless/job/119-pipeline-style-step/)