### PR TITLE
Adds responsive fixes to homepage

### DIFF
--- a/docs/_sass/_defaults.scss
+++ b/docs/_sass/_defaults.scss
@@ -24,7 +24,7 @@ li {
 code {
 	margin-left: 2.5rem;
 	color: #4d8fcc;
-	background-color: darken($sless-light-blue, 02); //#7ca8d224;
+	background-color: darken($sless-light-blue, 02); /*#7ca8d224;*/
 }
 a {
 	text-decoration: none;
@@ -48,7 +48,6 @@ code {
 	color: $sless-blue;
 	font-weight: 800;
 	margin-bottom: 3rem;
-
 }
 
 h1 {
@@ -96,5 +95,5 @@ h5 {
 }
 
 .row {
-	//margin: 0 2rem;
+	/*margin: 0 2rem;*/
 }

--- a/docs/_sass/_media.scss
+++ b/docs/_sass/_media.scss
@@ -1,0 +1,89 @@
+// ***********************
+// Media tags
+// ***********************
+@media (max-width: 1200px) {
+}
+@media (max-width: 991px) {
+	.icon-bar {
+		background-color: #fff;
+	}
+	.about-subitem .inner {
+		min-height: 0;
+	}
+	.arch-respons-box {
+		flex-direction: column;
+	}
+	.learn-banner {
+		text-align: center;
+	}
+	.right-links {
+		display: flex;
+		width: 100%;
+	}
+	.arch-img {
+		width: 65%;
+	}
+	.footer-resources {
+		width: 35%
+	}
+}
+@media (max-width: 768px) {
+	.jumbotron-sub{
+		height: unset;
+		padding: 1rem;
+	}
+}
+@media screen and (max-width: 600px) {
+  .topnav a {
+  	display: none;
+  }
+  .topnav a.icon {
+    float: right;
+    display: block;
+  }
+  .nav-list{
+  	background-color: rgba(0, 0, 0, 0.15);
+  }
+}
+@media screen and (max-width: 600px) {
+  .topnav.responsive {
+  	position: relative;
+  	display: block;
+  }
+  .topnav.responsive .icon {
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+  .topnav.responsive a {
+    float: none;
+    display: block;
+    text-align: left;
+  }
+}
+@media screen and (max-width: 481px) {
+	.secretless-logo {
+		width: 25rem;
+	}
+	.btnrow {
+		flex-direction: column;
+	}
+	.toggle {
+		padding-left: 25%;
+    padding-right: 25%;
+	}
+	.ui-tabs .ui-tabs-panel {
+		padding: 0;
+	}
+	footer .learn-banner p {
+		font-size: 1.5rem;
+		width: 90%;
+	}
+	.right-links {
+		display: flex;
+    	flex-direction: column;
+	}
+	.footer-resources {
+		width: 100%;
+	}
+}

--- a/docs/css/secretless.scss
+++ b/docs/css/secretless.scss
@@ -16,4 +16,5 @@
 	"_elements",
 	"_buttons",
 	"_blog",
+	"_media",
 	"_footer";


### PR DESCRIPTION
Closes #227

This adds responsive fixes across varying screen sizes for home page part of site

The previous PR #234 accounted for both the hamburger menu and responsive fixes across differing screen sizes.
Because we are going in a different direction for the collapsable navbar, I pulled apart the changes across elements, **_excluding_** the navbar fixes, _**adding**_ the appropriate responsive fixes across elements and **_adding_** fixes for iphone 5 screens

Changes can be seen by selecting the 'toggle device toolbar' in inspector tool

Before:
![screen shot 2018-08-05 at 14 46 50](https://user-images.githubusercontent.com/19418506/43685590-709460e0-98be-11e8-8f8f-406b030f3f0c.png)

After:
![screen shot 2018-08-05 at 14 46 58](https://user-images.githubusercontent.com/19418506/43685591-71d1806e-98be-11e8-8589-ee92e536bc84.png)