### PR TITLE
Conjur provider can use the Conjur K8s authenticator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,10 +15,11 @@ require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
-	github.com/cenkalti/backoff v2.0.0+incompatible // indirect
+	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/codegangsta/cli v1.20.0
 	github.com/containerd/continuity v0.0.0-20180712174259-0377f7d76720 // indirect
 	github.com/cyberark/conjur-api-go v0.0.0-20180212213233-94b5cadf8f90
+	github.com/cyberark/conjur-authn-k8s-client v0.12.0
 	github.com/cyberark/summon v0.0.0-20171226164112-07326408eaed
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20180707235734-242fa5aa1b45 // indirect
@@ -27,6 +28,7 @@ require (
 	github.com/duosecurity/duo_api_golang v0.0.0-20180315112207-d0530c80e49a // indirect
 	github.com/fatih/structs v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/fullsailor/pkcs7 v0.0.0-20180613152042-8306686428a5 // indirect
 	github.com/go-ini/ini v1.32.0 // indirect
 	github.com/go-ozzo/ozzo-validation v0.0.0-20170913164239-85dcd8368eba
 	github.com/go-sql-driver/mysql v1.4.0 // indirect
@@ -69,6 +71,7 @@ require (
 	github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 // indirect
 	github.com/mitchellh/mapstructure v0.0.0-20180111000720-b4575eea38cc // indirect
 	github.com/mitchellh/reflectwalk v0.0.0-20170726202117-63d60e9d0dbc // indirect
+	github.com/nsf/gocode v0.0.0-20180502111240-9d1e0378d35b // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.6.0 // indirect
 	github.com/onsi/gomega v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/containerd/continuity v0.0.0-20180712174259-0377f7d76720 h1:T5LkgEMAC
 github.com/containerd/continuity v0.0.0-20180712174259-0377f7d76720/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/cyberark/conjur-api-go v0.0.0-20180212213233-94b5cadf8f90 h1:lqVSvpspNTNIrjAkOfI0nHRicd9yLfrWjt548zq4oJY=
 github.com/cyberark/conjur-api-go v0.0.0-20180212213233-94b5cadf8f90/go.mod h1:492M4gGHnfHHWtuewzmj+1fe0BiLzzsrsdGYcbP2lU8=
+github.com/cyberark/conjur-authn-k8s-client v0.12.0 h1:mwtVQzKjlax67HRnDxY4ogS5lvszV7VVonxPItxi+iQ=
+github.com/cyberark/conjur-authn-k8s-client v0.12.0/go.mod h1:hjpUeTkRMUCSR0EAEIko2RCp4+dncNeiIWHNJeLFuRg=
 github.com/cyberark/summon v0.0.0-20171226164112-07326408eaed h1:0HPMF9Oa2FiN6inNtxlAL5iobtWygfhYlhv/T10RWFU=
 github.com/cyberark/summon v0.0.0-20171226164112-07326408eaed/go.mod h1:EDdy0BSD9OwcV/Rvz32HsX/QM44Zmi0P8tpdbQ6QwHY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -50,6 +52,8 @@ github.com/fatih/structs v1.0.0 h1:BrX964Rv5uQ3wwS+KRUAJCBBw5PQmgJfJ6v4yly5QwU=
 github.com/fatih/structs v1.0.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fullsailor/pkcs7 v0.0.0-20180613152042-8306686428a5 h1:v+vxrd9XS8uWIXG2RK0BHCnXc30qLVQXVqbK+IOmpXk=
+github.com/fullsailor/pkcs7 v0.0.0-20180613152042-8306686428a5/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/go-ini/ini v1.32.0 h1:/MArBHSS0TFR28yPPDK1vPIjt4wUnPBfb81i6iiyKvA=
 github.com/go-ini/ini v1.32.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-ozzo/ozzo-validation v0.0.0-20170913164239-85dcd8368eba h1:P0TvLfAFQ/hc8Q+VBsrgzGv52DxTjAu199VHbAI4LLQ=
@@ -141,6 +145,8 @@ github.com/mitchellh/mapstructure v0.0.0-20180111000720-b4575eea38cc h1:5T6hzGUO
 github.com/mitchellh/mapstructure v0.0.0-20180111000720-b4575eea38cc/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/reflectwalk v0.0.0-20170726202117-63d60e9d0dbc h1:gqYjvctjtX4GHzgfutJxZpvZ7XhGwQLGR5BASwhpO2o=
 github.com/mitchellh/reflectwalk v0.0.0-20170726202117-63d60e9d0dbc/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
+github.com/nsf/gocode v0.0.0-20180502111240-9d1e0378d35b h1:agMWdTHUzw9qlSSiKEz7SwXP2ZmLesKkmWYaS0K2GLk=
+github.com/nsf/gocode v0.0.0-20180502111240-9d1e0378d35b/go.mod h1:6Q8/OMaaKAgTX7/jt2bOXVDrm1eJhoNd+iwzghR7jvs=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=

--- a/internal/app/secretless/providers/conjur/provider.go
+++ b/internal/app/secretless/providers/conjur/provider.go
@@ -1,25 +1,43 @@
 package conjur
 
 import (
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"strings"
+	"sync"
+	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/cyberark/conjur-api-go/conjurapi"
 	"github.com/cyberark/conjur-api-go/conjurapi/authn"
+	"github.com/cyberark/conjur-authn-k8s-client/pkg/authenticator"
 
 	plugin_v1 "github.com/conjurinc/secretless/pkg/secretless/plugin/v1"
 )
 
+// authenticateCycleDuration is the default time the system waits to
+// reauthenticate on error when using the authenticator client
+const authenticateCycleDuration = 6 * time.Minute
+const authenticatorTokenFile = "/run/conjur/access-token"
+
 // Provider provides data values from the Conjur vault.
 type Provider struct {
-	Name   string
-	Conjur *conjurapi.Client
-	Config conjurapi.Config
+	// Data related to Provider config
+	AuthenticationMutex *sync.Mutex
+	Authenticator       *authenticator.Authenticator
+	Config              conjurapi.Config
+	Conjur              *conjurapi.Client
+	Name                string
 
-	Username string
+	// Credentials for API-key based auth
 	APIKey   string
+	Username string
+
+	// Authn URL for K8s-authenticator based auth
+	AuthnURL string
 }
 
 func hasField(field string, params *map[string]string) (ok bool) {
@@ -29,36 +47,69 @@ func hasField(field string, params *map[string]string) (ok bool) {
 
 // ProviderFactory constructs a Conjur Provider. The API client is configured from
 // environment variables.
+// To authenticate with Conjur, you can provide Secretless with:
+// - A Conjur username and API key
+// - A path to a file where a Conjur access token is stored
+// - Config info to use the Conjur k8s authenticator client to retrieve an access token
+//   from Conjur (i.e. Conjur version, account, authn url, username, and SSL cert)
 func ProviderFactory(options plugin_v1.ProviderOptions) plugin_v1.Provider {
 	config := conjurapi.LoadConfig()
 
+	var apiKey, authnURL, tokenFile, username string
+	var authenticator *authenticator.Authenticator
 	var conjur *conjurapi.Client
-	var username, apiKey, tokenFile string
 	var err error
+	var provider Provider
+
+	authenticationMutex := &sync.Mutex{}
 
 	username = os.Getenv("CONJUR_AUTHN_LOGIN")
 	apiKey = os.Getenv("CONJUR_AUTHN_API_KEY")
 	tokenFile = os.Getenv("CONJUR_AUTHN_TOKEN_FILE")
+	authnURL = os.Getenv("CONJUR_AUTHN_URL")
 
-	if username != "" && apiKey != "" {
-		if conjur, err = conjurapi.NewClientFromKey(config, authn.LoginPair{username, apiKey}); err != nil {
+	provider = Provider{
+		Name:                options.Name,
+		Config:              config,
+		Username:            username,
+		APIKey:              apiKey,
+		AuthnURL:            authnURL,
+		AuthenticationMutex: authenticationMutex,
+	}
+
+	if provider.Username != "" && provider.APIKey != "" {
+		log.Printf("Info: Conjur provider using API key-based authentication")
+		if conjur, err = conjurapi.NewClientFromKey(provider.Config, authn.LoginPair{provider.Username, provider.APIKey}); err != nil {
 			log.Fatalf("ERROR: Could not create new Conjur provider: %s", err)
 		}
 	} else if tokenFile != "" {
-		if conjur, err = conjurapi.NewClientFromTokenFile(config, tokenFile); err != nil {
+		log.Printf("Info: Conjur provider using access token-based authentication")
+		if conjur, err = conjurapi.NewClientFromTokenFile(provider.Config, tokenFile); err != nil {
+			log.Fatalf("ERROR: Could not create new Conjur provider: %s", err)
+		}
+	} else if provider.AuthnURL != "" && strings.Contains(provider.AuthnURL, "authn-k8s") {
+		log.Printf("Info: Conjur provider using Kubernetes authenticator-based authentication")
+
+		// Load the authenticator with the config from the environment, and log in to Conjur
+		if authenticator, err = loadAuthenticator(provider.AuthnURL, authenticatorTokenFile, provider.Config); err != nil {
+			log.Fatalf("ERROR: Conjur provider could not retrieve access token using the authenticator client: %s", err)
+		}
+		provider.Authenticator = authenticator
+
+		// Kick off the goroutine that will maintain the Conjur access token
+		go provider.refreshAccessToken()
+
+		// Once the token file has been loaded, create a new instance of the Conjur client
+		if conjur, err = conjurapi.NewClientFromTokenFile(provider.Config, authenticatorTokenFile); err != nil {
 			log.Fatalf("ERROR: Could not create new Conjur provider: %s", err)
 		}
 	} else {
 		log.Fatalln("ERROR: Unable to construct a Conjur provider client from the available credentials")
 	}
 
-	return &Provider{
-		Name:     options.Name,
-		Conjur:   conjur,
-		Config:   config,
-		Username: username,
-		APIKey:   apiKey,
-	}
+	provider.Conjur = conjur
+
+	return &provider
 }
 
 // GetName returns the name of the provider
@@ -70,6 +121,8 @@ func (p Provider) GetName() string {
 //	* "accessToken"
 // 	* Any Conjur variable ID
 func (p Provider) GetValue(id string) ([]byte, error) {
+	var err error
+
 	if id == "accessToken" {
 		if p.Username != "" && p.APIKey != "" {
 			// TODO: Use a cached access token from the client, once it's exposed
@@ -78,7 +131,15 @@ func (p Provider) GetValue(id string) ([]byte, error) {
 				p.APIKey,
 			})
 		}
-		return nil, fmt.Errorf("Sorry, can't currently provide an accessToken unless username and apiKey credentials are provided")
+		return nil, fmt.Errorf("Error: Conjur provider can't provide an accessToken unless username and apiKey credentials are provided")
+	}
+
+	// If using the Conjur Kubernetes authenticator, ensure that the
+	// Conjur API is using the current access token
+	if p.AuthnURL != "" {
+		if p.Conjur, err = conjurapi.NewClientFromTokenFile(p.Config, authenticatorTokenFile); err != nil {
+			log.Fatalf("ERROR: Could not create new Conjur provider: %s", err)
+		}
 	}
 
 	tokens := strings.SplitN(id, ":", 3)
@@ -90,4 +151,181 @@ func (p Provider) GetValue(id string) ([]byte, error) {
 	}
 
 	return p.Conjur.RetrieveSecret(strings.Join(tokens, ":"))
+}
+
+// loadAuthenticator returns a Conjur Kubernetes authenticator client
+// that has performed the login process to retrieve the signed certificate
+// from Conjur
+// The authenticator will be used to retrieve a time-limited access token
+// This method requires CONJUR_ACCOUNT, CONJUR_AUTHN_URL, CONJUR_AUTHN_LOGIN, and
+// CONJUR_SSL_CERTIFICATE/CONJUR_CERT_FILE env vars to be present
+// if CONJUR_VERSION is not present, it defaults to "5"
+// Currently the deployment manifest for Secretless must also specify
+// MY_POD_NAMESPACE and MY_POD_NAME from the pod metadata, but there is a GH
+// issue logged in the authenticator for doing this via the Kubernetes API
+func loadAuthenticator(authnURL string, tokenFile string, config conjurapi.Config) (*authenticator.Authenticator, error) {
+	var err error
+	var conjurCACert []byte
+
+	// Set the client cert / token paths
+	clientCertPath := "/etc/conjur/ssl/client.pem"
+
+	// Check that required environment variables are set
+	for _, envvar := range []string{
+		"CONJUR_ACCOUNT",
+		"CONJUR_AUTHN_LOGIN",
+		"MY_POD_NAMESPACE",
+		"MY_POD_NAME",
+	} {
+		if os.Getenv(envvar) == "" {
+			return nil, fmt.Errorf("Error: Conjur provider requires the %s environment variable", envvar)
+		}
+	}
+
+	// Load configuration from the environment
+	// TODO get pod namespace / name using Kubernetes API
+	// instead of specifying in deployment manifest
+	podNamespace := os.Getenv("MY_POD_NAMESPACE")
+	podName := os.Getenv("MY_POD_NAME")
+	account := os.Getenv("CONJUR_ACCOUNT")
+	authnLogin := os.Getenv("CONJUR_AUTHN_LOGIN")
+	conjurVersion := os.Getenv("CONJUR_VERSION")
+	if len(conjurVersion) == 0 {
+		conjurVersion = "5"
+	}
+
+	// Load CA cert
+	if conjurCACert, err = readSSLCert(); err != nil {
+		return nil, err
+	}
+
+	// Create new Authenticator
+	authenticator, err := authenticator.New(
+		authenticator.Config{
+			Account:        account,
+			ClientCertPath: clientCertPath,
+			ConjurVersion:  conjurVersion,
+			PodName:        podName,
+			PodNamespace:   podNamespace,
+			SSLCertificate: conjurCACert,
+			TokenFilePath:  tokenFile,
+			URL:            authnURL,
+			Username:       authnLogin,
+		})
+	if err != nil {
+		return nil, err
+	}
+
+	// Send the login request to Conjur to retrieve the signed certificate
+	// Configure exponential backoff
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = 2 * time.Second
+	expBackoff.RandomizationFactor = 0.5
+	expBackoff.Multiplier = 2
+	expBackoff.MaxInterval = 15 * time.Second
+	expBackoff.MaxElapsedTime = 2 * time.Minute
+
+	// Try login with exponential backoff on failure
+	err = backoff.Retry(
+		func() error {
+			if err = authenticator.Login(); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		expBackoff)
+
+	// If unable to login, return error
+	if err != nil {
+		return nil, fmt.Errorf("Error: Conjur provider unable to log in to Conjur: %s", err.Error())
+	}
+
+	return authenticator, nil
+}
+
+// refreshAccessToken uses the Conjur Kubernetes authenticator
+// to authenticate with Conjur and retrieve a new time-limited
+// access token in a loop
+func (p Provider) refreshAccessToken() error {
+
+	var err error
+
+	if p.Authenticator == nil {
+		return errors.New("Error: Conjur Kubernetes authenticator must be instantiated before access token may be refreshed")
+	}
+
+	// Configure exponential backoff
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = 2 * time.Second
+	expBackoff.RandomizationFactor = 0.5
+	expBackoff.Multiplier = 2
+	expBackoff.MaxInterval = 15 * time.Second
+	expBackoff.MaxElapsedTime = 2 * time.Minute
+
+	// Authenticate in a loop with retries on failure with exponential backoff
+	err = backoff.Retry(func() error {
+		for {
+
+			// Lock the authenticatorMutex
+			p.AuthenticationMutex.Lock()
+
+			log.Printf("Info: Conjur provider is authenticating as %s ...", p.Authenticator.Config.Username)
+			resp, err := p.Authenticator.Authenticate()
+
+			if err == nil {
+				log.Printf("Info: Conjur provider received a valid authentication response")
+				err = p.Authenticator.ParseAuthenticationResponse(resp)
+			}
+
+			if err != nil {
+				log.Printf("Info: Conjur provider received an error on authenticate: %s", err.Error())
+
+				if autherr, ok := err.(*authenticator.Error); ok {
+					if autherr.CertExpired() {
+						log.Printf("Info: Conjur certificate expired; Conjur provider is re-logging in.")
+
+						if err = p.Authenticator.Login(); err != nil {
+							return err
+						}
+
+						// if the cert expired and login worked then continue
+						continue
+					}
+				} else {
+					return fmt.Errorf("Error: Conjur provider unable to authenticate: %s", err.Error())
+				}
+			}
+
+			// Unlock the authenticatorMutex
+			p.AuthenticationMutex.Unlock()
+
+			// Reset exponential backoff
+			expBackoff.Reset()
+
+			log.Printf("Info: Conjur provider is waiting for %v minutes to re-authenticate.", authenticateCycleDuration)
+			time.Sleep(authenticateCycleDuration)
+		}
+	}, expBackoff)
+
+	if err != nil {
+		return fmt.Errorf("Error: Conjur provider unable to authenticate; backoff exhausted: %s", err.Error())
+	}
+
+	return nil
+}
+
+func readSSLCert() ([]byte, error) {
+	SSLCert := os.Getenv("CONJUR_SSL_CERTIFICATE")
+	SSLCertPath := os.Getenv("CONJUR_CERT_FILE")
+	if SSLCert == "" && SSLCertPath == "" {
+		err := errors.New("At least one of CONJUR_SSL_CERTIFICATE and CONJUR_CERT_FILE must be provided")
+		return nil, err
+	}
+
+	if SSLCert != "" {
+		return []byte(SSLCert), nil
+	}
+
+	return ioutil.ReadFile(SSLCertPath)
 }


### PR DESCRIPTION
Resolves #243 

# Description of changes
- The Conjur provider is updated to use the Conjur K8s authenticator client if
  the `CONJUR_AUTHN_URL` is specified in the Secretless environment
   - Additional required env vars include `CONJUR_ACCOUNT`, `CONJUR_AUTHN_LOGIN`, and either `CONJUR_SSL_CERTIFICATE` or `CONJUR_CERT_FILE`. `CONJUR_VERSION` is optional and defaults to `5` if not set.
- The function to refresh the access token is run as a goroutine with a
  `sync.Mutex` that locks the Provider while the access token is being
  refreshed
- The `GetValue` method is updated to reinstantiate the Conjur client using the current access token

# Validating changes
At this point, until the `kubernetes-conjur-demo` is updated to work with the Secretless Docker image (I'm working on that next), these changes can't be validated - but the existing functionality of the Conjur provider is unchanged with these updates (ie you can still configure it to authenticate to Conjur via access token env var or username / api key env vars)

# Future work
- Handle errors in the refreshAccessToken goroutine
- Use Provider Debug mode to print warnings
- Add tests
- Update the Conjur Go API to allow you to update the token value without fully reinstantiating the client