### PR TITLE
Update the README

### DIFF
--- a/demos/quick-start/docker/Dockerfile
+++ b/demos/quick-start/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM secretless:latest as secretless
+FROM registry2.itci.conjur.net/conjurinc/secretless:latest as secretless
 FROM postgres:9.6.9-alpine
 
 MAINTAINER "CyberArk Software, Inc."


### PR DESCRIPTION
Resolves #78 

- Update project to Alpha status
- Revise content - reorganize order of appearance, add more details, etc
- Replace demos with reference to quick start demo
- Add community and contributing info

Also updates quick start to pull from Docker registry instead of using local secretless image, so
that demo users don't have to build the project. This can be updated once we're pushing to
Dockerhub to pull from there instead of our internal registry.

[Jenkins build](https://jenkins.conjur.net/job/conjurinc--secretless/job/78-update-project-readme/)