### PR TITLE
fix: pg_test.go TCP requires sslmode=disable

### DIFF
--- a/test/pg_handler/pg_test.go
+++ b/test/pg_handler/pg_test.go
@@ -24,7 +24,7 @@ func psql(host string, port int, user string, environment []string) (string, err
 	}
 	args = append(args, "-c")
 	args = append(args, "select count(*) from test.test")
-	args = append(args, "dbname=postgres")
+	args = append(args, "dbname=postgres sslmode=disable")
 
 	log.Println(strings.Join(append([]string{"psql"}, args...), " "))
 


### PR DESCRIPTION
I have no idea how tests have been passing prior to this. 