### PR TITLE
Fixed panic when using server plugin with "match" config field

### DIFF
--- a/pkg/secretless/config/config.go
+++ b/pkg/secretless/config/config.go
@@ -39,8 +39,8 @@ type Handler struct {
 	Type         string
 	ListenerName string `yaml:"listener"`
 	Debug        bool
-	Match        []string `yaml:"match"`
-	Patterns     []*regexp.Regexp
+	Match        []string         `yaml:"match"`
+	Patterns     []*regexp.Regexp `yaml:"-"`
 	Credentials  []Variable
 }
 
@@ -189,8 +189,8 @@ func Load(data []byte) (config Config, err error) {
 		}
 
 		h.Patterns = make([]*regexp.Regexp, len(h.Match))
-		for i, pattern := range h.Match {
-			pattern, err := regexp.Compile(pattern)
+		for i, matchPattern := range h.Match {
+			pattern, err := regexp.Compile(matchPattern)
 			if err != nil {
 				panic(err.Error())
 			} else {

--- a/pkg/secretless/config/config_test.go
+++ b/pkg/secretless/config/config_test.go
@@ -147,4 +147,22 @@ handlers:
 		_, err := Load([]byte(yaml))
 		So(fmt.Sprintf("%s", err), ShouldContainSubstring, "Handlers: (0: (Name: cannot be blank.).)")
 	})
+
+	Convey("Can serialize match fields", t, func() {
+		yaml := `
+listeners:
+  - name: http_default
+    protocol: tcp
+    address: 0.0.0.0:1080
+
+handlers:
+  - name: http_default
+    listener: http_default
+    match:
+      - test_for_secretless_issues_216
+`
+		config, err := Load([]byte(yaml))
+		So(err, ShouldBeNil)
+		So(config.String(), ShouldContainSubstring, "test_for_secretless_issues_216")
+	})
 }


### PR DESCRIPTION
Resolves #216 

Sister PR: https://github.com/conjurinc/secretless-server/pull/101

[Jenkins Build](https://jenkins.conjur.net/view/conjurinc/job/conjurinc--secretless/job/216-fix-match-fields/)

Turns out that we would try to marshal a generated field during
stringification of configs which has private fields and the program
panics. The fix makes sure that we never marshal this field when
stringifying, thus fixing issues in any code that would try to print the
config.