### PR TITLE
Add test for clean listener shutdown

### DIFF
--- a/pkg/secretless/plugin/v1/listener_test.go
+++ b/pkg/secretless/plugin/v1/listener_test.go
@@ -1,0 +1,35 @@
+package v1
+
+import (
+	"os"
+	"net"
+	"testing"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestListener(t *testing.T) {
+	socketFile := "/sock/test"
+	if _, err := os.Stat(socketFile); os.IsNotExist(err) {
+		socketFile = "./sock"
+	}
+
+	netListener, _ := net.Listen("unix", socketFile)
+	listener := NewBaseListener(ListenerOptions{
+		NetListener: netListener,
+	})
+
+	Convey("BaseListener shuts down cleanly without errors", t, func() {
+		// First, check that the socket file exists
+		_, err := os.Stat(socketFile)
+		So(err, ShouldBeNil)
+
+		err = listener.Shutdown()
+		So(err, ShouldBeNil)
+
+		Convey("and its socket file is removed", func() {
+			_, err := os.Stat(socketFile)
+			So(err, ShouldNotBeNil)
+			So(os.IsNotExist(err), ShouldBeTrue)
+		})
+	})
+}


### PR DESCRIPTION
Closes #173.

**Issue was previously fixed.** Likely fixed along with #290 (see [UnixConn.File](https://golang.org/pkg/net/#UnixConn.File) for more info).

This PR adds a test to ensure that the BaseListener shuts down without error and
cleans up any socket files that were in use.