### PR TITLE
Fixed soft-reload 100% CPU bug

### DIFF
--- a/internal/app/secretless/handlers/mysql/handler.go
+++ b/internal/app/secretless/handlers/mysql/handler.go
@@ -1,10 +1,10 @@
 package mysql
 
 import (
-	"log"
-	"net"
 	"fmt"
 	"io"
+	"log"
+	"net"
 
 	"github.com/cyberark/secretless-broker/internal/app/secretless/handlers/mysql/protocol"
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
@@ -27,16 +27,18 @@ type BackendConfig struct {
 // Handler requires "host", "port", "username" and "password" credentials.
 type Handler struct {
 	plugin_v1.BaseHandler
-	BackendConfig    *BackendConfig
+	BackendConfig *BackendConfig
 }
 
 func (h *Handler) abort(err error) {
-	mysqlError := protocol.Error{
-		Code:     protocol.CRUnknownError,
-		SQLSTATE: protocol.ErrorCodeInternalError,
-		Message:  err.Error(),
+	if h.GetClientConnection() != nil {
+		mysqlError := protocol.Error{
+			Code:     protocol.CRUnknownError,
+			SQLSTATE: protocol.ErrorCodeInternalError,
+			Message:  err.Error(),
+		}
+		h.GetClientConnection().Write(mysqlError.GetMessage())
 	}
-	h.GetClientConnection().Write(mysqlError.GetMessage())
 }
 
 func stream(source, dest net.Conn, callback func([]byte)) {

--- a/internal/app/secretless/listeners/mysql/listener.go
+++ b/internal/app/secretless/listeners/mysql/listener.go
@@ -2,6 +2,7 @@ package mysql
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"strconv"
 
@@ -54,10 +55,11 @@ func (l Listener) Validate() error {
 
 // Listen listens on the port or socket and attaches new connections to the handler.
 func (l *Listener) Listen() {
-	for {
+	for l.IsClosed != true {
 		var client net.Conn
 		var err error
 		if client, err = util.Accept(l); err != nil {
+			log.Printf("WARN: Failed to accept incoming mysql connection: ", err)
 			continue
 		}
 
@@ -90,7 +92,8 @@ func (l *Listener) Listen() {
 func (l *Listener) GetName() string {
 	return "mysql"
 }
+
 // ListenerFactory returns a Listener created from options
 func ListenerFactory(options plugin_v1.ListenerOptions) plugin_v1.Listener {
-	return &Listener{ BaseListener: plugin_v1.NewBaseListener(options) }
+	return &Listener{BaseListener: plugin_v1.NewBaseListener(options)}
 }

--- a/internal/app/secretless/listeners/pg/listener.go
+++ b/internal/app/secretless/listeners/pg/listener.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"strconv"
 
@@ -51,10 +52,11 @@ func (l Listener) Validate() error {
 
 // Listen listens on the port or socket and attaches new connections to the handler.
 func (l *Listener) Listen() {
-	for {
+	for l.IsClosed != true {
 		var client net.Conn
 		var err error
 		if client, err = util.Accept(l); err != nil {
+			log.Printf("WARN: Failed to accept incoming pg connection: ", err)
 			continue
 		}
 
@@ -67,7 +69,7 @@ func (l *Listener) Listen() {
 				ShutdownNotifier: func(handler plugin_v1.Handler) {
 					l.RemoveHandler(handler)
 				},
-				Resolver:         l.Resolver,
+				Resolver: l.Resolver,
 			}
 
 			handler := l.RunHandlerFunc("pg", handlerOptions)
@@ -90,5 +92,5 @@ func (l *Listener) GetName() string {
 
 // ListenerFactory returns a Listener created from options
 func ListenerFactory(options plugin_v1.ListenerOptions) plugin_v1.Listener {
-	return &Listener{ BaseListener: plugin_v1.NewBaseListener(options) }
+	return &Listener{BaseListener: plugin_v1.NewBaseListener(options)}
 }

--- a/internal/app/secretless/listeners/ssh/listener.go
+++ b/internal/app/secretless/listeners/ssh/listener.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"strconv"
 
-	"golang.org/x/crypto/ssh"
 	"github.com/go-ozzo/ozzo-validation"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/cyberark/secretless-broker/internal/pkg/util"
 	"github.com/cyberark/secretless-broker/pkg/secretless/config"
@@ -130,10 +130,10 @@ func (l *Listener) Listen() {
 
 	serverConfig.AddHostKey(private)
 
-	for {
+	for l.IsClosed != true {
 		nConn, err := util.Accept(l)
 		if err != nil {
-			log.Printf("Failed to accept incoming connection: ", err)
+			log.Printf("WARN: Failed to accept incoming ssh connection: ", err)
 			continue
 		}
 
@@ -177,5 +177,5 @@ func (l *Listener) GetName() string {
 
 // ListenerFactory returns a Listener created from options
 func ListenerFactory(options plugin_v1.ListenerOptions) plugin_v1.Listener {
-	return &Listener{ BaseListener: plugin_v1.NewBaseListener(options) }
+	return &Listener{BaseListener: plugin_v1.NewBaseListener(options)}
 }

--- a/internal/app/secretless/listeners/sshagent/listener.go
+++ b/internal/app/secretless/listeners/sshagent/listener.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"strconv"
 
-	"golang.org/x/crypto/ssh/agent"
 	"github.com/go-ozzo/ozzo-validation"
+	"golang.org/x/crypto/ssh/agent"
 
 	"github.com/cyberark/secretless-broker/internal/pkg/util"
 	"github.com/cyberark/secretless-broker/pkg/secretless/config"
@@ -64,10 +64,10 @@ func (l *Listener) Listen() {
 		return
 	}
 
-	for {
+	for l.IsClosed != true {
 		nConn, err := util.Accept(l)
 		if err != nil {
-			log.Printf("Failed to accept incoming connection: ", err)
+			log.Printf("WARN: Failed to accept incoming sshagent connection: ", err)
 			return
 		}
 
@@ -84,5 +84,5 @@ func (l *Listener) GetName() string {
 
 // ListenerFactory returns a Listener created from options
 func ListenerFactory(options plugin_v1.ListenerOptions) plugin_v1.Listener {
-	return &Listener{ BaseListener: plugin_v1.NewBaseListener(options) }
+	return &Listener{BaseListener: plugin_v1.NewBaseListener(options)}
 }


### PR DESCRIPTION
Old code would keep old listener gofuncs running after listeners were
closed which would keep erroring out on `Accept`s and keep the loops
spinning forever, driving the CPU usage up to 100%. We now flag the
listerner as being wound down and check that flag in the accept loops,
allowing us to exit listener once the shutdown has begun.

[Jenkins Build](https://jenkins.conjur.net/view/cyberark/job/cyberark--secretless-broker/job/fix-broken-shutdown/)