### PR TITLE
Updates to Secretless to get Conjur K8s authenticator working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,13 @@ RUN apk add -u shadow libc6-compat && \
     mkdir -p /usr/local/lib/secretless && \
     # Make and setup a directory for sockets at /sock
     mkdir /sock && \
+    # Make and setup a directory for the Conjur client certificate/access token
+    mkdir -p /etc/conjur/ssl && \
+    mkdir -p /run/conjur && \
     chown secretless:secretless /usr/local/lib/secretless \
-                                /sock
+                                /sock \
+                                /etc/conjur/ssl \
+                                /run/conjur
 
 USER secretless
 


### PR DESCRIPTION
### Update Dockerfile to add folders for Conjur provider
The Conjur provider with the Kubernetes authenticator requires a couple of directories be available for the Conjur certificate and the access token. This PR updates the Secretless image to ensure these directories will be available and owned by the `secretless` user.

### Update the Conjur provider to work with v4 or v5
The Conjur provider is updated to provide appropriate resource IDs to the Conjur Go API.