### PR TITLE
Fix linting error handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,6 @@ test/junit.output
 
 # Ignore compose file changes
 docker-compose.yml
+
+# We don't want Docker cache to break on Jenkinsfile changes
+Jenkinsfile

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
       steps {
         sh './bin/check_style'
 
-        checkstyle pattern: 'test/golint.xml', canComputeNew: false, usePreviousBuildAsReference: false, unstableTotalAll: '0', healthy: '0', failedTotalAll: '0',  unHealthy: '0'
+        checkstyle pattern: 'test/golint.xml', canComputeNew: true, usePreviousBuildAsReference: false, failedNewAll: "0", failedTotalAll: "0",  unHealthy: "0", healthy: "1", thresholdLimit: "low", useDeltaValues: false
       }
     }
 

--- a/bin/check_style
+++ b/bin/check_style
@@ -37,7 +37,7 @@ output_xml() {
         current_file=$file
       fi
 
-      echo "    <error line=\"$line\" message=\"$error\"></error>"
+      echo "    <error line=\"$line\" severity=\"error\" message=\"$error\"></error>"
     done <<< "$style_errs"
 
     echo "  </file>"

--- a/internal/app/secretless/providers/kubernetessecrets/client.go
+++ b/internal/app/secretless/providers/kubernetessecrets/client.go
@@ -1,15 +1,15 @@
-package kubernetes_secrets
+package kubernetessecrets
 
 import (
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/api/core/v1"
 )
 
 // KubeClient represents Kubernetes client and calculated namespace
 type KubeClient struct {
-	clientset *kubernetes.Clientset
+	clientset    *kubernetes.Clientset
 	clientConfig clientcmd.ClientConfig
 }
 
@@ -32,7 +32,7 @@ func NewKubeClient() (*KubeClient, error) {
 	}
 
 	return &KubeClient{
-		clientset: clientset,
+		clientset:    clientset,
 		clientConfig: clientConfig,
 	}, nil
 }

--- a/internal/app/secretless/providers/kubernetessecrets/provider.go
+++ b/internal/app/secretless/providers/kubernetessecrets/provider.go
@@ -1,4 +1,4 @@
-package kubernetes_secrets
+package kubernetessecrets
 
 import (
 	"fmt"
@@ -55,12 +55,12 @@ func (p *Provider) GetValue(id string) ([]byte, error) {
 		return nil, err
 	}
 
-	secret, err := p.Client.GetSecret(currentNamespace, secretName);
+	secret, err := p.Client.GetSecret(currentNamespace, secretName)
 	if err != nil {
 		return nil, err
 	}
 
-	value, ok := secret.Data[fieldName];
+	value, ok := secret.Data[fieldName]
 	if !ok {
 		return nil, fmt.Errorf("could not find field '%s' in Kubernetes secret '%s'", fieldName, secretName)
 	}

--- a/internal/app/secretless/providers/providers.go
+++ b/internal/app/secretless/providers/providers.go
@@ -5,7 +5,7 @@ import (
 	envProvider "github.com/cyberark/secretless-broker/internal/app/secretless/providers/env"
 	fileProvider "github.com/cyberark/secretless-broker/internal/app/secretless/providers/file"
 	keychainProvider "github.com/cyberark/secretless-broker/internal/app/secretless/providers/keychain"
-	kubernetesProvider "github.com/cyberark/secretless-broker/internal/app/secretless/providers/kubernetes-secrets"
+	kubernetesProvider "github.com/cyberark/secretless-broker/internal/app/secretless/providers/kubernetessecrets"
 	literalProvider "github.com/cyberark/secretless-broker/internal/app/secretless/providers/literal"
 	vaultProvider "github.com/cyberark/secretless-broker/internal/app/secretless/providers/vault"
 
@@ -13,12 +13,12 @@ import (
 )
 
 // ProviderFactories contains the list of built-in provider factories
-var ProviderFactories = map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error) {
-	"conjur":   conjurProvider.ProviderFactory,
-	"env":      envProvider.ProviderFactory,
-	"file":     fileProvider.ProviderFactory,
-	"keychain": keychainProvider.ProviderFactory,
-	"kubernetes":  kubernetesProvider.ProviderFactory,
-	"literal":  literalProvider.ProviderFactory,
-	"vault":    vaultProvider.ProviderFactory,
+var ProviderFactories = map[string]func(plugin_v1.ProviderOptions) (plugin_v1.Provider, error){
+	"conjur":     conjurProvider.ProviderFactory,
+	"env":        envProvider.ProviderFactory,
+	"file":       fileProvider.ProviderFactory,
+	"keychain":   keychainProvider.ProviderFactory,
+	"kubernetes": kubernetesProvider.ProviderFactory,
+	"literal":    literalProvider.ProviderFactory,
+	"vault":      vaultProvider.ProviderFactory,
 }

--- a/test/plugin/example/conn_manager.go
+++ b/test/plugin/example/conn_manager.go
@@ -83,7 +83,7 @@ func (manager *connectionManager) Shutdown() {
 	log.Println("Shutdown manager event...")
 }
 
-// ConnectionManagerFactory returns an empty ConnectionManager
+// ConnManagerFactory returns an empty ConnectionManager
 func ConnManagerFactory() plugin_v1.ConnectionManager {
 	return &connectionManager{}
 }


### PR DESCRIPTION
Resolves #367 

[Jenkins Build](https://jenkins.conjur.net/view/cyberark/job/cyberark--secretless-broker/job/fix-linting/)

Linting is currently broken (doesn't trigger failures) so this change
ensures that the errors are enforced as expected.