### PR TITLE
Added better readme and dev_env to ssh_agent test

### DIFF
--- a/internal/app/secretless/handlers/sshagent/handler.go
+++ b/internal/app/secretless/handlers/sshagent/handler.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"reflect"
 	"strconv"
 
 	"golang.org/x/crypto/ssh/agent"
@@ -53,7 +54,8 @@ func (h *Handler) LoadKeys(keyring agent.Agent) (err error) {
 	}
 
 	if h.GetConfig().Debug {
-		log.Printf("ssh-agent credential values : %s", values)
+		keys := reflect.ValueOf(values).MapKeys()
+		log.Printf("SSH agent connection parameters: %s", keys)
 	}
 
 	key := agent.AddedKey{}

--- a/test/ssh_agent_handler/README.md
+++ b/test/ssh_agent_handler/README.md
@@ -1,4 +1,10 @@
-## Testing your local changes
+# SSH Agent test
+
+This test runs a connection test using Secretless and a SSH agent socket. Ideally the
+test will ensure that connection to a secured ssh-host required no authentication data
+from the client connecting over Secretless.
+
+## Testing
 
 You can test your local changes by re-building the Docker images (running
 `./bin/build` in the project root) and then running the test suite as usual:
@@ -13,3 +19,30 @@ added to the image in the last build:
 ./start
 ./test -l
 ```
+
+## Development
+
+From this directory run `./run_dev` which should get you into a container with Secretless code.
+
+You can start Secretless with:
+```
+$ go run cmd/secretless/main.go -f test/ssh_agent_handler/secretless.dev.yml
+```
+
+You can test the code by first either:
+- running the previous command in the background (appending ` &` to it)
+- or connecting with a different terminal to the container with `docker-compose exec dev /bin/bash`
+
+After doing that, you can try opening a separate connection to Secretless on `/sock/.agent` and ensuring
+that no authentication is needed.
+
+_Note: You may need to remove the `/sock/.agent` after you exit Secretless to be able to start it again_
+
+```
+$ export SSH_AUTH_SOCK=/sock/.agent
+$ ssh -o StrictHostKeyChecking=no root@ssh_host 'ls -la /'
+```
+
+## Cleaning up
+
+From this directory, run `./stop`.

--- a/test/ssh_agent_handler/docker-compose.yml
+++ b/test/ssh_agent_handler/docker-compose.yml
@@ -34,8 +34,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
+    command: sleep 999d
     volumes:
       - ../..:/go/src/github.com/conjurinc/secretless
+      - ./id_insecure:/id_insecure:ro
+      - ssh-agent-socket:/sock
+    depends_on:
+      - ssh_host
 
 volumes:
   ssh-agent-socket:

--- a/test/ssh_agent_handler/run_dev
+++ b/test/ssh_agent_handler/run_dev
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+
+trap './stop' EXIT QUIT INT
+
+docker-compose up -d dev
+docker-compose exec dev /bin/bash

--- a/test/ssh_agent_handler/secretless.dev.yml
+++ b/test/ssh_agent_handler/secretless.dev.yml
@@ -1,0 +1,13 @@
+listeners:
+  - name: sshagent
+    protocol: ssh-agent
+    socket: /sock/.agent
+
+handlers:
+  - name: ssh-agent
+    listener: sshagent
+    debug: true
+    credentials:
+      - name: rsa
+        provider: file
+        id: /id_insecure


### PR DESCRIPTION
This should make the test much more accessible to newcomers.

Resolves #83 

[Jenkins Build](https://jenkins.conjur.net/view/conjurinc/job/conjurinc--secretless/job/83-ssh-agent-test-improvements/)

What this PR does:
- Adds better README to ssh_agent test
- Adds a working run_dev script
- Removes display of private keys from Secretless ssh_agent handler