### PR TITLE
Move plugin reference and add pages

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -12,19 +12,19 @@ main:
 
 documentation:
   - title: Overview
+    url: /overview.html
     subfolderitems:
       - page: Why Secretless?
         url: /docs.html
-      - page: How does it work?
+      - page: How Does It Work?
         url: /how_it_works.html
       - page: Key Terms
         url: /key_terms.html
   - title: Get Started
+    url: /get_started.html
     subfolderitems:
       - page: Quick Start
         url: /quick_start.html
-      - page: Plugins
-        url: /generated/pkg_secretless_plugin_v1.html
       - page: Deploying to Kubernetes
         url: /deploy_to_kubernetes.html
   - title: Reference
@@ -36,6 +36,8 @@ documentation:
         url: /handlers.html
       - page: Credential Providers
         url: /providers.html
+      - page: Plugin Reference
+        url: /generated/pkg_secretless_plugin_v1.html
       - page: How to Deploy
         url: /how_to_deploy.html
   - page: FAQ

--- a/docs/_sass/_navbar.scss
+++ b/docs/_sass/_navbar.scss
@@ -36,9 +36,6 @@
 	font-size: 15px;
 	padding: 8px 16px;
 }
-.sidenav-item a {
-	color: black;
-}
 .fixed-nav {
 	position: fixed;
 	top: 0;

--- a/docs/get_started.md
+++ b/docs/get_started.md
@@ -1,0 +1,18 @@
+---
+title: Secretless
+id: get_started
+layout: docs
+description: Secretless Documentation
+permalink: get_started
+---
+
+<p class="card-heading">Get Started</p>
+
+To get started trying out Secretless, you can run through our [quick start demos](/quick_start.html)
+that allow you to try it out with PostgreSQL, SSH, or an HTTP web service.
+
+If you are looking for a more detailed introduction to how Secretless works in
+practice, please look at our introduction to [deploying to Kubernetes](/deploy_to_kubernetes.html).
+
+Secretless is currently in **alpha**, which means that it's suitable for demo and evaluation
+purposes.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,17 @@
+---
+title: Secretless
+id: overview
+layout: docs
+description: Secretless Documentation
+permalink: overview
+---
+
+<p class="card-heading">Overview</p>
+
+Secretless is a connection broker which relieves client applications of the need
+to directly handle secrets to target services such as databases, web services, SSH
+connections, or any other TCP-based service.
+
+In this section of the documentation, we will provide the motivation for
+[why you should use Secretless](/docs.html), talk about [how it works](/how_it_works.html),
+and define some [key terms](/key_terms.html).


### PR DESCRIPTION
- Move the plugin reference under `reference`
- Standardize side nav capitalization
- Add pages for `reference` and `get started` so that all pages have content
- Update CSS so all pages will be links in sidebar