### PR TITLE
Conjur handler consumes access token from Conjur provider

### DIFF
--- a/internal/app/secretless/handlers/http/conjur.go
+++ b/internal/app/secretless/handlers/http/conjur.go
@@ -38,7 +38,15 @@ func (h ConjurHandler) Authenticate(values map[string][]byte, r *http.Request) e
 
 // ConjurHandlerFactory instantiates a handler given HandlerOptions
 func ConjurHandlerFactory(options plugin_v1.HandlerOptions) plugin_v1.Handler {
-	return &ConjurHandler{
+	handler := &ConjurHandler{
 		BaseHandler: plugin_v1.NewBaseHandler(options),
 	}
+
+	// Force instantiate the Conjur provider so we can use an access token.
+	// This will fail unless a means of authentication to Conjur is available.
+	if handler.Resolver != nil {
+		handler.Resolver.GetProvider("conjur");
+	}
+
+	return handler
 }

--- a/internal/app/secretless/providers/env/provider.go
+++ b/internal/app/secretless/providers/env/provider.go
@@ -14,19 +14,19 @@ type EnvironmentProvider struct {
 
 // ProviderFactory constructs a EnvironmentProvider.
 // No configuration or credentials are required.
-func ProviderFactory(options plugin_v1.ProviderOptions) plugin_v1.Provider {
+func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
 	return &EnvironmentProvider{
 		Name: options.Name,
-	}
+	}, nil
 }
 
 // GetName returns the name of the provider
-func (p EnvironmentProvider) GetName() string {
+func (p *EnvironmentProvider) GetName() string {
 	return p.Name
 }
 
 // GetValue obtains a value by ID. Any environment is a recognized ID.
-func (p EnvironmentProvider) GetValue(id string) (result []byte, err error) {
+func (p *EnvironmentProvider) GetValue(id string) (result []byte, err error) {
 	var found bool
 	envVar, found := os.LookupEnv(id)
 	if found {

--- a/internal/app/secretless/providers/file/provider.go
+++ b/internal/app/secretless/providers/file/provider.go
@@ -13,18 +13,18 @@ type Provider struct {
 
 // ProviderFactory constructs a filesystem Provider.
 // No configuration or credentials are required.
-func ProviderFactory(options plugin_v1.ProviderOptions) plugin_v1.Provider {
+func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
 	return &Provider{
 		Name: options.Name,
-	}
+	}, nil
 }
 
 // GetName returns the name of the provider
-func (p Provider) GetName() string {
+func (p *Provider) GetName() string {
 	return p.Name
 }
 
 // GetValue reads the contents of the identified file.
-func (p Provider) GetValue(id string) ([]byte, error) {
+func (p *Provider) GetValue(id string) ([]byte, error) {
 	return ioutil.ReadFile(id)
 }

--- a/internal/app/secretless/providers/keychain/provider.go
+++ b/internal/app/secretless/providers/keychain/provider.go
@@ -14,19 +14,19 @@ type Provider struct {
 
 // ProviderFactory constructs a keychain Provider.
 // No configuration or credentials are required.
-func ProviderFactory(options plugin_v1.ProviderOptions) plugin_v1.Provider {
+func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
 	return &Provider{
 		Name: options.Name,
-	}
+	}, nil
 }
 
 // GetName returns the name of the provider
-func (p Provider) GetName() string {
+func (p *Provider) GetName() string {
 	return p.Name
 }
 
 // GetValue reads the contents of the identified file.
-func (p Provider) GetValue(id string) ([]byte, error) {
+func (p *Provider) GetValue(id string) ([]byte, error) {
 	tokens := strings.Split(id, "#")
 	if len(tokens) != 2 {
 		return nil, fmt.Errorf("Keychain secret id '%s' must be formatted as '<service>#<account>'", id)

--- a/internal/app/secretless/providers/kubernetes-secrets/provider.go
+++ b/internal/app/secretless/providers/kubernetes-secrets/provider.go
@@ -2,7 +2,6 @@ package kubernetes_secrets
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
@@ -16,30 +15,30 @@ type Provider struct {
 
 // ProviderFactory constructs a Provider. The API client is configured from
 // in-cluster environment variables and files.
-func ProviderFactory(options plugin_v1.ProviderOptions) plugin_v1.Provider {
+func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
 	var client *KubeClient
 	var err error
 	if client, err = NewKubeClient(); err != nil {
-		log.Panicf("ERROR: Could not create Kubernetes Secrets provider: %s", err)
+		return nil, fmt.Errorf("ERROR: Could not create Kubernetes Secrets provider: %s", err)
 	}
 
-	provider := Provider{
+	provider := &Provider{
 		Name:   options.Name,
 		Client: client,
 	}
 
-	return provider
+	return provider, nil
 }
 
 // GetName returns the name of the provider
-func (p Provider) GetName() string {
+func (p *Provider) GetName() string {
 	return p.Name
 }
 
 // GetValue obtains a value by id. Any secret which is stored in Kubernetes Secrets is recognized.
 // The data type returned by Kubernetes Secrets is map[string][]byte. Therefore this provider needs
 // to know which field to return from the map. The field to be returned is specified by appending '#fieldName' to the id argument.
-func (p Provider) GetValue(id string) ([]byte, error) {
+func (p *Provider) GetValue(id string) ([]byte, error) {
 	tokens := strings.SplitN(id, "#", 2)
 
 	if len(tokens) != 2 {

--- a/internal/app/secretless/providers/literal/provider.go
+++ b/internal/app/secretless/providers/literal/provider.go
@@ -9,18 +9,18 @@ type Provider struct {
 
 // ProviderFactory constructs a literal value Provider.
 // No configuration or credentials are required.
-func ProviderFactory(options plugin_v1.ProviderOptions) plugin_v1.Provider {
+func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
 	return &Provider{
 		Name: options.Name,
-	}
+	}, nil
 }
 
 // GetName returns the name of the provider
-func (p Provider) GetName() string {
+func (p *Provider) GetName() string {
 	return p.Name
 }
 
 // GetValue returns the id.
-func (p Provider) GetValue(id string) ([]byte, error) {
+func (p *Provider) GetValue(id string) ([]byte, error) {
 	return []byte(id), nil
 }

--- a/internal/app/secretless/providers/providers.go
+++ b/internal/app/secretless/providers/providers.go
@@ -13,7 +13,7 @@ import (
 )
 
 // ProviderFactories contains the list of built-in provider factories
-var ProviderFactories = map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider{
+var ProviderFactories = map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
 	"conjur":   conjurProvider.ProviderFactory,
 	"env":      envProvider.ProviderFactory,
 	"file":     fileProvider.ProviderFactory,

--- a/internal/app/secretless/providers/vault/provider.go
+++ b/internal/app/secretless/providers/vault/provider.go
@@ -2,7 +2,6 @@ package vault
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	vault "github.com/hashicorp/vault/api"
@@ -18,25 +17,25 @@ type Provider struct {
 
 // ProviderFactory constructs a Provider. The API client is configured from
 // environment variables.
-func ProviderFactory(options plugin_v1.ProviderOptions) plugin_v1.Provider {
+func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
 	config := vault.DefaultConfig()
 
 	var client *vault.Client
 	var err error
 	if client, err = vault.NewClient(config); err != nil {
-		log.Panicf("ERROR: Could not create Vault provider: %s", err)
+		return nil, fmt.Errorf("ERROR: Could not create Vault provider: %s", err)
 	}
 
-	provider := Provider{
+	provider := &Provider{
 		Name:   options.Name,
 		Client: client,
 	}
 
-	return provider
+	return provider, nil
 }
 
 // GetName returns the name of the provider
-func (p Provider) GetName() string {
+func (p *Provider) GetName() string {
 	return p.Name
 }
 
@@ -59,7 +58,7 @@ func parseVaultID(id string) (string, string) {
 // The datatype returned by Vault is map[string]interface{}. Therefore this provider needs
 // to know which field to return from the map. By default, it returns the 'value'.
 // An alternative field can be obtained by appending '#fieldName' to the id argument.
-func (p Provider) GetValue(id string) (value []byte, err error) {
+func (p *Provider) GetValue(id string) (value []byte, err error) {
 	id, fieldName := parseVaultID(id)
 
 	var secret *vault.Secret

--- a/internal/app/summon/command/command.go
+++ b/internal/app/summon/command/command.go
@@ -87,7 +87,7 @@ func parseCommandArgsToSubcommand(options *Options) (subcommand *Subcommand, err
 	}
 
 	// Load all internal Providers
-	providerFactories := make(map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider)
+	providerFactories := make(map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error))
 	for providerID, providerFactory := range secretless.InternalProviders {
 		providerFactories[providerID] = providerFactory
 	}

--- a/internal/pkg/plugin/manager.go
+++ b/internal/pkg/plugin/manager.go
@@ -38,7 +38,7 @@ type Manager struct {
 	ConnectionManagers map[string]plugin_v1.ConnectionManager
 	HandlerFactories   map[string]func(plugin_v1.HandlerOptions) plugin_v1.Handler
 	ListenerFactories  map[string]func(plugin_v1.ListenerOptions) plugin_v1.Listener
-	ProviderFactories  map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider
+	ProviderFactories  map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error)
 	Proxy              secretless.Proxy
 }
 
@@ -52,7 +52,7 @@ func GetManager() *Manager {
 			ConnectionManagers: make(map[string]plugin_v1.ConnectionManager),
 			HandlerFactories:   make(map[string]func(plugin_v1.HandlerOptions) plugin_v1.Handler),
 			ListenerFactories:  make(map[string]func(plugin_v1.ListenerOptions) plugin_v1.Listener),
-			ProviderFactories:  make(map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider),
+			ProviderFactories:  make(map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error)),
 		}
 	})
 
@@ -228,7 +228,7 @@ func _LoadProvidersFromPlugin(manager *Manager, config config.Config,
 	}
 
 	// TODO: Handle different interface versions
-	providerPluginsFunc, ok := rawProviderPluginsFunc.(func() map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider)
+	providerPluginsFunc, ok := rawProviderPluginsFunc.(func() map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error))
 	if !ok {
 		return errors.New("ERROR: Could not cast GetProviders to proper type")
 	}

--- a/internal/pkg/plugin/resolver.go
+++ b/internal/pkg/plugin/resolver.go
@@ -13,13 +13,13 @@ import (
 // Resolver is used to instantiate providers and resolve credentials
 type Resolver struct {
 	EventNotifier     plugin_v1.EventNotifier
-	ProviderFactories map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider
+	ProviderFactories map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error)
 	Providers         map[string]plugin_v1.Provider
 	LogFatalf         func(string, ...interface{})
 }
 
 // NewResolver instantiates providers based on the name and ProviderOptions
-func NewResolver(providerFactories map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider,
+func NewResolver(providerFactories map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error),
 	eventNotifier plugin_v1.EventNotifier,
 	LogFatalFunc func(string, ...interface{})) plugin_v1.Resolver {
 
@@ -58,7 +58,10 @@ func (resolver *Resolver) GetProvider(name string) (provider plugin_v1.Provider,
 	providerFactory := resolver.ProviderFactories[name]
 
 	log.Printf("Instantiating provider '%s'", name)
-	provider = providerFactory(providerOptions)
+	provider, err = providerFactory(providerOptions)
+	if err != nil {
+		return nil, err
+	}
 
 	resolver.Providers[name] = provider
 

--- a/test/conjur/conjur_provider_test.go
+++ b/test/conjur/conjur_provider_test.go
@@ -16,14 +16,17 @@ import (
 // as well as secret values.
 func TestConjur_Provider(t *testing.T) {
 	var err error
-
+	var provider plugin_v1.Provider
 	name := "conjur"
 
 	options := plugin_v1.ProviderOptions{
 		Name: name,
 	}
 
-	provider := providers.ProviderFactories[name](options)
+	Convey("Can create the Conjur provider", t, func() {
+		provider, err = providers.ProviderFactories[name](options)
+		So(err, ShouldBeNil)
+	})
 
 	Convey("Has the expected provider name", t, func() {
 		So(provider.GetName(), ShouldEqual, "conjur")

--- a/test/plugin/example/cmd/main.go
+++ b/test/plugin/example/cmd/main.go
@@ -31,8 +31,8 @@ func GetHandlers() map[string]func(plugin_v1.HandlerOptions) plugin_v1.Handler {
 }
 
 // GetProviders returns the example provider
-func GetProviders() map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider {
-	return map[string]func(plugin_v1.ProviderOptions) plugin_v1.Provider{
+func GetProviders() map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
+	return map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error){
 		"example-provider": example.ProviderFactory,
 	}
 }

--- a/test/plugin/example/provider.go
+++ b/test/plugin/example/provider.go
@@ -8,18 +8,18 @@ type Provider struct {
 }
 
 // ProviderFactory constructs a mock Provider.
-func ProviderFactory(options plugin_v1.ProviderOptions) plugin_v1.Provider {
+func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
 	return &Provider{
 		Name: options.Name,
-	}
+	}, nil
 }
 
 // GetName returns the name of the provider
-func (provider Provider) GetName() string {
+func (provider *Provider) GetName() string {
 	return provider.Name
 }
 
 // GetValue returns the id + "Provider"
-func (provider Provider) GetValue(id string) ([]byte, error) {
+func (provider *Provider) GetValue(id string) ([]byte, error) {
 	return []byte(id + "Provider"), nil
 }

--- a/test/vault_provider/vault_provider_test.go
+++ b/test/vault_provider/vault_provider_test.go
@@ -12,13 +12,18 @@ import (
 )
 
 func TestVault_Provider(t *testing.T) {
+	var err error
+	var provider plugin_v1.Provider
 	name := "vault"
 
 	options := plugin_v1.ProviderOptions{
 		Name: name,
 	}
 
-	provider := providers.ProviderFactories[name](options)
+	Convey("Can create the Vault provider", t, func() {
+		provider, err = providers.ProviderFactories[name](options)
+		So(err, ShouldBeNil)
+	})
 
 	Convey("Has the expected provider name", t, func() {
 		So(provider.GetName(), ShouldEqual, "vault")


### PR DESCRIPTION
Resolves #340

This change cleans up handler implementations (mostly changing receiver types) and instantiates a Conjur provider from the Conjur handler.