### PR TITLE
Hide blog navigation in nav and footer

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -5,8 +5,8 @@ main:
     url: /docs.html
   - page: Community
     url: /community.html
-  - page: Blog
-    url: /blog.html
+  # - page: Blog
+  #   url: /blog.html
   - page: Github
     url: https://github.com/conjurinc/secretless
 

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -25,7 +25,7 @@
 					<ul class="toggle">
 						<p class="footer-title">Resources</p>
 						<li class="footer-resource"><a href="/community.html">Community</a></li>
-						<li class="footer-resource"><a href="/blog.html">Blog</a></li>
+						<!-- <li class="footer-resource"><a href="/blog.html">Blog</a></li> -->
 						<li class="footer-resource"><a href="/faq.html">FAQ</a></li>
 					</ul>
 				</div>


### PR DESCRIPTION
Blog links are hidden because blog posts are not ready
Closes #196 

Nav before:
![screen shot 2018-07-24 at 10 46 43](https://user-images.githubusercontent.com/19418506/43124281-61b6c038-8f2f-11e8-867c-3999f07933e1.png)
After
![screen shot 2018-07-24 at 10 46 39](https://user-images.githubusercontent.com/19418506/43124290-68e0dc18-8f2f-11e8-8c6e-71a36b74345d.png)

Footer before:
![screen shot 2018-07-24 at 10 46 47](https://user-images.githubusercontent.com/19418506/43124323-8171cfc6-8f2f-11e8-894d-7e9d7fe7c994.png)
After
![screen shot 2018-07-24 at 10 46 53](https://user-images.githubusercontent.com/19418506/43124333-89a5d87c-8f2f-11e8-85e5-bdeec4699442.png)
