### PR TITLE
Make the integrated CRD injector use capitalized names for 'Kind' field

### DIFF
--- a/internal/app/secretless/configurationmanagers/kubernetes/crd/crd_injector.go
+++ b/internal/app/secretless/configurationmanagers/kubernetes/crd/crd_injector.go
@@ -3,6 +3,7 @@ package crd
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -18,7 +19,7 @@ func createCRD(apiExtClient *apiextensionsclientset.Clientset) error {
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
 			Group: CRDGroupName,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Kind:       CRDLongName,
+				Kind:       strings.Title(CRDLongName),
 				Plural:     CRDName,
 				ShortNames: CRDShortNames,
 			},


### PR DESCRIPTION
Fixes #389 

[Jenkins Build](https://jenkins.conjur.net/view/cyberark/job/cyberark--secretless-broker/job/389-crd-capitalization/)

Without this, we don't have a matching 'kind' between our examples
configuration, our standalone injector, and the integrated injector.