### PR TITLE
WIP: Parallelized `Resolver.Resolve` and Conjur Provider now uses batch secrets retrieval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/SAP/go-hdb v0.12.1 // indirect
 	github.com/SermoDigital/jose v0.9.1 // indirect
+	github.com/acroca/go-symbols v0.0.0-20180523203557-953befd75e22 // indirect
 	github.com/armon/go-metrics v0.0.0-20180713145231-3c58d8115a78 // indirect
 	github.com/armon/go-radix v0.0.0-20170727155443-1fca145dffbc // indirect
 	github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf // indirect
@@ -19,7 +20,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/codegangsta/cli v1.20.0
 	github.com/containerd/continuity v0.0.0-20180712174259-0377f7d76720 // indirect
-	github.com/cyberark/conjur-api-go v0.0.0-20180212213233-94b5cadf8f90
+	github.com/cyberark/conjur-api-go v0.3.3
 	github.com/cyberark/conjur-authn-k8s-client v0.12.0
 	github.com/cyberark/summon v0.0.0-20171226164112-07326408eaed
 	github.com/davecgh/go-spew v1.1.0 // indirect
@@ -28,6 +29,7 @@ require (
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/duosecurity/duo_api_golang v0.0.0-20180315112207-d0530c80e49a // indirect
 	github.com/fatih/structs v1.0.0 // indirect
+	github.com/fatih/structtag v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/fullsailor/pkcs7 v0.0.0-20180613152042-8306686428a5 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
@@ -66,6 +68,7 @@ require (
 	github.com/jefferai/jsonx v0.0.0-20160721235117-9cc31c3135ee // indirect
 	github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8 // indirect
 	github.com/joho/godotenv v1.2.0
+	github.com/josharian/impl v0.0.0-20180228163738-3d0f908298c4 // indirect
 	github.com/json-iterator/go v0.0.0-20180806060727-1624edc4454b // indirect
 	github.com/jtolds/gls v4.2.1+incompatible // indirect
 	github.com/keybase/go-crypto v0.0.0-20180627172517-670ebd3adf7a // indirect
@@ -73,6 +76,7 @@ require (
 	github.com/lib/pq v0.0.0-20180123210206-19c8e9ad0095
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect
+	github.com/mdempsky/gocode v0.0.0-20180727200127-00e7f5ac290a // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
 	github.com/mgutz/logxi v0.0.0-20161027140823-aebf8a7d67ab // indirect
 	github.com/mitchellh/copystructure v0.0.0-20170525013902-d23ffcb85de3 // indirect
@@ -94,6 +98,8 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.8.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/ramya-rao-a/go-outline v0.0.0-20170803230019-9e9d089bb61a // indirect
+	github.com/rogpeppe/godef v0.0.0-20170920080713-b692db1de522 // indirect
 	github.com/ryanuber/go-glob v0.0.0-20170128012129-256dc444b735 // indirect
 	github.com/sethgrid/pester v0.0.0-20171127025028-760f8913c048 // indirect
 	github.com/sirupsen/logrus v1.0.6 // indirect
@@ -101,6 +107,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20170602164621-9e8dc3f972df
 	github.com/smartystreets/gunit v0.0.0-20180314194857-6f0d6275bdcd // indirect
 	github.com/spf13/pflag v1.0.2 // indirect
+	github.com/sqs/goreturns v0.0.0-20180302073349-83e02874ec12 // indirect
 	github.com/stretchr/testify v1.2.1
 	golang.org/x/crypto v0.0.0-20180119074636-ee41a25c63fb
 	golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b // indirect

--- a/internal/app/secretless/providers/env/provider.go
+++ b/internal/app/secretless/providers/env/provider.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
 )
 
 // EnvironmentProvider provides data values from the process environment.
@@ -23,6 +24,19 @@ func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, err
 // GetName returns the name of the provider
 func (p *EnvironmentProvider) GetName() string {
 	return p.Name
+}
+
+// GetValues resolves multiple environment variables into values
+func (p *EnvironmentProvider) GetValues(variables []config.Variable) (map[string][]byte, error) {
+	result := map[string][]byte{}
+	for _, variable := range variables {
+		value, err := p.GetValue(variable.ID)
+			if err != nil {
+				return nil, err
+			}
+		result[variable.Name] = value
+	}
+	return result, nil
 }
 
 // GetValue obtains a value by ID. Any environment is a recognized ID.

--- a/internal/app/secretless/providers/file/provider.go
+++ b/internal/app/secretless/providers/file/provider.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
 )
 
 // Provider reads the contents of the specified file.
@@ -22,6 +23,19 @@ func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, err
 // GetName returns the name of the provider
 func (p *Provider) GetName() string {
 	return p.Name
+}
+
+// GetValues resolves multiple files into values
+func (p *Provider) GetValues(variables []config.Variable) (map[string][]byte, error) {
+	result := map[string][]byte{}
+	for _, variable := range variables {
+		value, err := p.GetValue(variable.ID)
+			if err != nil {
+				return nil, err
+			}
+		result[variable.Name] = value
+	}
+	return result, nil
 }
 
 // GetValue reads the contents of the identified file.

--- a/internal/app/secretless/providers/keychain/provider.go
+++ b/internal/app/secretless/providers/keychain/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
 )
 
 // Provider obtains a secret from an OS keychain.
