### PR TITLE
Update Jenkinsfile to publish master to staging site

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,9 @@ pipeline {
             branch 'master'
           }
           steps {
-            sh 'summon -e production bin/publish_website'
+            sh 'echo "Skipping production website push - pushing to staging"'
+            sh 'summon -e staging bin/publish_website'
+            //sh 'summon -e production bin/publish_website'
             archiveArtifacts 'docs/_site/'
           }
         }


### PR DESCRIPTION
Since we are still doing heavy development on the website, let's update the Jenkinsfile to publish the `master` branch to the staging site again for now.