### PR TITLE
Add tabs to landing page quickstart

### DIFF
--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -81,19 +81,44 @@ id: home
 	<div class="card introduction" id="simple-started">
 		<div class="row sub-card">
 			<p class="card-heading">It's simple to get started!</p>
-			<ol>
-				<li>Download and run the Secretless quick-start as a Docker container:
-				<pre>docker container run --rm -p 5454:5454 cyberark/secretless-quickstart</pre></li>
-				<li>That's all! Now you can connect to the password-protected PostgreSQL database via the Secretless broker, without knowing its password.<p>Give it a try:</p>
-<pre>psql \
---host localhost \
---port 5454 \
---username secretless \
--d quickstart \
--c 'select * from counties;'
-</pre></li>
-			</ol>
-
+			<p class="card-subheading">Choose your path:</p>
+			<div class="row btnrow"></div>
+				<a class="button active" href="javascript:void(0)" onclick="showTab(event, 'PostgreSQL')">PostgreSQL</a>
+				<a class="button" href="javascript:void(0)" onclick="showTab(event, 'HTTP')">HTTP</a>
+				<a class="button" href="javascript:void(0)" onclick="showTab(event, 'SSH')">SSH</a>
+			</div>
+			<div class="tab-content" style="display: block" id="PostgreSQL">
+				<ol>
+					<li>Download and run the Secretless quick-start as a Docker container:
+					<pre>docker container run --rm -p 5454:5454 cyberark/secretless-quickstart</pre></li>
+					<li>That's all! Now you can connect to the password-protected PostgreSQL database via the Secretless broker, without knowing its password.<p>Give it a try:</p>
+	<pre>psql \
+  --host localhost \
+  --port 5454 \
+  --username secretless \
+  -d quickstart \
+  -c 'select * from counties;'
+	</pre></li>
+				</ol>
+			</div>
+			<div class="tab-content" id="HTTP">
+				<ol>
+					<li>Download and run the Secretless quick-start as a Docker container:
+					<pre>docker container run --rm -p 80:80 -p 8081:8081 cyberark/secretless-quickstart</pre></li>
+					<li>That's all! Now you can make an authenticated HTTP request by using the Secretless broker as a proxy without knowing any credentials.<p>Give it a try:</p>
+						<pre>http_proxy=localhost:8081 curl -i localhost</pre>
+					</li>
+				</ol>
+			</div>
+			<div class="tab-content" id="SSH">
+				<ol>
+					<li>Download and run the Secretless quick-start as a Docker container:
+					<pre>docker container run --rm -p 2222:2222 cyberark/secretless-quickstart</pre></li>
+					<li>That's all! Now you can establish an SSH connection through the Secretless broker without knowing any credentials.<p>Give it a try:</p>
+						<pre>ssh -p 2222 user@localhost</pre>
+					</li>
+				</ol>
+			</div>
 		</div>
 	</div>
 </div>

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -24,6 +24,10 @@ hr{
 button:focus{
 	outline: 0;
 }
+.button.active{
+	box-shadow: inset 0 2px 5px 0 rgba(0,0,0,0.16), inset 0 2px 10px 0 rgba(0,0,0,0.12);
+	background-color: rgba(0,0,0,0.001);
+}
 pre{
 	background-color: white;
 }
@@ -342,6 +346,9 @@ pre{
 .container-fluid{
 	background-color: #f8f8f8;
 	/*box-shadow: 0 3px 4px rgba(0,0,0,.1);*/
+}
+.tab-content{
+	display: none;
 }
 footer{
 	background-color: #4e4f4f;

--- a/docs/javascript/secretless_js.js
+++ b/docs/javascript/secretless_js.js
@@ -13,3 +13,39 @@ function fixNav(){
 	}
 }
 window.addEventListener('scroll', fixNav);
+
+
+// showTab
+// Traverses up the DOM and finds `tab-content` class elements which share a
+// common root with the `event` source. Once found, all `tab-content` elements
+// are hidden, except for the element whose `id` matches `tabName`.
+function showTab(event, tabName) {
+	// Toggle `active` class on sibling buttons
+	var srcElement = event.srcElement;
+	const parentElement = srcElement.parentElement;
+	const srcSiblings = parentElement.getElementsByClassName('button');
+	for (var i = 0; i < srcSiblings.length; ++i) {
+		srcSiblings[i].classList.remove('active');
+	}
+	srcElement.classList.add('active');
+
+	// Find a common root between the event source and `tab-content` elements
+	var closestTabs = [];
+	while (srcElement != null) {
+		const tabs = srcElement.getElementsByClassName('tab-content');
+		if (tabs.length > 0) {
+			closestTabs = tabs;
+			break;
+		}
+
+		srcElement = srcElement.parentElement;
+	}
+
+	// Toggle `tab-content` visibility
+	for (var i = 0; i < closestTabs.length; ++i) {
+		const tab = closestTabs[i];
+		const display = tab.id === tabName ? 'block' : 'none';
+
+		tab.style.display = display;
+	}
+}


### PR DESCRIPTION
Resolves #144 

You may now select PostgreSQL/HTTP/SSH quickstarts by clicking the
appropriate button.

![image](https://user-images.githubusercontent.com/4897145/42655514-6a8dea22-85ea-11e8-8bee-0f57799864eb.png)

To test:
```
$ cd docs
$ bundle exec jekyll serve
$ open localhost:4000
```