### PR TITLE
Add k8 banner and fix dropped active class

### DIFF
--- a/docs/_includes/cta-banner-integ.html
+++ b/docs/_includes/cta-banner-integ.html
@@ -1,3 +1,5 @@
-<div class = "cta-banner">
-	<p>Ready to use Secretless Broker in your Kubernetes environment? Check out our page on <b><a href="docs/get_started/deploy_to_kubernetes.html">Deploying to Kubernetes</a></b>!</p>
+<div class="cta-banner-wrapper">
+	<div class = "cta-banner">
+	  <p>Ready to use Secretless Broker in your Kubernetes environment? Check out our page on <a href="/docs/get_started/deploy_to_kubernetes.html">Deploying to Kubernetes</a>!</p>
+	</div>
 </div>

--- a/docs/_includes/cta-banner-integ.html
+++ b/docs/_includes/cta-banner-integ.html
@@ -1,0 +1,3 @@
+<div class = "cta-banner">
+	<p>Ready to use Secretless Broker in your Kubernetes environment? Check out our page on <b><a href="docs/get_started/deploy_to_kubernetes.html">Deploying to Kubernetes</a></b>!</p>
+</div>

--- a/docs/_includes/cta-banner.html
+++ b/docs/_includes/cta-banner.html
@@ -1,6 +1,5 @@
 <div class="cta-banner-wrapper">
 	<div class = "cta-banner">
-	  <p>Want to learn more? Check out our <b><a href="/docs/overview.html">documentation</a></b> for more information!</p>
+	  <p>Want to learn more? Check out our <a href="/docs/overview.html">documentation</a> for more information, like how to use <a href="/docs/get_started/deploy_to_kubernetes.html">Secretless Broker in your Kubernetes environment!</a></p>
 	</div>
-	{% include cta-banner-integ.html %}
 </div>

--- a/docs/_includes/cta-banner.html
+++ b/docs/_includes/cta-banner.html
@@ -1,3 +1,6 @@
-<div class = "cta-banner">
-  <p>Want to learn more? Check out our <b><a href="/docs/overview.html">documentation</a></b> for more information!</p>
+<div class="cta-banner-wrapper">
+	<div class = "cta-banner">
+	  <p>Want to learn more? Check out our <b><a href="/docs/overview.html">documentation</a></b> for more information!</p>
+	</div>
+	{% include cta-banner-integ.html %}
 </div>

--- a/docs/_includes/side_navigation.html
+++ b/docs/_includes/side_navigation.html
@@ -3,11 +3,13 @@
 		{% if site.data.navigation.chapters[0] %}
 			{% for chapter in site.data.navigation.chapters %}
 			<h3 class="{% if page.url == chapter.url %}active{% endif %}"><a href="{{ chapter.url }}">{{ chapter.title }}</a></h3>
+	
 				{% if chapter.sections[0] %}
 					<ul class="group-of-sections">
 						{% for section in chapter.sections %}
 							{% if section.entries[0] %}
-							<li class="{% if page.url == section.url %}active {% endif %}section dropdown-btn"><a href="{{ section.url }}">{{ section.page }}</a>
+
+							<li class="{% if page.title == section.page %}active {% endif %}section dropdown-btn"><a href="{{ section.url }}">{{ section.page }}</a>
 							{% if section.page == page.title %}
 								<i class="fa fa-angle-right arrow rotatingArrow"></i>
 							</li>

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -25,7 +25,7 @@ description: Secretless Broker Documentation
         </div>
       </div>
     </div>
-    {% if page.title == 'Quick Start'%}
+    {% if page.title != 'Deploy to Kubernetes'%}
       {% include cta-banner-integ.html %}
     {% endif %}
     {% include footer.html %}

--- a/docs/_layouts/docs.html
+++ b/docs/_layouts/docs.html
@@ -25,7 +25,11 @@ description: Secretless Broker Documentation
         </div>
       </div>
     </div>
+    {% if page.title == 'Quick Start'%}
+      {% include cta-banner-integ.html %}
+    {% endif %}
     {% include footer.html %}
