### PR TITLE
Added quickstart to the build/test/publish pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,12 @@ pipeline {
       }
     }
 
+    stage('Demo tests') {
+      steps {
+        sh './bin/test_quickstart'
+      }
+    }
+
     stage('Push Images') {
       when {
         branch 'master'

--- a/bin/build
+++ b/bin/build
@@ -4,23 +4,15 @@
 # usage: ./bin/build
 set -ex
 
-on_exit () {
-  containers=$(docker container ls -aq --filter "label=builder=secretless-builder")
-
-  if [ "${containers}" != "" ]; then
-    for container in ${containers}; do
-      docker rm -f "${container}" >/dev/null
-    done
-  fi
-}
-trap on_exit ERR INT QUIT EXIT
-
-
 VERSION=$(cat VERSION)
+QUICK_START_REL_DIR="$(dirname $0)/../demos/quick-start/docker"
+QUICK_START_DIR="$(realpath "$QUICK_START_REL_DIR")"
 
 DOCKER_FLAGS=""
 if [ "${KEEP_ALIVE}" != "" ]; then
   DOCKER_FLAGS="${DOCKER_FLAGS} -rm=false"
+else
+  DOCKER_FLAGS="${DOCKER_FLAGS} --force-rm"
 fi
 
 echo "Building Docker image"
@@ -32,6 +24,13 @@ docker build -t "secretless:${VERSION}" \
 echo "Building Docker dev image"
 docker build -t "secretless-dev:${VERSION}" \
              -t "secretless-dev:latest" \
-             -f Dockerfile.dev \
              $DOCKER_FLAGS \
+             -f Dockerfile.dev \
              .
+
+echo "Building Docker Quick-Start image"
+docker build -t "secretless-quickstart:${VERSION}" \
+             -t "secretless-quickstart:latest" \
+             $DOCKER_FLAGS \
+             -f "$QUICK_START_DIR/Dockerfile" \
+             "$QUICK_START_DIR"

--- a/bin/publish
+++ b/bin/publish
@@ -1,13 +1,28 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 readonly VERSION="$(cat VERSION)"
-readonly IMAGE_NAME="secretless"
-readonly REGISTRY="${1:-registry2.itci.conjur.net}"
+readonly REGISTRY="${1:-registry2.itci.conjur.net/conjurinc}"
 
-# tag images
-docker tag "$IMAGE_NAME:$VERSION" "$REGISTRY/conjurinc/$IMAGE_NAME:$VERSION"
-docker tag "$IMAGE_NAME:$VERSION" "$REGISTRY/conjurinc/$IMAGE_NAME:latest"
+readonly IMAGES=(
+  "secretless"
+  "secretless-quickstart"
+)
 
-# push images
-docker push "$REGISTRY/conjurinc/$IMAGE_NAME:$VERSION"
-docker push "$REGISTRY/conjurinc/$IMAGE_NAME:latest"
+readonly TAGS=(
+  "$VERSION"
+  "latest"
+)
+
+for image_name in "${IMAGES[@]}"; do
+  # Tag images
+  for tag in "${TAGS[@]}"; do
+    echo "Tagging $REGISTRY/$image_name:$tag"
+    docker tag "$image_name:$VERSION" "$REGISTRY/$image_name:$tag"
+  done
+
+  # Push images
+  for tag in "${TAGS[@]}"; do
+    echo "Pushing $REGISTRY/$image_name:$tag"
+    echo docker push "$REGISTRY/$image_name:$tag"
+  done
+done

--- a/bin/test
+++ b/bin/test
@@ -1,11 +1,17 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
+# Requires Bash v4+ for the associative array to be available
 
 CURRENT_DIR=$(dirname $0)
 
-echo "Running unit tests..."
-$CURRENT_DIR/test_unit
+declare -A TESTS=(
+  [unit]="unit tests"
+  [integration]="integration tests"
+  [quickstart]="Quick Start demo tests"
+)
 
-echo "Running integration tests..."
-$CURRENT_DIR/test_integration
+for test_key in "${!TESTS[@]}"; do
+  echo "Running ${TESTS[$test_key]}..."
+  $CURRENT_DIR/test_$test_key
+done
 
 echo "Done"

--- a/bin/test_quickstart
+++ b/bin/test_quickstart
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eo pipefail
+
+QUICK_START_REL_DIR="$(dirname $0)/../demos/quick-start"
+QUICK_START_DIR="$(realpath "$QUICK_START_REL_DIR")"
+
+pushd "$QUICK_START_REL_DIR" >/dev/null
+
+cleanup() {
+  ./bin/stop || true
+  popd >/dev/null
+}
+trap cleanup EXIT ABRT QUIT
+
+echo "Starting Quick Start demo tests..."
+set +e
+  ./bin/test
+  exit_status=$?
+set -e
+
+if [[ $exit_status -ne 0 ]]; then
+  echo "FAIL: Quick Start demo exited with an error (exit code $exit_status)!"
+  exit 1
+fi
+
+echo "PASS: Quick Start tests were successful!"

--- a/demos/quick-start/bin/test
+++ b/demos/quick-start/bin/test
@@ -1,20 +1,28 @@
 #!/bin/bash
 set -e
 
-cleanup () {
-  pushd test &>/dev/null
-    docker-compose rm -fs
-  popd &>/dev/null
-}
-trap cleanup EXIT ERR
+CURRENT_DIR=$(dirname $0)
+
+echo "Cleaning up old runners..."
+$CURRENT_DIR/stop || true
+echo "Clean up complete"
 
 pushd test &>/dev/null
-  docker-compose up -d quickstart
+cleanup() {
+  local exit_status=$?
+  docker-compose rm -fsv || true
+  exit $exit_status
+}
+trap cleanup EXIT ABRT QUIT ERR
 
-  echo "Waiting for services to be running.."
-  until docker-compose exec quickstart ls /run/postgresql/.init &>/dev/null; do
-    sleep 1s
-  done
+docker-compose up -d quickstart
 
-  docker-compose up test-client
-popd &>/dev/null
+# Used to show in the builds what the test image is doing
+docker-compose logs quickstart &
+
+echo "Waiting for services to be running.."
+until docker-compose exec -T quickstart ls /run/postgresql/.init &>/dev/null; do
+  sleep 1s
+done
+
+docker-compose run -T test-client

--- a/demos/quick-start/docker/Dockerfile
+++ b/demos/quick-start/docker/Dockerfile
@@ -1,4 +1,6 @@
-FROM registry2.itci.conjur.net/conjurinc/secretless:latest as secretless
+# TODO: Use DockerHub account image after public release
+FROM secretless:latest as secretless
+
 FROM postgres:9.6.9-alpine
 
 MAINTAINER "CyberArk Software, Inc."
@@ -9,15 +11,18 @@ USER root
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD [ "/entrypoint" ]
 
-COPY --from=secretless /usr/local/bin/secretless  /usr/local/bin/
 COPY bin/entrypoint                 /
 COPY bin/pg-init.sh                 /docker-entrypoint-initdb.d/
 COPY etc/nginx.conf                 /etc/nginx/
 COPY etc/secretless.yml etc/motd    /etc/
 
-RUN apk add -U openssl openssh nginx apache2-utils tini \
+RUN apk add --no-cache apache2-utils \
+                       libc6-compat \
+                       nginx \
+                       tini \
+                       openssh \
+                       openssl \
     && mkdir -p /lib64 /etc/nginx /run/nginx /home/user/.ssh/ \
-    && ln -fs /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 \
     && ssh-keygen -A \
     && adduser -DH secretless \
     && chown secretless /etc/secretless.yml \
@@ -26,3 +31,5 @@ RUN apk add -U openssl openssh nginx apache2-utils tini \
     && sed \
         -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' \
         /etc/ssh/sshd_config
+
+COPY --from=secretless /usr/local/bin/secretless  /usr/local/bin/

--- a/demos/quick-start/docker/etc/secretless.yml
+++ b/demos/quick-start/docker/etc/secretless.yml
@@ -20,10 +20,10 @@ handlers:
         provider: literal
         id: localhost:5432
       - name: username
-        provider: environment
+        provider: env
         id: QUICKSTART_USERNAME
       - name: password
-        provider: environment
+        provider: env
         id: QUICKSTART_PASSWORD
 
   - name: ssh
@@ -43,7 +43,7 @@ handlers:
     type: basic_auth
     listener: http_basic_auth
     debug: true
-    match: 
+    match:
      - ^http\:\/\/quickstart\/
      - ^http\:\/\/localhost.*
     credentials:

--- a/demos/quick-start/test/docker-compose.yml
+++ b/demos/quick-start/test/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "2"
+version: "3"
 
 services:
   quickstart:


### PR DESCRIPTION
Since we want the quickstart to be tied to Secretless better, we now
integrate it with the main build process.

Resolves #167 

[Jenkins Build](https://jenkins.conjur.net/view/conjurinc/job/conjurinc--secretless/job/167-quickstart-docker-image/)