### PR TITLE
Made configuration file reading use a configuration manager plugin

### DIFF
--- a/internal/app/secretless/configurationmanagers/configfile/fs_watcher.go
+++ b/internal/app/secretless/configurationmanagers/configfile/fs_watcher.go
@@ -1,4 +1,4 @@
-package plugin
+package configfile
 
 import (
 	"log"

--- a/internal/app/secretless/configurationmanagers/configfile/manager.go
+++ b/internal/app/secretless/configurationmanagers/configfile/manager.go
@@ -1,0 +1,160 @@
+package configfile
+
+import (
+	"fmt"
+	"log"
+	"net/url"
+	"os"
+	"os/signal"
+	"os/user"
+	"path"
+	"strconv"
+	"syscall"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/config"
+	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
+)
+
+const (
+	// ConfigFileName is the default name expected from configuration files
+	ConfigFileName = "secretless.yml"
+
+	// PluginName is the external name that this plugin will be identified by
+	PluginName = "configfile"
+)
+
+type configurationManager struct {
+	ConfigChangedFunc func(string, config.Config) error
+	Name              string
+}
+
+func (configManager *configurationManager) getConfigFilePreferenceOrder() ([]string, error) {
+	configFileOrder := []string{
+		"./" + ConfigFileName,
+	}
+
+	currentUser, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(currentUser.HomeDir) > 0 {
+		homeDirConfigFile := "." + ConfigFileName
+		fullHomeConfigFilePath := path.Join(currentUser.HomeDir, homeDirConfigFile)
+		configFileOrder = append(configFileOrder, fullHomeConfigFilePath)
+	}
+
+	configFileOrder = append(configFileOrder,
+		path.Join("/etc", ConfigFileName))
+
+	return configFileOrder, nil
+}
+
+func (configManager *configurationManager) registerReloadSignalHandlers(configFile string,
+	changeHandler plugin_v1.ConfigurationChangedHandler) {
+	log.Println("Registering reload signal listeners...")
+	signalChannel := make(chan os.Signal, 1)
+	signal.Notify(signalChannel, syscall.SIGUSR1)
+
+	go func() {
+		for {
+			reloadSignal := <-signalChannel
+			log.Printf("Intercepted reload signal '%v'. Reloading (from '%s')...",
+				reloadSignal, configFile)
+
+			configuration, err := config.LoadFromFile(configFile)
+			if err != nil {
+				log.Fatalf(err.Error())
+			}
+			changeHandler.ConfigurationChanged(configManager.Name, configuration)
+		}
+	}()
+}
+
+// registerConfigFileWatcher adds a configuration file change trigger for reloads
+func (configManager *configurationManager) registerConfigFileWatcher(configFile string) {
+	onChangeRunner := func() {
+		log.Println("Sending reload signal (SIGUSR1)...")
+		syscall.Kill(syscall.Getpid(), syscall.SIGUSR1)
+	}
+
+	AttachWatcher(configFile, onChangeRunner)
+}
+
+func (configManager *configurationManager) onGoodConfigLoad(configuration config.Config,
+	changeHandler plugin_v1.ConfigurationChangedHandler, configFilePath string, watchFile bool) error {
+
+	go func() {
+		changeHandler.ConfigurationChanged(configManager.Name, configuration)
+		if watchFile == true {
+			configManager.registerConfigFileWatcher(configFilePath)
+		}
+
+		configManager.registerReloadSignalHandlers(configFilePath, changeHandler)
+	}()
+
+	return nil
+}
+
+// Initialize implements plugin_v1.ConfigurationManager
+func (configManager *configurationManager) Initialize(changeHandler plugin_v1.ConfigurationChangedHandler,
+	configSpecQuery string) error {
+
+	configSpecObject, err := url.Parse(configSpecQuery)
+	if err != nil {
+		return err
+	}
+
+	configFilePath := configSpecObject.Path
+
+	watchFile := false
+	if watchFileParam, ok := configSpecObject.Query()["watch"]; ok == true {
+		watchFileParamValue, err := strconv.ParseBool(watchFileParam[0])
+		if err == nil {
+			watchFile = watchFileParamValue
+		}
+	}
+
+	if len(configFilePath) > 0 {
+		log.Printf("Trying to load configuration file: %s", configFilePath)
+		configuration, err := config.LoadFromFile(configFilePath)
+		if err != nil {
+			return err
+		}
+
+		return configManager.onGoodConfigLoad(configuration, changeHandler, configFilePath,
+			watchFile)
+	}
+
+	configFileOrder, err := configManager.getConfigFilePreferenceOrder()
+	if err != nil {
+		return err
+	}
+
+	for _, configFilePath := range configFileOrder {
+		log.Printf("Trying to load %s...", configFilePath)
+
+		configuration, err := config.LoadFromFile(configFilePath)
+		if err == nil {
+			log.Printf("Configuration file %s loaded", configFilePath)
+			return configManager.onGoodConfigLoad(configuration, changeHandler, configFilePath, watchFile)
+		}
+
+		log.Printf("WARN: Could not load %s. Skipping...", configFilePath)
+		continue
+	}
+
+	return fmt.Errorf("ERROR: Unable to locate any working configuration files")
+}
+
+// GetName implements plugin_v1.ConfigurationManager
+func (configManager *configurationManager) GetName() string {
+	return configManager.Name
+}
+
+// ConfigurationManagerFactory returns a file-based ConfigurationManager instance
+func ConfigurationManagerFactory(options plugin_v1.ConfigurationManagerOptions) plugin_v1.ConfigurationManager {
+	return &configurationManager{
+		Name: options.Name,
+	}
+}

--- a/internal/app/secretless/configurationmanagers/configuration_managers.go
+++ b/internal/app/secretless/configurationmanagers/configuration_managers.go
@@ -1,11 +1,13 @@
 package configurationmanagers
 
 import (
+	"github.com/cyberark/secretless-broker/internal/app/secretless/configurationmanagers/configfile"
 	"github.com/cyberark/secretless-broker/internal/app/secretless/configurationmanagers/kubernetes/crd"
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
 )
 
 // ConfigurationManagerFactories contains the list of built-in factories
 var ConfigurationManagerFactories = map[string]func(plugin_v1.ConfigurationManagerOptions) plugin_v1.ConfigurationManager{
-	crd.PluginName: crd.ConfigurationManagerFactory,
+	configfile.PluginName: configfile.ConfigurationManagerFactory,
+	crd.PluginName:        crd.ConfigurationManagerFactory,
 }

--- a/internal/app/secretless/proxy.go
+++ b/internal/app/secretless/proxy.go
@@ -135,7 +135,7 @@ func (p *Proxy) Run() {
 
 			// TODO: Delegate logic of this `if` check to connection managers
 			if len(p.Config.Listeners) < 1 {
-				log.Println("WARN! No listeners specified in config (wait loop)!")
+				log.Println("Waiting for valid configuration to be provided...")
 				break
 			}
 

--- a/test/http_basic_auth/docker-compose.yml
+++ b/test/http_basic_auth/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.0'
 
 services:
   nginx:
-    image: nginx:1-alpine
+    image: nginx:stable-alpine
     ports:
       - 8080
     healthcheck:

--- a/test/plugin/example/conn_manager.go
+++ b/test/plugin/example/conn_manager.go
@@ -83,7 +83,7 @@ func (manager *connectionManager) Shutdown() {
 	log.Println("Shutdown manager event...")
 }
 
-// ConnectionManagerFactory returns an empty ConnectionManager
+// ConnManagerFactory returns an empty ConnectionManager
 func ConnManagerFactory() plugin_v1.ConnectionManager {
 	return &connectionManager{}
 }


### PR DESCRIPTION
Resolves #366 
Resolves #102 
Resolves #74 
Resolves #215 

[Jenkins Build](https://jenkins.conjur.net/view/cyberark/job/cyberark--secretless-broker/job/366-configfile-config-manage/)

Since we now can use configuration manager plugins, we now have our
regular config file reading moved into this abstraction. The CLI
interactions have not been changed so it is a fully backward-compatible
feature.

How to test:
- Run the CLI with any of the default switches `-f <config>`, `-watch`, and then try without and to see the traversal logic.