### PR TITLE
503 - Dropdown fixes

### DIFF
--- a/docs/_sass/_navbar.scss
+++ b/docs/_sass/_navbar.scss
@@ -40,11 +40,6 @@
 			margin-top: 1rem;
 			margin-bottom: 1rem;
 		}
-		.dropdown.show {
-			.dropdown-toggle::after {
-				opacity: 0;
-			}
-		}
 	}
 }
 
@@ -121,6 +116,10 @@
 	.dropdown-menu li a {
 		color: #fff;
 	}
+}
+
+.dropdown.top-sub:focus, .dropdown.top-sub a:focus {
+	outline: none;
 }
 
 @media (max-width: 991px) {


### PR DESCRIPTION
**What does this PR do?**

Connected to #503 

Updates Staging to:
1. Removes :focus pseudo class causing a blue highlight when dropdown menus opened in Safari
2. Prevents caret for dropdown menus from disappearing when menu opened

**Before**
<img width="740" alt="screen shot 2018-11-15 at 1 18 53 pm" src="https://user-images.githubusercontent.com/123787/48573086-3e906d80-e8d9-11e8-8ddd-302d3b1598ea.png">
<img width="207" alt="screen shot 2018-11-15 at 1 18 40 pm" src="https://user-images.githubusercontent.com/123787/48573087-3e906d80-e8d9-11e8-831c-c518a4da145e.png">

**After**
![screenshot_2018-11-15 secretless broker secretless 1](https://user-images.githubusercontent.com/123787/48573115-4cde8980-e8d9-11e8-84a5-4010fc3ac75a.png)
![screenshot_2018-11-15 secretless broker secretless](https://user-images.githubusercontent.com/123787/48573116-4cde8980-e8d9-11e8-8c8d-46de4b616753.png)
