### PR TITLE
Clean up quickstart whitespace

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,12 +23,11 @@ description: Secretless
             <li>
               <p>Download and run the Secretless quick-start as a Docker container:</p>
               <pre>
-                docker container run \
-                  --rm \
-                  -p 5432:5432 \
-                  -p 5454:5454 \
-                  cyberark/secretless-quickstart
-              </pre>
+docker container run \
+  --rm \
+  -p 5432:5432 \
+  -p 5454:5454 \
+  cyberark/secretless-quickstart</pre>
             </li>
 
             <li>
@@ -37,12 +36,12 @@ description: Secretless
               have the credentials required to connect (even if you know the
               username):</p>
               <pre>
-                psql \
-                  --host localhost \
-                  --port 5432 \
-                  --username secretless \
-                  -d quickstart \
-                  -c 'select * from counties;'</pre>
+psql \
+  --host localhost \
+  --port 5432 \
+  --username secretless \
+  -d quickstart \
+  -c 'select * from counties;'</pre>
             </li>
 
             <li>
@@ -51,12 +50,12 @@ description: Secretless
               Secretless broker on port <code>5454</code>, <i>without knowing the
               password.</i> Give it a try:</p>
               <pre>
-                psql \
-                  --host localhost \
-                  --port 5454 \
-                  --username secretless \
-                  -d quickstart \
-                  -c 'select * from counties;'</pre>
+psql \
+  --host localhost \
+  --port 5454 \
+  --username secretless \
+  -d quickstart \
+  -c 'select * from counties;'</pre>
             </li>
           </ol>
         </div>
@@ -66,21 +65,18 @@ description: Secretless
             <li>
               <p>Download and run the Secretless quick-start as a Docker container:</p>
               <pre>
-                docker container run \
-                  --rm \
-                  -p 8080:80 \
-                  -p 8081:8081 \
-                  cyberark/secretless-quickstart
-              </pre>
+docker container run \
+  --rm \
+  -p 8080:80 \
+  -p 8081:8081 \
+  cyberark/secretless-quickstart</pre>
             </li>
 
             <li>
               <p>The service we're trying to connect to is listening on port
               <code>8080</code>. If you try to access it, the service will inform
               you that you're unauthorized:</p>
-              <pre>
-                curl -i localhost:8080
-              </pre>
+              <pre>curl -i localhost:8080</pre>
             </li>
 
             <li>
@@ -88,9 +84,7 @@ description: Secretless
               through the Secretless broker on port <code>8081</code>. Secretless
               will inject the proper credentials into the request <i>without you
               needing to know what they are</i>. Give it a try:</p>
-              <pre>
-                http_proxy=localhost:8081 curl -i localhost:8080
-              </pre>
+              <pre>http_proxy=localhost:8081 curl -i localhost:8080</pre>
             </li>
           </ol>
         </div>
@@ -100,30 +94,25 @@ description: Secretless
             <li>
               <p>Download and run the Secretless quick-start as a Docker container:</p>
               <pre>
-                docker container run \
-                  --rm \
-                  -p 2221:22 \
-                  -p 2222:2222 \
-                  cyberark/secretless-quickstart
-              </pre>
+docker container run \
+  --rm \
+  -p 2221:22 \
+  -p 2222:2222 \
+  cyberark/secretless-quickstart</pre>
             </li>
 
             <li>
               <p>The default SSH service is exposed over port <code>2221</code>. You
               can try opening an SSH connection to the server, but you don't have
               the credentials to log in:</p>
-              <pre>
-                ssh -p 2221 user@localhost
-              </pre>
+              <pre>ssh -p 2221 user@localhost</pre>
             </li>
 
             <li>
               <p>The good news is that you don't need credentials! You can establish
               an SSH connection through the Secretless broker on port
               <code>2222</code> <i>without any credentials</i>. Give it a try:</p>
-              <pre>
-                ssh -p 2222 user@localhost
-              </pre>
+              <pre>ssh -p 2222 user@localhost</pre>
             </li>
           </ol>
         </div>

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -25,12 +25,11 @@ Choose your path:
       <li>
         <p>Download and run the Secretless quick-start as a Docker container:</p>
         <pre>
