### PR TITLE
Add Postgres benchmarking

### DIFF
--- a/test/pg_handler/bench_test.go
+++ b/test/pg_handler/bench_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"testing"
+
+	_ "github.com/lib/pq"
+)
+
+const (
+	select1Query     = "SELECT 1"
+	select10Query    = "SELECT generate_series(0, 9)"
+	select100Query   = "SELECT generate_series(0, 99)"
+	select1000Query  = "SELECT generate_series(0, 999)"
+	select10000Query = "SELECT generate_series(0, 9999)"
+)
+
+type Endpoint int
+
+const (
+	Postgres Endpoint = iota
+	Secretless
+)
+
+var endpointToEnv = map[Endpoint]string{
+	Postgres:   "PG_ADDRESS",
+	Secretless: "SECRETLESS_ADDRESS",
+}
+
+func getConnection(endpoint Endpoint) (*sql.DB, error) {
+	var ok bool
+	var envAddress string
+	if envAddress, ok = endpointToEnv[endpoint]; ok == false {
+		return nil, fmt.Errorf("got unknown endpoint %v", endpoint)
+	}
+
+	var address string
+	if address, ok = os.LookupEnv(envAddress); ok == false {
+		return nil, fmt.Errorf("%s is not set", envAddress)
+	}
+
+	if endpoint == Postgres {
+		address = fmt.Sprintf("test@%s", address)
+	}
+
+	connStr := fmt.Sprintf("postgresql://%s/postgres?sslmode=disable", address)
+	db, err := sql.Open("postgres", connStr)
+	if err != nil {
+		return nil, err
+	}
+
+	db.SetMaxOpenConns(1)
+
+	return db, nil
+}
+
+// runQuery executes a query. Expects the timer to already have been stopped.
+func runQuery(db *sql.DB, query string, b *testing.B) {
+	b.StartTimer()
+	rows, err := db.Query(query)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.StopTimer()
+	rows.Close()
+}
+
+func benchmarkQuery(endpoint Endpoint, query string, b *testing.B) {
+	b.StopTimer()
+	db, err := getConnection(endpoint)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer db.Close()
+
+	for i := 0; i < b.N; i++ {
+		runQuery(db, query, b)
+	}
+}
+
+func BenchmarkBaseline_Select1(b *testing.B) {
+	benchmarkQuery(Postgres, select1Query, b)
+}
+
+func BenchmarkBaseline_Select10(b *testing.B) {
+	benchmarkQuery(Postgres, select10Query, b)
+}
+
+func BenchmarkBaseline_Select100(b *testing.B) {
+	benchmarkQuery(Postgres, select100Query, b)
+}
+
+func BenchmarkBaseline_Select1000(b *testing.B) {
+	benchmarkQuery(Postgres, select1000Query, b)
+}
+
+func BenchmarkBaseline_Select10000(b *testing.B) {
+	benchmarkQuery(Postgres, select10000Query, b)
+}
+
+func BenchmarkSecretless_Select1(b *testing.B) {
+	benchmarkQuery(Secretless, select1Query, b)
+}
+
+func BenchmarkSecretless_Select10(b *testing.B) {
+	benchmarkQuery(Secretless, select10Query, b)
+}
+
+func BenchmarkSecretless_Select100(b *testing.B) {
+	benchmarkQuery(Secretless, select100Query, b)
+}
+
+func BenchmarkSecretless_Select1000(b *testing.B) {
+	benchmarkQuery(Secretless, select1000Query, b)
+}
+
+func BenchmarkSecretless_Select10000(b *testing.B) {
+	benchmarkQuery(Secretless, select10000Query, b)
+}

--- a/test/pg_handler/docker-compose.yml
+++ b/test/pg_handler/docker-compose.yml
@@ -17,6 +17,8 @@ services:
       context: ../..
     environment:
       PG_PASSWORD: test
+    ports:
+      - 15432
     volumes:
       - ./secretless.yml:/secretless.yml
       - pg-socket:/sock
@@ -26,6 +28,9 @@ services:
       context: .
       dockerfile: Dockerfile.dev
     command: go test -v ./test/pg_handler
+    environment:
+      PG_ADDRESS: pg:5432
+      SECRETLESS_ADDRESS: secretless:15432
     volumes:
       - pg-socket:/sock
     depends_on:
@@ -37,6 +42,8 @@ services:
       dockerfile: Dockerfile.dev
     environment:
       PG_PASSWORD: test
+      PG_ADDRESS: pg:5432
+      SECRETLESS_ADDRESS: secretless:15432
     volumes:
       - ../..:/secretless
       - pg-socket:/sock

--- a/test/pg_handler/pg_test.go
+++ b/test/pg_handler/pg_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"strconv"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -53,10 +54,13 @@ func TestPGHandler(t *testing.T) {
 		_, err := net.LookupIP("pg")
 		if err == nil {
 			host = "secretless"
-			port = 5432
+			port = 15432
 		} else {
 			host = "localhost"
-			port = 15432
+			port, err = strconv.Atoi(os.Getenv("SECRETLESS_PORT"))
+			if err != nil {
+				t.Error(err)
+			}
 		}
 
 		cmdOut, err := psql(host, port, "", []string{})

--- a/test/pg_handler/secretless.yml
+++ b/test/pg_handler/secretless.yml
@@ -1,7 +1,7 @@
 listeners:
   - name: pg_tcp
     protocol: pg
-    address: 0.0.0.0:5432
+    address: 0.0.0.0:15432
 
   - name: pg_socket
     protocol: pg


### PR DESCRIPTION
Closes #364 

Benchmarking runs a series of SELECT queries directly to Postgres and
through Secretless over TCP.

Running the benchmark:
```
→ cd test/pg_handler
→ ./start
  [...]
→ PG_ADDRESS=localhost:5432
→ SECRETLESS_ADDRESS=localhost:15432
→ go test -v -bench=. -test.benchtime=10s ./bench_test.go
go: finding github.com/cyberark/conjur-api-go v0.5.0
goos: linux
goarch: amd64
BenchmarkBaseline_Select1-4               100000            153786 ns/op
BenchmarkBaseline_Select10-4              100000            169145 ns/op
BenchmarkBaseline_Select100-4             100000            176324 ns/op
BenchmarkBaseline_Select1000-4             50000            274557 ns/op
BenchmarkBaseline_Select10000-4            50000            407285 ns/op
BenchmarkSecretless_Select1-4              50000            281437 ns/op
BenchmarkSecretless_Select10-4             50000            288196 ns/op
BenchmarkSecretless_Select100-4            50000            312763 ns/op
BenchmarkSecretless_Select1000-4           30000            420000 ns/op
BenchmarkSecretless_Select10000-4          20000            644353 ns/op
PASS
ok      command-line-arguments  465.070s
```