### PR TITLE
Added Goreleaser for automated binary archive building (for tags)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,44 @@
+project_name: secretless-broker
+
+builds:
+- binary: summon2
+  env:
+  - CGO_ENABLED=0
+  goos:
+  - linux
+  goarch:
+  - amd64
+  main: ./cmd/summon2/main.go
+- binary: secretless-broker
+  env:               
+  - CGO_ENABLED=0    
+  goos:          
+  - linux        
+  goarch:
+  - amd64
+  main: ./cmd/secretless-broker/main.go
+
+archive:
+  files:
+    - CHANGELOG.md
+    - LICENSE.md
+    - README.md
+  format_overrides:
+    - goos: windows
+      format: zip
+  name_template: "{{.ProjectName}}_{{.Os}}_{{.Arch}}"
+  wrap_in_directory: true
+
+checksum:
+  name_template: 'SHA256SUMS.txt'
+
+dist: ./dist/goreleaser
+
+git:
+  short_hash: true
+
+snapshot:
+  name_template: "{{ .Tag }}-next"
+
+release:
+  disable: true

--- a/bin/Dockerfile.releaser
+++ b/bin/Dockerfile.releaser
@@ -1,0 +1,17 @@
+FROM golang:1.11beta2-alpine
+
+ENTRYPOINT [ "/go/src/github.com/goreleaser/goreleaser/goreleaser" ]
+CMD [ "--rm-dist" ]
+
+RUN apk add --no-cache bash \
+                       build-base \
+                       curl \
+                       git && \
+    go get -u github.com/golang/dep/cmd/dep
+
+RUN go get -d github.com/goreleaser/goreleaser && \
+    cd $GOPATH/src/github.com/goreleaser/goreleaser && \
+    dep ensure -vendor-only && \
+    make setup build
+
+WORKDIR "/secretless-broker"

--- a/bin/build_release
+++ b/bin/build_release
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+CURRENT_DIR=$(realpath $(dirname $0))
+echo "Current dir: $CURRENT_DIR"
+
+docker build -f "$CURRENT_DIR/Dockerfile.releaser" \
+             -t secretless-broker-releaser \
+             "$CURRENT_DIR/.."
+
+docker run --rm \
+           -v "$CURRENT_DIR/..":/secretless-broker \
+           secretless-broker-releaser
+
+echo "Releases built. Archives can be found in dist/goreleaser"


### PR DESCRIPTION
With this setup, we are now able to build binary archives to add to
GitHub when we tag a release, replacing many manual steps we did before.
We still have to trigger/upload manually when we tag but that will be
tackled in a separate task.

Resolves #305 

Note: Jenkins build results do not apply since this code path is run manually