-          docker container run \
-            --rm \
-            -p 5432:5432 \
-            -p 5454:5454 \
-            cyberark/secretless-quickstart
-        </pre>
+docker container run \
+  --rm \
+  -p 5432:5432 \
+  -p 5454:5454 \
+  cyberark/secretless-quickstart</pre>
       </li>
 
       <li>
@@ -39,12 +38,12 @@ Choose your path:
         have the credentials required to connect (even if you know the
         username):</p>
         <pre>
-          psql \
-            --host localhost \
-            --port 5432 \
-            --username secretless \
-            -d quickstart \
-            -c 'select * from counties;'</pre>
+psql \
+  --host localhost \
+  --port 5432 \
+  --username secretless \
+  -d quickstart \
+  -c 'select * from counties;'</pre>
       </li>
 
       <li>
@@ -53,12 +52,12 @@ Choose your path:
         Secretless broker on port <code>5454</code>, <i>without knowing the
         password.</i> Give it a try:</p>
         <pre>
-          psql \
-            --host localhost \
-            --port 5454 \
-            --username secretless \
-            -d quickstart \
-            -c 'select * from counties;'</pre>
+psql \
+  --host localhost \
+  --port 5454 \
+  --username secretless \
+  -d quickstart \
+  -c 'select * from counties;'</pre>
       </li>
     </ol>
   </div>
@@ -68,21 +67,18 @@ Choose your path:
       <li>
         <p>Download and run the Secretless quick-start as a Docker container:</p>
         <pre>
-          docker container run \
-            --rm \
-            -p 8080:80 \
-            -p 8081:8081 \
-            cyberark/secretless-quickstart
-        </pre>
+docker container run \
+  --rm \
+  -p 8080:80 \
+  -p 8081:8081 \
+  cyberark/secretless-quickstart</pre>
       </li>
 
       <li>
         <p>The service we're trying to connect to is listening on port
         <code>8080</code>. If you try to access it, the service will inform
         you that you're unauthorized:</p>
-        <pre>
-          curl -i localhost:8080
-        </pre>
+        <pre>curl -i localhost:8080</pre>
       </li>
 
       <li>
@@ -90,9 +86,7 @@ Choose your path:
         through the Secretless broker on port <code>8081</code>. Secretless
         will inject the proper credentials into the request <i>without you
         needing to know what they are</i>. Give it a try:</p>
-        <pre>
-          http_proxy=localhost:8081 curl -i localhost:8080
-        </pre>
+        <pre>http_proxy=localhost:8081 curl -i localhost:8080</pre>
       </li>
     </ol>
   </div>
@@ -102,30 +96,25 @@ Choose your path:
       <li>
         <p>Download and run the Secretless quick-start as a Docker container:</p>
         <pre>
-          docker container run \
-            --rm \
-            -p 2221:22 \
-            -p 2222:2222 \
-            cyberark/secretless-quickstart
-        </pre>
+docker container run \
+  --rm \
+  -p 2221:22 \
+  -p 2222:2222 \
+  cyberark/secretless-quickstart</pre>
       </li>
 
       <li>
         <p>The default SSH service is exposed over port <code>2221</code>. You
         can try opening an SSH connection to the server, but you don't have
         the credentials to log in:</p>
-        <pre>
-          ssh -p 2221 user@localhost
-        </pre>
+        <pre>ssh -p 2221 user@localhost</pre>
       </li>
 
       <li>
         <p>The good news is that you don't need credentials! You can establish
         an SSH connection through the Secretless broker on port
         <code>2222</code> <i>without any credentials</i>. Give it a try:</p>
-        <pre>
-          ssh -p 2222 user@localhost
-        </pre>
+        <pre>ssh -p 2222 user@localhost</pre>
       </li>
     </ol>
   </div>


### PR DESCRIPTION
Removed leading and trailing whitespace from end-user view. All code snippets now begin without indentation and do not have an empty new line at the end of the snippet.