### PR TITLE
Added provider plugin information to godoc files

### DIFF
--- a/pkg/secretless/plugin/v1/doc.go
+++ b/pkg/secretless/plugin/v1/doc.go
@@ -7,6 +7,7 @@ as a reference point and use the source code in this folder as the true represen
 Supported plugin types:
   -Listeners
   -Handlers
+  -Providers
   -Connection managers
 
 There is also an additional EventNotifier class used to bubble up events from listeners and handlers up
@@ -22,11 +23,14 @@ All plugins are currently loaded in the following manner:
     - PluginInfo
     - GetListeners
     - GetHandlers
+    - GetProviders
     - GetConnectionManagers
   - Handlers are added to handler factory map.
   - Listeners are added to listener factory map.
+  - Providers are added to provider factory map.
   - Managers are added to manager factory map.
   - Managers are instantiated.
+  - Providers are instantiated.
   - Listeners and handlers are instantiated by id whenever a configuration references them.
 
 
@@ -53,18 +57,23 @@ While extraneous keys in the map are ignored, the map _must_ contain the followi
 GetListeners
 
 Returns a map of provided listener ids to their factory methods (`map[string]func(v1.ListenerOptions) v1.Listener`) that
-accept `v1.ListenerOptions` when invoked and return a new `v1.Listener` [listener](#listeners).
+accept v1.ListenerOptions when invoked and return a new v1.Listener.
 
 GetHandlers
 
 Returns a map of provided handler ids to their factory methods (`map[string]func(v1.HandlerOptions) v1.Handler`) that
-accept `v1.HandlerOptions` when invoked and return a new `v1.Handler` [handler](#handlers).
+accept v1.HandlerOptions when invoked and return a new v1.Handler.
+
+GetProviders
+
+Returns a map of provided provider ids to their factory methods (`map[string]func(v1.ProviderOptions) v1.Provider`) that
+accept v1.ProviderOptions when invoked and return a new v1.Provider.
 
 GetConnectionManagers
 
 
 Returns a map of provided manager ids to their factory methods (`map[string]func() v1.ConnectionManager`) that
-return a new `v1.ConnectionManager` connection manager when invoked.
+return a new v1.ConnectionManager connection manager when invoked.
 
 Note: There is a high likelihood that this method will also have `v1.ConnectionManagerOptions` as the
 factory parameter like the rest of the factory maps in the future releases
@@ -81,11 +90,11 @@ The following shows a sample plugin that conforms to the expected API:
   )
 
   // PluginAPIVersion is the API version being used
-  var PluginAPIVersion = "0.0.7"
+  var PluginAPIVersion = "0.0.8"
 
   // PluginInfo describes the plugin
   var PluginInfo = map[string]string{
-  	"version":     "0.0.7",
+  	"version":     "0.0.8",
   	"id":          "example-plugin",
   	"name":        "Example Plugin",
   	"description": "Example plugin to demonstrate plugin functionality",
@@ -105,11 +114,19 @@ The following shows a sample plugin that conforms to the expected API:
   	}
   }
 
+  // GetProviders returns the example provider
+  func GetProviders() map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider {
+  	return map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider{
+  		"example-provider": example.ProviderFactory,
+  	}
+  }
+
   // GetConnectionManagers returns the example connection manager
   func GetConnectionManagers() map[string]func() plugin_v1.ConnectionManager {
   	return map[string]func() plugin_v1.ConnectionManager{
   		"example-plugin-manager": example.ManagerFactory,
   	}
   }
+
 */
 package v1

--- a/pkg/secretless/plugin/v1/provider.go
+++ b/pkg/secretless/plugin/v1/provider.go
@@ -2,11 +2,16 @@ package v1
 
 // ProviderOptions contains the configuration for the provider instantiation
 type ProviderOptions struct {
+	// Name is the internal name that the provider will have. This may be different from
+	// the name passed back from the provider factory.
 	Name string
 }
 
 // Provider is the interface used to obtain values from a secret vault backend.
 type Provider interface {
+	// GetName returns the name that the Provider was instantiated with
 	GetName() string
+
+	// GetValue takes in an id of a variable and returns its resolved value
 	GetValue(id string) ([]byte, error)
 }

--- a/pkg/secretless/plugin/v1/resolver.go
+++ b/pkg/secretless/plugin/v1/resolver.go
@@ -5,5 +5,6 @@ import "github.com/conjurinc/secretless/pkg/secretless/config"
 // Resolver is the interface which is used to pass a generic resolver
 // down to the Listeners/Handlers.
 type Resolver interface {
+	// Resolve accepts an array of variables and returns a map of resolved ones
 	Resolve(variables []config.Variable) (result map[string][]byte, err error)
 }

--- a/test/plugin/README.md
+++ b/test/plugin/README.md
@@ -3,6 +3,7 @@ implements an example plugin and verifies that it works as expected.
 
 Currently tests:
  - Manager connection reject/allow
+ - Sample Provider
  - Listener that passes a connection and injects a custom header in a HTTP-like
  connection
 
@@ -31,7 +32,7 @@ $ curl -A Agent http://<agent_host>:6174
 
 The plugin opens two local ports (6175 and 6176) and forwards them to the backend echo
 service. Manager closes any connections to even ports (in this case 6176). Allowed
-connections are intercepted and a mock header added. Tests listen for this header to ensure
+connections are intercepted and two mock headers added. Tests listen for these headers to ensure
 that the plugin is operating as expected.
 
 Plugin is generally built and placed in `/usr/local/lib/secretless` as a `.so` library.
@@ -48,6 +49,9 @@ Note: If either side of the connection is forcibly closed, the whole tunnel goes
 is also too much delay in sending the messages to the backend echo server, the listener
 will close the connection.
 
+#### Provider (`./example/provider.go`)
+
+This provider resolves variables by appending `Provider` to the variable id
 
 #### Manager (`./example/manager.go`)
 


### PR DESCRIPTION
Partially implements #207 (website is in flux so this only changes the code-side)

[Jenkins Build](https://jenkins.conjur.net/view/conjurinc/job/conjurinc--secretless/job/207-provider-docs/)

This will be used by developers and automated tools to generate
web-based documentation on the new provider plugins.