### PR TITLE
Run pg benchmarks with test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+bench.*
 debug
 debug.*
 .vscode/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,25 +23,37 @@ pipeline {
       }
     }
 
-    stage('Unit tests') {
-      steps {
-        sh './bin/test_unit'
+    stage('Run Tests') {
+      parallel {
+        stage('Unit tests') {
+          steps {
+            sh './bin/test_unit'
 
-        junit 'test/junit.xml'
-      }
-    }
+            junit 'test/junit.xml'
+          }
+        }
 
-    stage('Integration tests') {
-      steps {
-        sh './bin/test_integration'
+        stage('Integration tests') {
+          steps {
+            sh './bin/test_integration'
 
-        junit 'test/junit.xml'
-      }
-    }
+            junit 'test/junit.xml'
+          }
+        }
 
-    stage('Demo tests') {
-      steps {
-        sh './bin/test_quickstart'
+        stage('Demo tests') {
+          steps {
+            sh './bin/test_quickstart'
+          }
+        }
+
+        stage('Benchmarks') {
+          steps {
+            sh './bin/test_benchmarks'
+
+            junit 'test/bench.xml'
+          }
+        }
       }
     }
 

--- a/bin/test_benchmarks
+++ b/bin/test_benchmarks
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+set -eo pipefail
+
+project_dir=$PWD
+rm -f $project_dir/test/bench.output
+touch $project_dir/test/bench.output
+
+pushd test
+  exit_status="0"
+  for dir in */; do
+    pushd "$dir" 2>/dev/null
+      # Bail if the folder doesn't have a bench_test file
+      # Assumes folder has a start file if it has a bench_test file
+      if [[ ! -f bench_test.go ]]; then
+        popd 2>/dev/null
+        continue
+      fi
+
+      # Start the needed prerequisites. Assumes that start pre-cleans the env
+      ./start
+
+      # Run the tests
+      set +e
+        ./test -b | tee -a $project_dir/test/bench.output
+        last_status="$?"
+
+        # Only save first failure exit code
+        if [[ "$exit_status" -eq "0" && "$last_status" -ne "0" ]]; then
+          echo "ERROR: Detected a failure in the runner for $dir!"
+          exit_status="$last_status"
+        fi
+      set -e
+
+      # Clean up
+      if [[ -f ./stop ]]; then
+        ./stop
+      fi
+    popd
+  done
+
+  # Format the benchmark output
+  rm -f $project_dir/test/bench.xml
+  docker run --rm \
+    -v $project_dir/test/:/secretless/test/output/ \
+    secretless-dev \
+    bash -exc "
+      go get -u github.com/jstemmer/go-junit-report
+      cat ./test/output/bench.output | go-junit-report > ./test/output/bench.xml
+    "
+popd || true
+
+exit $exit_status

--- a/bin/test_benchmarks
+++ b/bin/test_benchmarks
@@ -17,6 +17,9 @@ pushd test
         continue
       fi
 
+      # set up the containers to run in their own namespace
+      export COMPOSE_PROJECT_NAME="$(basename $PWD)_$(openssl rand -hex 3)"
+
       # Start the needed prerequisites. Assumes that start pre-cleans the env
       ./start
 

--- a/test/http_basic_auth/test
+++ b/test/http_basic_auth/test
@@ -10,7 +10,7 @@ done
 
 docker_args=""
 if $local_test; then
-  docker_args="-v $(cd ../..; pwd):/go/src/github.com/cyberark/secretless-broker"
+  docker_args="-v $(cd ../..; pwd):/secretless"
 fi
 
 docker-compose run \

--- a/test/mysql_handler/test
+++ b/test/mysql_handler/test
@@ -10,7 +10,7 @@ done
 
 docker_args=""
 if $local_test; then
-  docker_args="-v $(cd ../..; pwd):/go/src/github.com/cyberark/secretless-broker"
+  docker_args="-v $(cd ../..; pwd):/secretless"
 fi
 
 docker-compose run \

--- a/test/pg_handler/Dockerfile.dev
+++ b/test/pg_handler/Dockerfile.dev
@@ -3,3 +3,6 @@ FROM secretless-dev
 RUN apt-get update && \
     apt-get install -y postgresql-client \
                        postgresql-contrib
+
+RUN go get github.com/ajstarks/svgo/benchviz && \
+    go get golang.org/x/tools/cmd/benchcmp

--- a/test/pg_handler/bench_test.go
+++ b/test/pg_handler/bench_test.go
@@ -9,14 +9,6 @@ import (
 	_ "github.com/lib/pq"
 )
 
-const (
-	select1Query     = "SELECT * FROM test.test WHERE id < 1"
-	select10Query    = "SELECT * FROM test.test WHERE id < 10"
-	select100Query   = "SELECT * FROM test.test WHERE id < 100"
-	select1000Query  = "SELECT * FROM test.test WHERE id < 1000"
-	select10000Query = "SELECT * FROM test.test WHERE id < 10000"
-)
-
 func getConnection() (*sql.DB, error) {
 	var ok bool
 	var address string
@@ -44,10 +36,12 @@ func runQuery(db *sql.DB, query string, b *testing.B) {
 	rows.Close()
 }
 
-func benchmarkQuery(query string, b *testing.B) {
+func benchmarkQuery(queryMax int, b *testing.B) {
 
 	// stop time while the connection is opened
 	b.StopTimer()
+
+	query := fmt.Sprintf("SELECT * FROM test.test WHERE id < %d", queryMax)
 
 	db, err := getConnection()
 	if err != nil {
@@ -63,21 +57,25 @@ func benchmarkQuery(query string, b *testing.B) {
 }
 
 func Benchmark_Select1(b *testing.B) {
-	benchmarkQuery(select1Query, b)
+	benchmarkQuery(1, b)
 }
 
 func Benchmark_Select10(b *testing.B) {
-	benchmarkQuery(select10Query, b)
+	benchmarkQuery(10, b)
 }
 
 func Benchmark_Select100(b *testing.B) {
-	benchmarkQuery(select100Query, b)
+	benchmarkQuery(100, b)
 }
 
 func Benchmark_Select1000(b *testing.B) {
-	benchmarkQuery(select1000Query, b)
+	benchmarkQuery(1000, b)
 }
 
 func Benchmark_Select10000(b *testing.B) {
-	benchmarkQuery(select10000Query, b)
+	benchmarkQuery(10000, b)
+}
+
+func Benchmark_Select100000(b *testing.B) {
+	benchmarkQuery(100000, b)
 }

--- a/test/pg_handler/bench_test.go
+++ b/test/pg_handler/bench_test.go
@@ -29,23 +29,14 @@ var endpointToEnv = map[Endpoint]string{
 	Secretless: "SECRETLESS_ADDRESS",
 }
 
-func getConnection(endpoint Endpoint) (*sql.DB, error) {
+func getConnection() (*sql.DB, error) {
 	var ok bool
-	var envAddress string
-	if envAddress, ok = endpointToEnv[endpoint]; ok == false {
-		return nil, fmt.Errorf("got unknown endpoint %v", endpoint)
-	}
-
 	var address string
-	if address, ok = os.LookupEnv(envAddress); ok == false {
-		return nil, fmt.Errorf("%s is not set", envAddress)
+	if address, ok = os.LookupEnv("BENCH_ADDRESS"); ok == false {
+		return nil, fmt.Errorf("%s is not set", "BENCH_ADDRESS")
 	}
 
-	if endpoint == Postgres {
-		address = fmt.Sprintf("test@%s", address)
-	}
-
-	connStr := fmt.Sprintf("postgresql://%s/postgres?sslmode=disable", address)
+	connStr := fmt.Sprintf("postgresql://test@%s/postgres?sslmode=disable", address)
 	db, err := sql.Open("postgres", connStr)
 	if err != nil {
 		return nil, err
@@ -67,9 +58,9 @@ func runQuery(db *sql.DB, query string, b *testing.B) {
 	rows.Close()
 }
 
-func benchmarkQuery(endpoint Endpoint, query string, b *testing.B) {
+func benchmarkQuery(query string, b *testing.B) {
 	b.StopTimer()
-	db, err := getConnection(endpoint)
+	db, err := getConnection()
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -80,42 +71,22 @@ func benchmarkQuery(endpoint Endpoint, query string, b *testing.B) {
 	}
 }
 
-func BenchmarkBaseline_Select1(b *testing.B) {
-	benchmarkQuery(Postgres, select1Query, b)
+func Benchmark_Select1(b *testing.B) {
+	benchmarkQuery(select1Query, b)
 }
 
-func BenchmarkBaseline_Select10(b *testing.B) {
-	benchmarkQuery(Postgres, select10Query, b)
+func Benchmark_Select10(b *testing.B) {
+	benchmarkQuery(select10Query, b)
 }
 
-func BenchmarkBaseline_Select100(b *testing.B) {
-	benchmarkQuery(Postgres, select100Query, b)
+func Benchmark_Select100(b *testing.B) {
+	benchmarkQuery(select100Query, b)
 }
 
-func BenchmarkBaseline_Select1000(b *testing.B) {
-	benchmarkQuery(Postgres, select1000Query, b)
+func Benchmark_Select1000(b *testing.B) {
+	benchmarkQuery(select1000Query, b)
 }
 
-func BenchmarkBaseline_Select10000(b *testing.B) {
-	benchmarkQuery(Postgres, select10000Query, b)
-}
-
-func BenchmarkSecretless_Select1(b *testing.B) {
-	benchmarkQuery(Secretless, select1Query, b)
-}
-
-func BenchmarkSecretless_Select10(b *testing.B) {
-	benchmarkQuery(Secretless, select10Query, b)
-}
-
-func BenchmarkSecretless_Select100(b *testing.B) {
-	benchmarkQuery(Secretless, select100Query, b)
-}
-
-func BenchmarkSecretless_Select1000(b *testing.B) {
-	benchmarkQuery(Secretless, select1000Query, b)
-}
-
-func BenchmarkSecretless_Select10000(b *testing.B) {
-	benchmarkQuery(Secretless, select10000Query, b)
+func Benchmark_Select10000(b *testing.B) {
+	benchmarkQuery(select10000Query, b)
 }

--- a/test/pg_handler/docker-compose.yml
+++ b/test/pg_handler/docker-compose.yml
@@ -16,6 +16,7 @@ services:
     build:
       context: ../..
     environment:
+      PG_ADDRESS:
       PG_PASSWORD: test
     ports:
       - 15432
@@ -27,10 +28,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: go test -v ./test/pg_handler
     environment:
-      PG_ADDRESS: pg:5432
-      SECRETLESS_ADDRESS: secretless:15432
+      PG_ADDRESS:
+      SECRETLESS_ADDRESS:
     volumes:
       - pg-socket:/sock
     depends_on:

--- a/test/pg_handler/docker-compose.yml
+++ b/test/pg_handler/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 1s
       timeout: 30s
+    volumes:
+      - psql-data:/var/lib/postgresql/data
 
   secretless:
     build:
@@ -50,3 +52,4 @@ services:
 
 volumes:
   pg-socket:
+  psql-data:

--- a/test/pg_handler/secretless.yml
+++ b/test/pg_handler/secretless.yml
@@ -13,8 +13,8 @@ handlers:
     debug: true
     credentials:
       - name: address
-        provider: literal
-        id: pg:5432
+        provider: env
+        id: PG_ADDRESS
       - name: username
         provider: literal
         id: test
@@ -27,8 +27,8 @@ handlers:
     debug: true
     credentials:
       - name: address
-        provider: literal
-        id: pg:5432
+        provider: env
+        id: PG_ADDRESS
       - name: username
         provider: literal
         id: test

--- a/test/pg_handler/start
+++ b/test/pg_handler/start
@@ -11,6 +11,10 @@ docker-compose up \
 ./wait-for-pg
 
 # start secretless once pg is running
+pg_cid=$(docker-compose ps -q pg)
+pg_ip=$(docker inspect \
+  -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $pg_cid)
+export PG_ADDRESS=$pg_ip:5432
 docker-compose up \
   -d \
   secretless

--- a/test/pg_handler/test
+++ b/test/pg_handler/test
@@ -1,9 +1,11 @@
 #!/bin/bash -ex
 
 local_test=false
-while getopts :l opt; do
+benchmark=false
+while getopts ":lb" opt; do
     case $opt in
         l) local_test=true ;;
+        b) benchmark=true ;;
        \?) echo "Unknown option -$OPTARG"; exit 1;;
     esac
 done
@@ -13,8 +15,44 @@ if $local_test; then
   docker_args="-v $(cd ../..; pwd):/go/src/github.com/cyberark/secretless-broker"
 fi
 
-docker-compose run \
-  --rm \
-  --no-deps \
-  $docker_args \
-  test
+if $benchmark; then
+  # first set PG_ADDRESS and SECRETLESS_ADDRESS
+  pg_cid=$(docker-compose ps -q pg)
+  secretless_cid=$(docker-compose ps -q secretless)
+  pg_ip=$(docker inspect \
+    -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $pg_cid)
+  secretless_ip=$(docker inspect \
+    -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $secretless_cid)
+
+  export PG_ADDRESS=$pg_ip:5432
+  export SECRETLESS_ADDRESS=$secretless_ip:15432
+
+  echo "++++++++++++++++++++++++++++++++++++++"
+  echo ""
+  echo "Running PostgreSQL benchmarks ..."
+  echo ""
+  echo "++++++++++++++++++++++++++++++++++++++"
+
+  docker-compose run \
+    --rm \
+    --no-deps \
+    $docker_args \
+    test \
+    bash -c '
+      echo "--- QUERYING POSTGRES DIRECTLY ---" && \
+      BENCH_ADDRESS=$PG_ADDRESS go test -v -bench=. -test.benchtime=10s ./test/pg_handler/bench_test.go | tee bench.old && \
+
+      echo "--- QUERYING VIA SECRETLESS ---" && \
+      BENCH_ADDRESS=$SECRETLESS_ADDRESS go test -v -bench=. -test.benchtime=10s ./test/pg_handler/bench_test.go | tee bench.new && \
+
+      echo "--- COMPARING BENCHMARKS ---" && \
+      benchcmp bench.old bench.new
+    '
+else
+  docker-compose run \
+    --rm \
+    --no-deps \
+    $docker_args \
+    test \
+    go test -v ./test/pg_handler
+fi

--- a/test/pg_handler/test
+++ b/test/pg_handler/test
@@ -12,7 +12,7 @@ done
 
 docker_args=""
 if $local_test; then
-  docker_args="-v $(cd ../..; pwd):/go/src/github.com/cyberark/secretless-broker"
+  docker_args="-v $(cd ../..; pwd):/secretless"
 fi
 
 if $benchmark; then

--- a/test/pg_handler/test.sql
+++ b/test/pg_handler/test.sql
@@ -2,9 +2,9 @@ CREATE USER test PASSWORD 'test';
 
 CREATE SCHEMA test;
 
-CREATE TABLE test.test ( id integer );
+CREATE TABLE test.test ( id INTEGER PRIMARY KEY );
 
-INSERT INTO test.test VALUES ( 1 ), ( 2 );
+INSERT INTO test.test VALUES ( generate_series(0, 99999) );
 
 GRANT ALL ON SCHEMA test TO test;
 GRANT ALL ON test.test TO test;

--- a/test/plugin/test
+++ b/test/plugin/test
@@ -11,7 +11,7 @@ done
 docker_args=""
 if $local_test; then
   echo "Using local test setup for $(dirname $0)"
-  docker_args="-v $(pwd)/../..:/go/src/github.com/cyberark/secretless-broker"
+  docker_args="-v $(pwd)/../..:/secretless"
 fi
 
 docker-compose run \

--- a/test/ssh_agent_handler/test
+++ b/test/ssh_agent_handler/test
@@ -40,7 +40,7 @@ done
 
 docker_args=""
 if $local_test; then
-  docker_args="-v $(cd ../..; pwd):/go/src/github.com/cyberark/secretless-broker"
+  docker_args="-v $(cd ../..; pwd):/secretless"
 fi
 
 start=`date +%s`

--- a/test/ssh_handler/test
+++ b/test/ssh_handler/test
@@ -40,7 +40,7 @@ done
 
 docker_args=""
 if $local_test; then
-  docker_args="-v $(cd ../..; pwd):/go/src/github.com/cyberark/secretless-broker"
+  docker_args="-v $(cd ../..; pwd):/secretless"
 fi
 
 start=`date +%s`


### PR DESCRIPTION
Resolves #364 

Updates the pg benchmark to return more consistent results
- Adds a volume to the pg instance to avoid using overlayfs for io ops that aren't in ram
- References pg / secretless by container IP instead of name so that DNS lookup will not impact performance

Adds benchmark tests to the CI pipeline
- Parallelizes the test suite runs
- Adds benchmark tests (if the test directory has a bench_test.go file included)

TODO:
- red build if benchmark run fails (logged issue #471)