### PR TITLE
Add Mercurial to releaser dependencies

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,10 +10,10 @@ builds:
   - amd64
   main: ./cmd/summon2/main.go
 - binary: secretless-broker
-  env:               
-  - CGO_ENABLED=0    
-  goos:          
-  - linux        
+  env:
+  - CGO_ENABLED=1
+  goos:
+  - linux
   goarch:
   - amd64
   main: ./cmd/secretless-broker/main.go

--- a/bin/Dockerfile.releaser
+++ b/bin/Dockerfile.releaser
@@ -6,7 +6,8 @@ CMD [ "--rm-dist" ]
 RUN apk add --no-cache bash \
                        build-base \
                        curl \
-                       git && \
+                       git \
+                       mercurial && \
     go get -u github.com/golang/dep/cmd/dep
 
 RUN go get -d github.com/goreleaser/goreleaser && \


### PR DESCRIPTION
Since mercurial is needed to fetch the broker dependencies, we need it
in the releaser container too.