### PR TITLE
fix: lift side-nav above all other elements

### DIFF
--- a/docs/_sass/_navbar.scss
+++ b/docs/_sass/_navbar.scss
@@ -73,6 +73,7 @@
 	width: 21.5rem;
 	padding-top: 0.5em;
 	padding-bottom: 0.5em;
+	z-index: 99999;
 }
 .navbar-list > ul {
 	display: flex;


### PR DESCRIPTION
PR is to avoid this strange overlap:
![image](https://user-images.githubusercontent.com/8653164/43400641-d13e8df8-9440-11e8-8b98-3306fac25c43.png)
