### PR TITLE
 fix: avoid failing build -> set GO111MODULE=on for full-demo/myapp

### DIFF
--- a/demos/full-demo/src/ansible/Dockerfile
+++ b/demos/full-demo/src/ansible/Dockerfile
@@ -1,4 +1,4 @@
-FROM secretless-broker:latest as secretless-broker
+FROM cyberark/secretless-broker:latest as secretless-broker
 
 FROM alpine:3.8
 

--- a/demos/full-demo/src/myapp/Dockerfile
+++ b/demos/full-demo/src/myapp/Dockerfile
@@ -13,6 +13,9 @@ ENTRYPOINT [ "./myapp" ]
 WORKDIR /go/src/myapp
 
 COPY . .
+
+ENV GO111MODULE=on
+
 RUN go mod -sync
 
 RUN go build

--- a/demos/quick-start/docker/Dockerfile
+++ b/demos/quick-start/docker/Dockerfile
@@ -1,5 +1,4 @@
-# TODO: Use DockerHub account image after public release
-FROM secretless-broker:latest as secretless-broker
+FROM cyberark/secretless-broker:latest as secretless-broker
 
 FROM postgres:9.6.9-alpine
 


### PR DESCRIPTION
This PR addresses:
+ An error while executing `docker-compose build` under `secretless-broker/demos/full-demo` for both `plaintext` and `conjur`:
```
Error: `Step 7/8 : RUN go mod -sync
---> Running in 4a44651d6b9c
go: modules disabled inside GOPATH/src by GO111MODULE=auto; see ‘go help modules’
ERROR: Service ‘myapp’ failed to build: The command ‘/bin/sh -c go mod -sync’ returned a non-zero code: 1` 
```
+ Updates the demos to use the DockerHub Secretless image