@@ -23,6 +24,19 @@ func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, err
 // GetName returns the name of the provider
 func (p *Provider) GetName() string {
 	return p.Name
+}
+
+// GetValues resolves multiple keychain variables into values
+func (p *Provider) GetValues(variables []config.Variable) (map[string][]byte, error) {
+	result := map[string][]byte{}
+	for _, variable := range variables {
+		value, err := p.GetValue(variable.ID)
+			if err != nil {
+				return nil, err
+			}
+		result[variable.Name] = value
+	}
+	return result, nil
 }
 
 // GetValue reads the contents of the identified file.

--- a/internal/app/secretless/providers/kubernetessecrets/provider.go
+++ b/internal/app/secretless/providers/kubernetessecrets/provider.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
 )
 
 // Provider provides data values from Kubernetes Secrets.
@@ -33,6 +34,19 @@ func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, err
 // GetName returns the name of the provider
 func (p *Provider) GetName() string {
 	return p.Name
+}
+
+// GetValues resolves multiple Kubernetes secrets into values
+func (p *Provider) GetValues(variables []config.Variable) (map[string][]byte, error) {
+	result := map[string][]byte{}
+	for _, variable := range variables {
+		value, err := p.GetValue(variable.ID)
+			if err != nil {
+				return nil, err
+			}
+		result[variable.Name] = value
+	}
+	return result, nil
 }
 
 // GetValue obtains a value by id. Any secret which is stored in Kubernetes Secrets is recognized.

--- a/internal/app/secretless/providers/literal/provider.go
+++ b/internal/app/secretless/providers/literal/provider.go
@@ -1,6 +1,10 @@
 package literal
 
-import plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+import (
+	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
+)
+
 
 // Provider provides the ID as the value.
 type Provider struct {
@@ -18,6 +22,19 @@ func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, err
 // GetName returns the name of the provider
 func (p *Provider) GetName() string {
 	return p.Name
+}
+
+// GetValues resolves multiple literal fields into values
+func (p *Provider) GetValues(variables []config.Variable) (map[string][]byte, error) {
+	result := map[string][]byte{}
+	for _, variable := range variables {
+		value, err := p.GetValue(variable.ID)
+			if err != nil {
+				return nil, err
+			}
+		result[variable.Name] = value
+	}
+	return result, nil
 }
 
 // GetValue returns the id.

--- a/internal/app/secretless/providers/vault/provider.go
+++ b/internal/app/secretless/providers/vault/provider.go
@@ -7,6 +7,7 @@ import (
 	vault "github.com/hashicorp/vault/api"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
 )
 
 // Provider provides data values from the Conjur vault.
@@ -52,6 +53,19 @@ func parseVaultID(id string) (string, string) {
 	default:
 		return tokens[0], tokens[1]
 	}
+}
+
+// GetValues resolves multiple secrets into values
+func (p *Provider) GetValues(variables []config.Variable) (map[string][]byte, error) {
+	result := map[string][]byte{}
+	for _, variable := range variables {
+		value, err := p.GetValue(variable.ID)
+			if err != nil {
+				return nil, err
+			}
+		result[variable.Name] = value
+	}
+	return result, nil
 }
 
 // GetValue obtains a value by id. Any secret which is stored in the vault is recognized.

--- a/internal/pkg/plugin/resolver_test.go
+++ b/internal/pkg/plugin/resolver_test.go
@@ -83,7 +83,7 @@ func Test_Resolver(t *testing.T) {
 			variableValues, err := resolver.Resolve(variables)
 			So(len(variableValues), ShouldEqual, 0)
 			So(err, ShouldNotBeNil)
-			errorMsg := "ERROR: Resolving variable 'something-not-in-env' from provider 'env' failed: env cannot find environment variable 'something-not-in-env'"
+			errorMsg := "Failed to resolve variable: env cannot find environment variable 'something-not-in-env'"
 			So(err.Error(), ShouldEqual, errorMsg)
 
 		})

--- a/pkg/secretless/plugin/v1/provider.go
+++ b/pkg/secretless/plugin/v1/provider.go
@@ -1,5 +1,9 @@
 package v1
 
