### PR TITLE
Added ability for Secretless to watch for configuration file changes

### DIFF
--- a/cmd/secretless-broker/main.go
+++ b/cmd/secretless-broker/main.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	"github.com/cyberark/secretless-broker/internal/pkg/plugin"
-	"github.com/cyberark/secretless-broker/pkg/secretless/config"
 	yaml "gopkg.in/yaml.v1"
 )
 
@@ -14,25 +13,27 @@ func main() {
 
 	pluginDir := flag.String("p", "/usr/local/lib/secretless", "Directory containing Secretless plugins")
 	configFile := flag.String("f", "secretless.yml", "Location of the configuration file.")
+	fsWatchSwitch := flag.Bool("watch", false, "Enable automatic reloads when configuration file changes.")
 	debugSwitch := flag.Bool("debug", false, "Enable debug logging.")
 	flag.Parse()
 
-	var err error
-	var configuration config.Config
-	if configuration, err = config.LoadFromFile(*configFile); err != nil {
-		log.Fatal(err)
+	configuration := plugin.GetManager().LoadConfigurationFile(*configFile)
+
+	if *fsWatchSwitch {
+		log.Printf("Watching for changes: %s", *configFile)
+		plugin.GetManager().RegisterConfigFileWatcher(*configFile)
 	}
 
 	if *debugSwitch {
 		configStr, _ := yaml.Marshal(configuration)
-		log.Printf("Loaded configuration : %s", configStr)
+		log.Printf("Loaded configuration: %s", configStr)
 		for _, handler := range configuration.Handlers {
 			handler.Debug = true
 		}
 	}
 
 	log.Println("Loading internal plugins...")
-	err = plugin.GetManager().LoadInternalPlugins(configuration)
+	err := plugin.GetManager().LoadInternalPlugins(configuration)
 	if err != nil {
 		log.Println(err)
 	}
@@ -43,7 +44,7 @@ func main() {
 		log.Println(err)
 	}
 
-	plugin.GetManager().RegisterSignalHandlers()
+	plugin.GetManager().RegisterSignalHandlers(*configFile)
 
 	plugin.GetManager().Run(configuration)
 }

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/emicklei/go-restful v2.8.0+incompatible // indirect
 	github.com/emicklei/go-restful-swagger12 v0.0.0-20170926063155-7524189396c6 // indirect
 	github.com/fatih/structs v1.0.0 // indirect
-	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/fullsailor/pkcs7 v0.0.0-20180613152042-8306686428a5 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ini/ini v1.32.0 // indirect
@@ -110,7 +110,7 @@ require (
 	golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b // indirect
 	golang.org/x/oauth2 v0.0.0-20180724155351-3d292e4d0cdc // indirect
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
-	golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8 // indirect
+	golang.org/x/sys v0.0.0-20180727230415-bd9dbc187b6e // indirect
 	golang.org/x/text v0.0.0-20171227012246-e19ae1496984 // indirect
 	golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 // indirect
 	golang.org/x/tools v0.0.0-20180726173139-0bf5a3224797 // indirect

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,8 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6Zh
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8 h1:7T3bTJEttnfJdEY+NY/VYT7IXRaul8potWiyw/n7LB8=
 golang.org/x/sys v0.0.0-20180724212812-e072cadbbdc8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20180727230415-bd9dbc187b6e h1:3dQ4fR8k5KugjVKO0oqSd1odxuk2yaE2CIfxWP2WarQ=
+golang.org/x/sys v0.0.0-20180727230415-bd9dbc187b6e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.0.0-20171227012246-e19ae1496984 h1:ulYJn/BqO4fMRe1xAQzWjokgjsQLPpb21GltxXHI3fQ=
 golang.org/x/text v0.0.0-20171227012246-e19ae1496984/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2 h1:+DCIGbF/swA92ohVg0//6X2IVY3KZs6p9mix0ziNYJM=

--- a/internal/pkg/plugin/fs_watcher.go
+++ b/internal/pkg/plugin/fs_watcher.go
@@ -1,0 +1,52 @@
+package plugin
+
+import (
+	"log"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func AttachWatcher(filename string, runner func()) {
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	go func() {
+		defer watcher.Close()
+
+		for {
+			select {
+			case event := <-watcher.Events:
+				if event.Op&fsnotify.Write == fsnotify.Write {
+					log.Printf("WARN: Watched file '%s' modified!", filename)
+					go runner()
+				} else if event.Op&fsnotify.Remove == fsnotify.Remove ||
+					event.Op&fsnotify.Rename == fsnotify.Rename {
+					log.Printf("WARN: Watched file '%s' has been removed!",
+						filename)
+
+					// Some editors remove the old file and replace it with a new one
+					// so we need to give it a bit of time and try to reattach the notifier
+					time.Sleep(1 * time.Second)
+					log.Printf("WARN: Trying to reattach to '%s'...", filename)
+					AttachWatcher(filename, runner)
+
+					// If the file disappeared, we know it changed so run the trigger
+					go runner()
+				}
+			case err := <-watcher.Errors:
+				log.Println("error:", err)
+				break
+			}
+		}
+	}()
+
+	log.Printf("Attaching filesystem notifier onto %s", filename)
+	err = watcher.Add(filename)
+	if err != nil {
+		log.Fatal(err)
+		watcher.Close()
+	}
+}


### PR DESCRIPTION
We want to be able to support dynamic changes to the configuration files
so this code change allows us to do so by using notifications which
trigger a reload.

Resolves #211 

[Jenkins Build](https://jenkins.conjur.net/view/conjurinc/job/conjurinc--secretless/job/211-config-file-watch/)

How to test:
- Launch secretless with `-watch` flag
- Make changes to the config file
- Verify that the configuration got updated