### PR TITLE
Link to FAQ is added to Docs dropdown in top nav

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -18,6 +18,8 @@ main:
       url: /docs/get_started.html
     - title: Reference
       url: /docs/reference.html
+    - title: FAQ
+      url: /docs/faq.html
   - title: Community
     url: /community.html
   - title: Blog


### PR DESCRIPTION
Update to add a link to FAQ to the dropdiwn for Docs in the top nav. 

**To test:**
1. Check that FAQ link is appearing in the nav in the Docs dropdown 
2. Confirm that when navigating to the FAQ page, the Docs top nav item, and FAQ item within the dropdown are using the blue active link style (shown below) 

![screenshot_2018-10-18 frequently asked questions secretless](https://user-images.githubusercontent.com/123787/47176581-f6832880-d2e3-11e8-913b-f60d2c6f23f2.png)
