### PR TITLE
Add styling to ensure card features are same size

### DIFF
--- a/docs/_sass/_media.scss
+++ b/docs/_sass/_media.scss
@@ -30,7 +30,7 @@
 		display: flex;
     	flex-direction: column;
 	}
-	.col-md-4 {
+	.about-subitem {
 		max-width: 100%;
 	}
 }

--- a/docs/_sass/_media.scss
+++ b/docs/_sass/_media.scss
@@ -2,6 +2,9 @@
 // Media tags
 // ***********************
 @media (max-width: 1200px) {
+	.about-subitem .inner {
+		min-height: 39rem;
+	}
 }
 @media (max-width: 991px) {
 	.about-subitem .inner {
@@ -22,6 +25,13 @@
 	}
 	.footer-resources {
 		width: 35%
+	}
+	.sub-card {
+		display: flex;
+    	flex-direction: column;
+	}
+	.col-md-4 {
+		max-width: 100%;
 	}
 }
 @media (max-width: 768px) {


### PR DESCRIPTION
closes #347 
Regardless of mobile screen size, this ensures that card features boxes are even in height
Max-width 1200px
Before:
![screen shot 2018-08-20 at 10 33 39](https://user-images.githubusercontent.com/19418506/44326495-89c6eb80-a464-11e8-802c-c77710fc7a11.png)
After:
![screen shot 2018-08-20 at 10 29 41](https://user-images.githubusercontent.com/19418506/44326422-5a17e380-a464-11e8-8c9d-3ac246fb6c4e.png)

Max-width 990px
Before:
![screen shot 2018-08-20 at 10 16 26](https://user-images.githubusercontent.com/19418506/44326527-977c7100-a464-11e8-9067-32a9537e4792.png)

After:
![screen shot 2018-08-20 at 10 32 47](https://user-images.githubusercontent.com/19418506/44326449-6f8d0d80-a464-11e8-9636-c1ce28a88a40.png)