### PR TITLE
Update docs to add config for credential providers

### DIFF
--- a/docs/docs/reference/providers/conjur.md
+++ b/docs/docs/reference/providers/conjur.md
@@ -10,6 +10,18 @@ permalink: docs/reference/providers/conjur
 The Conjur provider (`conjur`) populates credentials from an external
 [Conjur](https://www.conjur.org) service.
 
+### Secretless Broker Configuration
+To use the Conjur provider, Secretless must be configured to authenticate with
+Conjur. The Secretless Broker currently supports two methods of authenticating
+with Conjur:
+- `CONJUR_AUTHN_TOKEN_FILE` environment variable
+- `CONJUR_AUTHN_LOGIN` and `CONJUR_AUTHN_API_KEY` environment variables
+
+Both methods also require `CONJUR_APPLIANCE_URL` and `CONJUR_ACCOUNT` to
+be set in the environment of the Secretless Broker. You may optionally
+also include any other configuration environment variables that are
+allowed by the [Conjur Go Client Library](https://github.com/cyberark/conjur-api-go).
+
 ### Examples
 ``` yaml
 listeners:

--- a/docs/docs/reference/providers/vault.md
+++ b/docs/docs/reference/providers/vault.md
@@ -10,6 +10,12 @@ permalink: docs/reference/providers/vault
 The Vault provider (`vault`) populates credentials from an external
 [Vault](https://www.vaultproject.io/) service.
 
+### Secretless Broker Configuration
+To use the Vault provider, the Secretless Broker requires the `VAULT_ADDR` and
+`VAULT_TOKEN` environment variables be set. You may optionally include any other
+configuration environment variables that are allowed by the
+[Vault Go Client Library](https://github.com/hashicorp/vault/tree/master/api).
+
 ### Parameters
 The value of `id` must be provided in the format `<path>#<key>` _or_ the path
 must have a key named `value`.


### PR DESCRIPTION
- Add notes to Conjur and Vault Credential Providers with information on
  configuring the Secretless Broker container / process to authenticate with
  them