+import (
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
+)
+
 // ProviderOptions contains the configuration for the provider instantiation
 type ProviderOptions struct {
 	// Name is the internal name that the provider will have. This may be different from
@@ -12,6 +16,9 @@ type Provider interface {
 	// GetName returns the name that the Provider was instantiated with
 	GetName() string
 
-	// GetValue takes in an id of a variable and returns its resolved value
+	// GetValues takes a slice of variable ids and returns their resolved values
+	GetValues(variables []config.Variable) (map[string][]byte, error)
+
+	// GetValue takes a single variable id and resolves its value
 	GetValue(id string) ([]byte, error)
 }

--- a/test/conjur/conjur.yml
+++ b/test/conjur/conjur.yml
@@ -1,2 +1,3 @@
 - !variable db/user
 - !variable db/password
+- !variable db/address

--- a/test/conjur/conjur.yml
+++ b/test/conjur/conjur.yml
@@ -1,1 +1,2 @@
+- !variable db/user
 - !variable db/password

--- a/test/conjur/conjur_provider_test.go
+++ b/test/conjur/conjur_provider_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+	"io/ioutil"
 	"encoding/json"
 	"testing"
 
@@ -78,6 +80,11 @@ func TestConjur_Provider(t *testing.T) {
 				Provider: name,
 				ID: "db/password", 
 			},
+			config.Variable{
+				Name: "address",
+				Provider: name,
+				ID: "db/address", 
+			},
 		})
 
 		So(err, ShouldBeNil)
@@ -121,4 +128,39 @@ func TestConjur_Provider(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(token, ShouldNotBeNil)
 	})
+}
+
+var result map[string][]byte
+func BenchmarkConjurProvider(b *testing.B) {
+	b.StopTimer()
+
+	log.SetOutput(ioutil.Discard)
+	name := "conjur"
+	resolver := plugin.NewResolver(providers.ProviderFactories, nil, nil)
+	resolver.GetProvider(name)
+	
+	var values map[string][]byte
+
+	b.StartTimer()
+
+	for n := 0; n < b.N; n++ {
+		values, _ = resolver.Resolve([]config.Variable{
+			config.Variable{
+				Name: "user",
+				Provider: name,
+				ID: "db/user",
+			},
+			config.Variable{
+				Name: "password",
+				Provider: name,
+				ID: "db/password", 
+			},
+			config.Variable{
+				Name: "address",
+				Provider: name,
+				ID: "db/address", 
+			},
+		})
+	}
+	result = values
 }

--- a/test/conjur/start
+++ b/test/conjur/start
@@ -36,4 +36,5 @@ docker-compose run \
   -e http_proxy=http://secretless:8080 \
   test \
   bash -c "conjur variable values add db/password secret \
-    && conjur variable values add db/user somewhat-secret"
+    && conjur variable values add db/user somewhat-secret \
+    && conjur variable values add db/address not-so-secret"

--- a/test/conjur/start
+++ b/test/conjur/start
@@ -35,4 +35,5 @@ docker-compose run \
   --no-deps \
   -e http_proxy=http://secretless:8080 \
   test \
-  conjur variable values add db/password secret
+  bash -c "conjur variable values add db/password secret \
+    && conjur variable values add db/user somewhat-secret"

--- a/test/plugin/example/provider.go
+++ b/test/plugin/example/provider.go
@@ -1,6 +1,9 @@
 package example
 
-import plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+import (
+	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
+)
 
 // Provider provides the `<ID>provider` as the value.
 type Provider struct {
@@ -17,6 +20,19 @@ func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, err
 // GetName returns the name of the provider
 func (provider *Provider) GetName() string {
 	return provider.Name
+}
+
+// GetValues returns multiple values
+func (provider *Provider) GetValues(variables []config.Variable) (map[string][]byte, error) {
+	result := map[string][]byte{}
+	for _, variable := range variables {
+		value, err := p.GetValue(variable.ID)
+			if err != nil {
+				return nil, err
+			}
+		result[variable.Name] = value
+	}
+	return result, nil
 }
 
 // GetValue returns the id + "Provider"

--- a/test/summon2/summon2_run_test.go
+++ b/test/summon2/summon2_run_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cyberark/secretless-broker/internal/app/summon/command"
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -22,6 +23,19 @@ type MapProvider struct {
 func (mp MapProvider) GetName() string {
 	return "mapProvider"
 }
+
+func (mp MapProvider) GetValues(variables []config.Variable) (map[string][]byte, error) {
+	result := map[string][]byte{}
+	for _, variable := range variables {
+		if value, ok := mp.Secrets[variable.ID]; ok {
+			result[variable.Name] = value
+		} else {
+			return nil, fmt.Errorf("Value '%s' not found in MapProvider", variable.ID)
+		}
+	}
+	return result, nil
+}
+
 func (mp MapProvider) GetValue(id string) ([]byte, error) {
 	value, ok := mp.Secrets[id]
 	if ok {


### PR DESCRIPTION
Connected to #514 
- `Resolver.Resolve` now runs all Provider value retrievals in parallel
- The Conjur Provider now retrieves all variable values in a single API call

Includes tests.