### PR TITLE
Remove dep reference in darwin build script

### DIFF
--- a/bin/build_darwin
+++ b/bin/build_darwin
@@ -3,10 +3,6 @@
 pushd $(dirname $0)/..
 trap popd EXIT INT TERM
 
-if [ "$NO_DEP" == "" ]; then
-  dep ensure
-fi
-
 echo "Building for darwin/amd64"
 
 mkdir -p dist/darwin/amd64


### PR DESCRIPTION
We don't use dep anymore and regular build should get all the needed
dependencies.