### PR TITLE
feat: run docs site with just docker-compose up

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,6 @@
+FROM ruby:2.3.7
+RUN gem install bundler jekyll
+RUN mkdir /src
+COPY ./Gemfile** /src
+WORKDIR /src
+RUN bundle install

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,9 @@ To construct:
 3. Run the following command:
 `bundle exec jekyll serve`
 4. Preview Jekyll site locally in web browser by either running `open localhost:4000` or manually navigating to http://localhost:4000
+
+### Run in Docker
+With `docker` and `docker-compose`:
+
+1. Run `docker-compose up -d` in the `docs` directory. 
+2. Preview Jekyll site locally in web browser by either running `open localhost:4000` or manually navigating to http://localhost:4000

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+  dev:
+    command: [ "bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0" ]
+    ports:
+      - 4000:4000
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: secretless-website-builder:latest
+    volumes:
+      - .:/src


### PR DESCRIPTION
it's nice to be able to run `docker-compose up -d` and be off on your way with the docs site.