+
     <script src='/javascript/clipboard-buttons.js' type="text/javascript"></script>
     <script src='/javascript/secretless.js' type="text/javascript"></script>
   </body>

--- a/docs/_sass/_elements.scss
+++ b/docs/_sass/_elements.scss
@@ -452,3 +452,31 @@ figure.highlight {
   border-width: 1rem;
   margin-left: -1rem;
 }
+
+
+// ***********************
+// CTA banner
+// ***********************
+.cta-banner-wrapper {
+	padding: 2rem 0;
+	background-color: #4d8fcc;
+}
+.cta-banner {
+	background-color: #4d8fcc;
+	height: 6.3rem;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	line-height: 3rem;
+	margin-bottom: 0;
+	padding: 0 4rem;
+	p {
+		color: white;
+		font-size: 2rem;
+		font-weight: normal;
+	}
+	a {
+		color: lighten($sless-blue, 30);
+		font-weight: 600;
+	}
+}

--- a/docs/_sass/_footer.scss
+++ b/docs/_sass/_footer.scss
@@ -1,28 +1,6 @@
 // ***********************
 // Footer
 // ***********************
-.cta-banner-wrapper {
-	padding: 2rem 0;
-	background-color: #4d8fcc;
-}
-.cta-banner {
-	background-color: #4d8fcc;
-	height: 6.3rem;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	line-height: 3rem;
-	margin-bottom: 0;
-	padding: 0 4rem;
-}
-.cta-banner p {
-	color: white;
-	font-size: 2rem;
-	font-weight: normal;
-}
-.cta-banner a {
-	color: white;
-}
 footer {
 	background-image: url("../img/secretless_pattern_dark.png");
 	background-repeat: round;

--- a/docs/_sass/_footer.scss
+++ b/docs/_sass/_footer.scss
@@ -1,10 +1,13 @@
 // ***********************
 // Footer
 // ***********************
-
+.cta-banner-wrapper {
+	padding: 2rem 0;
+	background-color: #4d8fcc;
+}
 .cta-banner {
 	background-color: #4d8fcc;
-	height: 9.3rem;
+	height: 6.3rem;
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/docs/docs/get_started/quick_start.md
+++ b/docs/docs/get_started/quick_start.md
@@ -121,10 +121,6 @@ docker container run \
   </div>
 </div>
 
-<div>
-  Ready to use Secretless Broker in your Kubernetes environment? Continue with <a href="deploy_to_kubernetes.html">Deploying to Kubernetes</a>!
-</div>
-
 <script>
   $( function() {
     $( "#quick-start-tabs" ).tabs();

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,10 +109,7 @@ docker container run \
       <br/>
     </div>
   </div>
-
-  Ready to use Secretless Broker in your Kubernetes environment? Check out our page on <a href="docs/get_started/deploy_to_kubernetes.html">Deploying to Kubernetes</a>!
 </div>
-
 <script>
   $( function() {
     $( "#quick-start-tabs-main" ).tabs();


### PR DESCRIPTION
closes #338
This PR addresses the following:
- add K8 banner
- fixes dropped active class from side navbar

K8 Banner
Before
<img width="1604" alt="screen shot 2018-08-21 at 11 57 46" src="https://user-images.githubusercontent.com/19418506/44391802-75a0ee00-a539-11e8-9560-41097933563c.png">

After
<img width="1605" alt="screen shot 2018-08-21 at 11 57 34" src="https://user-images.githubusercontent.com/19418506/44391804-76d21b00-a539-11e8-8b92-f8c6da008645.png">

Active Class
Before
<img width="252" alt="screen shot 2018-08-21 at 11 58 51" src="https://user-images.githubusercontent.com/19418506/44391900-a6812300-a539-11e8-9523-d140576301c6.png">

After
<img width="279" alt="screen shot 2018-08-21 at 11 58 58" src="https://user-images.githubusercontent.com/19418506/44391907-a8e37d00-a539-11e8-9798-1b8f618541bb.png">
