### PR TITLE
feat: handlers informs clients of close connections and secretless shutdown 

### DIFF
--- a/internal/app/secretless/handlers/http/aws.go
+++ b/internal/app/secretless/handlers/http/aws.go
@@ -141,8 +141,7 @@ func (h *AWSHandler) LoadKeys(keyring agent.Agent) error {
 	return errors.New("http/aws handler does not use LoadKeys")
 }
 
-func (h *AWSHandler) Shutdown() error {
-	return nil
+func (h *AWSHandler) Shutdown() {
 }
 
 // AWSHandlerFactory instantiates a handler given HandlerOptions

--- a/internal/app/secretless/handlers/http/basic_auth.go
+++ b/internal/app/secretless/handlers/http/basic_auth.go
@@ -72,8 +72,7 @@ func (h *BasicAuthHandler) LoadKeys(keyring agent.Agent) error {
 	return errors.New("http/conjur handler does not use LoadKeys")
 }
 
-func (h *BasicAuthHandler) Shutdown() error {
-	return nil
+func (h *BasicAuthHandler) Shutdown() {
 }
 
 // BasicAuthHandlerFactory instantiates a handler given HandlerOptions

--- a/internal/app/secretless/handlers/http/conjur.go
+++ b/internal/app/secretless/handlers/http/conjur.go
@@ -63,8 +63,7 @@ func (h *ConjurHandler) LoadKeys(keyring agent.Agent) error {
 	return errors.New("http/conjur handler does not use LoadKeys")
 }
 
-func (h *ConjurHandler) Shutdown() error {
-	return nil
+func (h *ConjurHandler) Shutdown() {
 }
 
 // ConjurHandlerFactory instantiates a handler given HandlerOptions

--- a/internal/app/secretless/handlers/mysql/handler.go
+++ b/internal/app/secretless/handlers/mysql/handler.go
@@ -133,9 +133,8 @@ func (h *Handler) LoadKeys(keyring agent.Agent) error {
 	return errors.New("mysql handler does not use LoadKeys")
 }
 
-func (h *Handler) Shutdown() error {
+func (h *Handler) Shutdown() {
 	h.abort(fmt.Errorf("secretless shutting down"))
-	return nil
 }
 
 // HandlerFactory instantiates a handler given HandlerOptions

--- a/internal/app/secretless/handlers/pg/handler.go
+++ b/internal/app/secretless/handlers/pg/handler.go
@@ -152,9 +152,8 @@ func (h *Handler) LoadKeys(keyring agent.Agent) error {
 	return errors.New("pg handler does not use LoadKeys")
 }
 
-func (h *Handler) Shutdown() error {
+func (h *Handler) Shutdown() {
 	h.abort(fmt.Errorf("secretless shutting down"))
-	return nil
 }
 
 // HandlerFactory instantiates a handler given HandlerOptions

--- a/internal/app/secretless/handlers/ssh/handler.go
+++ b/internal/app/secretless/handlers/ssh/handler.go
@@ -223,8 +223,7 @@ func (h *Handler) LoadKeys(keyring agent.Agent) error {
 	return errors.New("ssh handler does not use LoadKeys")
 }
 
-func (h *Handler) Shutdown() error {
-	return nil
+func (h *Handler) Shutdown() {
 }
 
 // HandlerFactory instantiates a handler given HandlerOptions

--- a/internal/app/secretless/handlers/sshagent/handler.go
+++ b/internal/app/secretless/handlers/sshagent/handler.go
@@ -122,8 +122,7 @@ func (h *Handler) GetBackendConnection() net.Conn {
 	return nil
 }
 
-func (h *Handler) Shutdown() error {
-	return nil
+func (h *Handler) Shutdown() {
 }
 
 // HandlerFactory instantiates a handler given HandlerOptions

--- a/internal/app/secretless/listeners/mysql/listener.go
+++ b/internal/app/secretless/listeners/mysql/listener.go
@@ -16,7 +16,7 @@ import (
 
 // Listener listens for and handles new connections.
 type Listener struct {
-	_handlers 	   []plugin_v1.Handler
+	handlers       []plugin_v1.Handler
 	Config         config.Listener
 	EventNotifier  plugin_v1.EventNotifier
 	HandlerConfigs []config.Handler
@@ -60,7 +60,7 @@ func (l Listener) Validate() error {
 
 // Listen listens on the port or socket and attaches new connections to the handler.
 func (l *Listener) Listen() {
-	l._handlers = make([]plugin_v1.Handler, 0)
+	l.handlers = make([]plugin_v1.Handler, 0)
 
 	for {
 		var client net.Conn
@@ -79,10 +79,7 @@ func (l *Listener) Listen() {
 			}
 
 			handler := l.RunHandlerFunc("mysql", handlerOptions)
-			l._handlers = append(l._handlers, handler)
-
-			// TODO: there's a better way to do this
-			l.EventNotifier.CreateHandler(handler, client)
+			l.handlers = append(l.handlers, handler)
 		} else {
 			mysqlError := protocol.Error{
 				Code:     protocol.CRUnknownError,
@@ -106,7 +103,7 @@ func (l *Listener) GetListener() net.Listener {
 
 // GetHandlers implements plugin_v1.Listener
 func (l *Listener) GetHandlers() []plugin_v1.Handler {
-	return l._handlers
+	return l.handlers
 }
 
 // GetConnections implements plugin_v1.Listener

--- a/internal/app/secretless/listeners/pg/listener.go
+++ b/internal/app/secretless/listeners/pg/listener.go
@@ -16,7 +16,7 @@ import (
 
 // Listener listens for and handles new connections.
 type Listener struct {
-	_handlers 	   []plugin_v1.Handler
+	handlers       []plugin_v1.Handler
 	Config         config.Listener
 	EventNotifier  plugin_v1.EventNotifier
 	HandlerConfigs []config.Handler
@@ -57,7 +57,7 @@ func (l Listener) Validate() error {
 
 // Listen listens on the port or socket and attaches new connections to the handler.
 func (l *Listener) Listen() {
-	l._handlers = make([]plugin_v1.Handler, 0)
+	l.handlers = make([]plugin_v1.Handler, 0)
 
 	for {
 		var client net.Conn
@@ -76,10 +76,7 @@ func (l *Listener) Listen() {
 			}
 
 			handler := l.RunHandlerFunc("pg", handlerOptions)
-			l._handlers = append(l._handlers, handler)
-
-			// TODO: there's a better way to do this
-			l.EventNotifier.CreateHandler(handler, client)
+			l.handlers = append(l.handlers, handler)
 		} else {
 			pgError := protocol.Error{
 				Severity: protocol.ErrorSeverityFatal,
@@ -103,7 +100,7 @@ func (l *Listener) GetListener() net.Listener {
 
 // GetHandlers implements plugin_v1.Listener
 func (l *Listener) GetHandlers() []plugin_v1.Handler {
-	return l._handlers
+	return l.handlers
 }
 
 // GetConnections implements plugin_v1.Listener

--- a/internal/pkg/plugin/manager.go
+++ b/internal/pkg/plugin/manager.go
@@ -226,7 +226,11 @@ func (manager *Manager) _RunHandler(id string, options plugin_v1.HandlerOptions)
 		log.Panicf("Error! Unrecognized handler id '%s'", id)
 	}
 
-	return manager.HandlerFactories[id](options)
+	handler := manager.HandlerFactories[id](options)
+
+	manager.CreateHandler(handler, options.ClientConnection)
+
+	return handler
 }
 
 func (manager *Manager) _RunListener(id string, options plugin_v1.ListenerOptions) plugin_v1.Listener {

--- a/pkg/secretless/plugin/v1/handler.go
+++ b/pkg/secretless/plugin/v1/handler.go
@@ -28,5 +28,5 @@ type Handler interface {
 	GetClientConnection() net.Conn
 	GetBackendConnection() net.Conn
 	LoadKeys(keyring agent.Agent) error
-	Shutdown() error
+	Shutdown()
 }

--- a/test/plugin/example/handler.go
+++ b/test/plugin/example/handler.go
@@ -168,8 +168,7 @@ func (h *Handler) LoadKeys(keyring agent.Agent) error {
 	return errors.New("example handler does not use LoadKeys")
 }
 
-func (h *Handler) Shutdown() error {
-	return nil
+func (h *Handler) Shutdown() {
 }
 
 // HandlerFactory instantiates a handler given HandlerOptions


### PR DESCRIPTION
Closes #47 

## Confirm it works

Don't just copy. Run step by step and read between the lines.

```
# create shared network
docker network create dev-net

# start pg
docker run --net dev-net \
 --rm \
 -it \
 --name dev-postgres \
 --entrypoint=bash \
 postgres:9.6
    docker-entrypoint.sh postgres

docker run --net dev-net -v $PWD:/secretless --name secretless-dev --rm -it --entrypoint=bash secretless-dev:latest
    # add psql to secretless-dev
    apk add postgresql

    # run secretless
    go run cmd/secretless/main.go
```

## The different ways in which connections could be closed
```
docker exec -it secretless-dev bash
    psql "postgresql://postgres@localhost:5432?sslmode=disable"
    # run /dt to query db  
    # run /dt after below actions to see closing message from secretless
```

### Actions

+ force kill or interrupt postgres
```
docker exec -it dev-postgres bash
    # force kill or interrupt postgres
    kill -9 [PID of postgres]
```
+ interrupt secretless
```
docker exec -it dev-postgres bash
    # interrupt secretless
    kill -SIGINT [PID of secretless]
```
+ kill active connections
```
docker exec secretless-dev psql "postgresql://postgres@localhost:5432?sslmode=disable" -c "
SELECT
    pg_terminate_backend(pid)
FROM
    pg_stat_activity
WHERE
    pid <> pg_backend_pid()
"
```