### PR TITLE
Removed the need for realpath (coreutils)

### DIFF
--- a/bin/abspath
+++ b/bin/abspath
@@ -1,0 +1,17 @@
+#!/bin/bash -e
+#
+# Returns the bin/ directory as an absolute path as a workaround
+# to avoid needing coreutils on OSX
+# usage: ./bin/abspath
+
+to_abspath() {
+  prefix=$(dirname $0)
+  if [[ "$prefix" != /* ]]; then
+    echo "$PWD/${prefix#./}"
+    return
+  fi
+
+  echo "$prefix"
+}
+
+to_abspath "$@"

--- a/bin/build
+++ b/bin/build
@@ -4,9 +4,11 @@
 # usage: ./bin/build
 set -ex
 
-VERSION=$(cat VERSION)
-QUICK_START_REL_DIR="$(dirname $0)/../demos/quick-start/docker"
-QUICK_START_DIR="$(realpath "$QUICK_START_REL_DIR")"
+CURRENT_DIR=$($(dirname $0)/abspath)
+TOPLEVEL_DIR="$CURRENT_DIR/.."
+
+VERSION=$(cat $TOPLEVEL_DIR/VERSION)
+QUICK_START_DIR="$TOPLEVEL_DIR/demos/quick-start/docker"
 
 DOCKER_FLAGS=""
 if [ "${KEEP_ALIVE}" != "" ]; then
@@ -19,14 +21,15 @@ echo "Building Docker image"
 docker build -t "secretless-broker:${VERSION}" \
              -t "secretless-broker:latest" \
              $DOCKER_FLAGS \
-             .
+             -f $TOPLEVEL_DIR/Dockerfile \
+             $TOPLEVEL_DIR
 
 echo "Building Docker dev image"
 docker build -t "secretless-dev:${VERSION}" \
              -t "secretless-dev:latest" \
              $DOCKER_FLAGS \
-             -f Dockerfile.dev \
-             .
+             -f $TOPLEVEL_DIR/Dockerfile.dev \
+             $TOPLEVEL_DIR
 
 echo "Building Docker Quick-Start image"
 docker build -t "secretless-broker-quickstart:${VERSION}" \

--- a/bin/build_release
+++ b/bin/build_release
@@ -1,14 +1,16 @@
 #!/bin/bash -e
 
-CURRENT_DIR=$(realpath $(dirname $0))
+CURRENT_DIR=$($(dirname $0)/abspath)
+TOPLEVEL_DIR="$CURRENT_DIR/.."
+
 echo "Current dir: $CURRENT_DIR"
 
 docker build -f "$CURRENT_DIR/Dockerfile.releaser" \
              -t secretless-broker-releaser \
-             "$CURRENT_DIR/.."
+             "$TOPLEVEL_DIR"
 
 docker run --rm \
-           -v "$CURRENT_DIR/..":/secretless-broker \
+           -v "$TOPLEVEL_DIR":/secretless-broker \
            secretless-broker-releaser
 
 echo "Releases built. Archives can be found in dist/goreleaser"

--- a/bin/build_website
+++ b/bin/build_website
@@ -1,8 +1,10 @@
 #!/bin/bash -e
 set -o pipefail
 
-CURRENT_DIR=$(dirname $0 | xargs realpath)
-DOCS_DIR="$CURRENT_DIR/../docs"
+CURRENT_DIR=$($(dirname $0)/abspath)
+TOPLEVEL_DIR="$CURRENT_DIR/.."
+
+DOCS_DIR="$TOPLEVEL_DIR/docs"
 DEST_SITE_DIR="$DOCS_DIR/_site"
 REPOSITORY="github.com/cyberark/secretless-broker"
 
@@ -13,7 +15,7 @@ echo "Using container name: ${CONTAINER_NAME}"
 
 docker build -f "${CURRENT_DIR}/Dockerfile.website" \
              -t "${IMAGE_NAME}" \
-             "${CURRENT_DIR}/../docs"
+             "${TOPLEVEL_DIR}/docs"
 
 echo "Cleaning up current _site..."
 rm -rf "${DEST_SITE_DIR}"
@@ -51,7 +53,7 @@ godoc_package: ${package}
   # Generate the doc but strip out the header boilerplate and links
   docker run --rm \
              -t \
-             -v ${CURRENT_DIR}/..:/go/src/${REPOSITORY} \
+             -v "${TOPLEVEL_DIR}:/go/src/${REPOSITORY}" \
              "${IMAGE_NAME}" godoc -html \
                                    -links=false \
                                    "/go/src/${REPOSITORY}/${package}" | sed 1,19d >> "${output_file}"
@@ -71,7 +73,7 @@ docker run --rm \
            --name "${CONTAINER_NAME}" \
            -w /usr/src/app \
            --network none \
-           -v "$CURRENT_DIR/../docs:/usr/src/app" \
+           -v "$TOPLEVEL_DIR/docs:/usr/src/app" \
            -v "${DEST_SITE_DIR}:/tmp/_site" \
            "${IMAGE_NAME}"
 

--- a/bin/check_website_links
+++ b/bin/check_website_links
@@ -1,8 +1,9 @@
 #!/bin/bash -e
 
-CURRENT_DIR=$(dirname $0 | xargs realpath)
+CURRENT_DIR=$($(dirname $0)/abspath)
+TOPLEVEL_DIR="$CURRENT_DIR/.."
 
-docker run -v $CURRENT_DIR/../docs/_site:/_site:ro \
+docker run -v ${TOPLEVEL_DIR}/docs/_site:/_site:ro \
            --network none \
            --rm \
            18fgsa/html-proofer --check-external-hash \

--- a/bin/publish_website
+++ b/bin/publish_website
@@ -8,12 +8,13 @@
 
 # Note that this requires docs/_site to be present
 
-CURRENT_DIR=$(dirname $0 | xargs realpath)
+CURRENT_DIR=$($(dirname $0)/abspath)
+TOPLEVEL_DIR="$CURRENT_DIR/.."
 
 echo "Publishing to $S3_BUCKET..."
 
 docker run --rm \
-  -v "${CURRENT_DIR}/../docs/_site:/_site:ro" \
+  -v "${TOPLEVEL_DIR}/docs/_site:/_site:ro" \
   -e AWS_ACCESS_KEY_ID \
   -e AWS_SECRET_ACCESS_KEY \
   mesosphere/aws-cli \

--- a/bin/test_quickstart
+++ b/bin/test_quickstart
@@ -2,10 +2,11 @@
 
 set -eo pipefail
 
-QUICK_START_REL_DIR="$(dirname $0)/../demos/quick-start"
-QUICK_START_DIR="$(realpath "$QUICK_START_REL_DIR")"
+CURRENT_DIR=$($(dirname $0)/abspath)
+TOPLEVEL_DIR="$CURRENT_DIR/.."
+QUICK_START_DIR="${TOPLEVEL_DIR}/demos/quick-start"
 
-pushd "$QUICK_START_REL_DIR" >/dev/null
+pushd "$QUICK_START_DIR" >/dev/null
 
 cleanup() {
   ./bin/stop || true

--- a/bin/test_unit
+++ b/bin/test_unit
@@ -2,16 +2,16 @@
 
 set -eo pipefail
 
-CURRENT_DIR=$(realpath $(dirname $0))
-PROJECT_DIR=$PWD
+CURRENT_DIR=$($(dirname $0)/abspath)
+TOPLEVEL_DIR="$CURRENT_DIR/.."
 
-rm -f $PROJECT_DIR/test/junit.output
-touch $PROJECT_DIR/test/junit.output
+rm -f $TOPLEVEL_DIR/test/junit.output
+touch $TOPLEVEL_DIR/test/junit.output
 
 echo "Building unit test image..."
-docker build $CURRENT_DIR/.. \
+docker build "$TOPLEVEL_DIR" \
              -t secretless-unit-test-runner:latest \
-             -f $CURRENT_DIR/../Dockerfile.test
+             -f $TOPLEVEL_DIR/Dockerfile.test
 
 echo "Running unit tests..."
 set +e
@@ -21,13 +21,13 @@ set +e
              secretless-unit-test-runner:latest -vet=off \
                                                 ./cmd/... \
                                                 ./internal/... \
-                                                ./pkg/... | tee -a $PROJECT_DIR/test/junit.output
+                                                ./pkg/... | tee -a $TOPLEVEL_DIR/test/junit.output
   echo "Unit test exit status: $?"
 set -e
 
-rm -f $PROJECT_DIR/test/junit.xml
+rm -f $TOPLEVEL_DIR/test/junit.xml
 docker run --rm \
-  -v $PROJECT_DIR/test/:/secretless/test/output/ \
+  -v $TOPLEVEL_DIR/test/:/secretless/test/output/ \
   secretless-dev \
   bash -exc "
     go get -u github.com/jstemmer/go-junit-report


### PR DESCRIPTION
We don't want to depend on something that's not in a base install of OSX
for basic building (other than Docker) so we now use pure Bash to
assemble paths that Docker is fine with mounting.

Resolves #329 

[Jenkins Build](https://jenkins.conjur.net/view/cyberark/job/cyberark--secretless-broker/job/329-fix-realpaths/)