### PR TITLE
Added ability to build deb/rpm packages

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,10 +12,12 @@ builds:
 - binary: secretless-broker
   env:
   - CGO_ENABLED=1
+  flags: --tags netgo
   goos:
   - linux
   goarch:
   - amd64
+  ldflags: -s -w -linkmode external -extldflags "-static"
   main: ./cmd/secretless-broker/main.go
 
 archive:
@@ -36,6 +38,20 @@ dist: ./dist/goreleaser
 
 git:
   short_hash: true
+
+nfpm:
+  bindir: /usr/bin
+  description: Secures your apps by making them Secretless
+  empty_folders:
+  - /usr/local/lib/secretless
+  formats:
+  - deb
+  - rpm
+  homepage: https://secretless.io
+  license: "Apache 2.0"
+  maintainer: CyberArk Maintainers <conj_maintainers@cyberark.com>
+  name_template: "{{.ProjectName}}_{{.Version}}_{{.Arch}}"
+  vendor: CyberArk
 
 snapshot:
   name_template: "{{ .Tag }}-next"

--- a/bin/Dockerfile.releaser
+++ b/bin/Dockerfile.releaser
@@ -7,7 +7,8 @@ RUN apk add --no-cache bash \
                        build-base \
                        curl \
                        git \
-                       mercurial && \
+                       mercurial \
+                       rpm && \
     go get -u github.com/golang/dep/cmd/dep
 
 RUN go get -d github.com/goreleaser/goreleaser && \


### PR DESCRIPTION
Resolves #396

We can now target distributions with packages rather than just providing
a single binary.