### PR TITLE
"Why secretless?" page is updated for consistency

### DIFF
--- a/docs/_layouts/landing.html
+++ b/docs/_layouts/landing.html
@@ -28,7 +28,7 @@ layout: default
 						<i class="fa fa-angle-double-right btn-arrow-right" aria-hidden="true"></i>
 						<h3>Use Open Source</h3>
 					</div>
-					<p class="inner-text-description">Secretless Broker is open source, and its code is open and available to review. It is designed to be pluggable, so it’s easy to add support for additional services or vaults. It is natively integrated with Kubernetes for operational simplicity.</p>
+					<p class="inner-text-description">Secretless Broker is open source, and its code is open and auditable. It is designed to be pluggable, so it’s easy to add support for additional services or vaults. It is natively integrated with Kubernetes for operational simplicity.</p>
 				</div>
 			</div>
 		</div>

--- a/docs/docs/overview/why_secretless.md
+++ b/docs/docs/overview/why_secretless.md
@@ -6,23 +6,42 @@ description: Secretless Broker Documentation
 permalink: docs/overview/why_secretless.html
 ---
 
-The Secretless Broker is designed to solve two problems. The first is **loss or theft of credentials from applications and services**, which can occur by:
+Secretless Broker is primarily designed to solve two problems. The first is
+**loss or theft of credentials from applications and services**, which can occur by:
 
 - Accidental credential leakage (e.g. credential checked into source control, etc)
 - An attack on a privileged user (e.g. phishing, developer machine compromises, etc)
 - A vulnerability in an application (e.g. remote code execution, environment variable dump, etc)
 
-The second is **downtime caused when applications or services do not respond to credential rotation** and crash or get locked out of target services as a result.
+The second problem is that **applications must know how to interact with secrets
+vaults**. This often requires code to be changed to fetch needed credentials,
+and time spent implementing and maintaining connections to vaults could be better
+spent delivering business value.
 
-Keeping secrets in a vault is a good practice. However, when a client “checks out” a secret from a vault, where does it go? Often, directly into unprotected application memory at which point that client app has now part of the threat surface. There are a stringent set of best practices and recommendations that should be be followed by every user and application which checks secrets out of a vault but even if you harden the app in every possible way, it does not protect you from 0-day vulnerabilities in the app, underlying framework, and/or the programming language used.
+## Prevent Credential Theft
 
-Exposing plaintext secrets to clients (both users and machines) is hazardous from both a security and operational standpoint. First, by providing a secret to a client, the client becomes part of the threat surface. If the client is compromised, then the attacker has a good chance of obtaining the plaintext secrets and being able to establish direct connections to backend resources. To mitigate the severity of this problem, important secrets are (or should be) rotated (changed) on a regular basis. However, rotation introduces the operational problem of keeping applications up to date with changing passwords. This is a significant problem as many applications only read secrets on startup and are not prepared to handle changing passwords.
+Keeping secrets in a vault is a good practice. However, when a client “checks out” a secret from a vault, where does it go? Often, directly into unprotected application memory at which point that client app has now part of the threat surface. There are a stringent set of best practices and recommendations that should be be followed by every user and application which checks secrets out of a vault, but even if you harden the app in every possible way it does not protect you from 0-day vulnerabilities in the app, underlying framework, and/or the programming language used.
 
 It can be a losing battle to try and train every user and application developer about how to safely handle a secret once they’ve obtained it even if you can mitigate all of the attack surfaces of the client app itself. There are so many things that can go wrong, and people (and applications) have better things to worry about than babysitting secrets (such as doing their jobs). Do you want developers to write features or try to be security engineers too?
 
-The Secretless Broker is specifically written to be really good at interacting with a variety of vaults and abstracting away the security to a specialized module that can easily be audited and expanded with custom plugins. It does a really good job of securing any secrets that it might obtain from a vault, and it does it the same way no matter the developer, technology, or platform. Additionally, it knows what to do when a secret has been changed so that the client users and code never have to respond to changing secrets or even know that they are changing.
+## Focus on Adding Business Value
 
-In summary, when the client connects to the target service through the Secretless Broker:
+Secretless Broker is specifically written to be really good at interacting with a
+variety of vaults and abstracting away the security to a specialized module that
+can easily be audited and expanded with custom plugins. It does a really good job
+of securing any secrets that it might obtain from a vault, and it does it the same
+way no matter the developer, technology, or platform.
+
+## Summary
+
+In summary, when the client connects to the target service through Secretless Broker:
+
+- **The client does not have to know how to fetch credentials**
+
+  The client/app no longer has to directly interact with a secrets vault and no
+  code must be changed to fetch credentials before opening a connection. If the
+  vault used changes when the environment or platform changes no changes in code
+  are required, thus reducing the probability of human error and bugs.
 
 - **The client is not part of the threat surface**
 
@@ -30,8 +49,4 @@ In summary, when the client connects to the target service through the Secretles
 
 - **The client doesn't have to know how to properly manage secrets**
 
-  Handling secrets safely involves some complexities, and when every application needs to know how to handle secrets, accidents happen. The Secretless Broker centralizes the client-side management of secrets into one code base, making it easier for developers to focus on delivering features.
-
-- **The client doesn't have to manage secret rotation**
-
-  The Secretless Broker is responsible for establishing connections to the backend, and can handle secrets rotation in a way that's transparent to the client.
+  Handling secrets safely involves some complexities, and when every application needs to know how to handle secrets, accidents happen. Secretless Broker centralizes the client-side management of secrets into one code base, making it easier for developers to focus on delivering features.


### PR DESCRIPTION
Resolves #422 

Updates "Why Secretless?" page to be more consistent with other language currently being used on the site. This includes the arguments for using Secretless to improve responsiveness to rotation; there is future work to be done to really nail the rotation story, so it's best to remove this content until that later date.

Also makes a minor change to the "Use Open Source" feature on the main page.