### PR TITLE
Update build_website

### DIFF
--- a/bin/build_website
+++ b/bin/build_website
@@ -38,7 +38,7 @@ cat $DOCS_DIR/godoc_packages.txt | while read package; do
   echo "---
 layout: docs
 id: ${sanitized_package_name}
-title: Documentation
+title: Plugin Reference
 description: Secretless Broker Documentation
 godoc: True
 godoc_repository: ${REPOSITORY}

--- a/pkg/secretless/plugin/v1/doc.go
+++ b/pkg/secretless/plugin/v1/doc.go
@@ -15,8 +15,6 @@ There is also an additional EventNotifier class used to bubble up events from li
 to the plugin manager but this class may be removed as we move more of the abstract functionality to the plugin manager
 itself.
 
-Basic overview
-
 All plugins are currently loaded in the following manner:
   - Directory in `/usr/local/lib/secretless` is listed and any `*.so` files are iterated over. Sub-directory traversal is not supported at this time.
   - Each shared library plugin is searched for these variables:


### PR DESCRIPTION
Minor update to change the title on the Plugin Reference page from "Documentation" to "Plugin Reference"

Also removes "Basic Overview" header when there is also an "Overview" header