### PR TITLE
Fix uneven feature card

### DIFF
--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -92,7 +92,7 @@
 	padding: .5rem .5rem .5rem .5rem;
 }
 .about-subitem .inner {
-	min-height: 24.5rem;
+	min-height: 31rem;
 	padding: 2.5rem;
 	box-shadow: 0 .2rem .4rem rgba(0,0,0,.1);
 	margin: 0 1.0rem 3.0rem;


### PR DESCRIPTION
This sets the height of the features' card to be the same regardless of screen size.
Closes #221
Before:
![screen shot 2018-07-30 at 11 15 45](https://user-images.githubusercontent.com/19418506/43386479-6533ac5a-93ec-11e8-8685-eed942b2d1bd.png)

After:
![screen shot 2018-07-30 at 11 33 39](https://user-images.githubusercontent.com/19418506/43386501-749c3e78-93ec-11e8-9ab7-cad082709baf.png)
![screen shot 2018-07-30 at 11 33 45](https://user-images.githubusercontent.com/19418506/43386510-77ed7696-93ec-11e8-8769-bf001329dd86.png)