### PR TITLE
fix(pipeline): add missing and fix broken tags

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -21,19 +21,25 @@ else
 fi
 
 echo "Building secretless-broker:$TAG Docker image"
+# NOTE: the latest tag is required by downstream pipeline stages
 docker build -t "secretless-broker:${TAG}" \
+             -t "secretless-broker:latest" \
              $DOCKER_FLAGS \
              -f $TOPLEVEL_DIR/Dockerfile \
              $TOPLEVEL_DIR
 
 echo "Building secretless-dev:$TAG Docker image"
+# NOTE: the latest tag is required by downstream pipeline stages
 docker build -t "secretless-dev:${TAG}" \
+             -t "secretless-dev:latest" \
              $DOCKER_FLAGS \
              -f $TOPLEVEL_DIR/Dockerfile.dev \
              $TOPLEVEL_DIR
 
 echo "Building secretless-broker-quickstart:$TAG Docker image"
+# NOTE: the latest tag is required by downstream pipeline stages
 docker build -t "secretless-broker-quickstart:${TAG}" \
+             -t "secretless-broker-quickstart:latest" \
              $DOCKER_FLAGS \
              -f "$QUICK_START_DIR/Dockerfile" \
              "$QUICK_START_DIR"

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -24,18 +24,6 @@ function gen_versions() {
 # Functions to facilitate publishing images
 ###
 
-# tag_and_publish tag image1 image2 ...
-function tag_and_push() {
-  local tag="$1"
-  shift
-
-  for image in $*; do
-    local target="$image:$tag"
-    docker tag "$SOURCE_IMAGE" "$target"
-    docker push "$target"
-  done
-}
-
 # Return the results of git describe
 function git_description() {
   echo "$(git describe)"

--- a/bin/publish
+++ b/bin/publish
@@ -18,6 +18,8 @@ readonly TAGS=(
 
 for image_name in "${IMAGES[@]}"; do
   # always push the tag with the commit hash
+  echo "Tagging $REGISTRY/$image_name:${TAG}"
+  docker tag "$image_name:$TAG" "$REGISTRY/$image_name:$TAG"
   echo "Pushing $REGISTRY/$image_name:${TAG}"
   docker push "$REGISTRY/$image_name:$TAG"
 
@@ -28,7 +30,9 @@ for image_name in "${IMAGES[@]}"; do
 
     for tag in "${TAGS[@]}" $(gen_versions $VERSION); do
       echo "Tagging and pushing $REGISTRY/$image_name:$tag"
-      tag_and_push $tag $REGISTRY/$image_name
+
+      docker tag "$image_name:$TAG" "$REGISTRY/$image_name:$tag"
+      docker push "$REGISTRY/$image_name:$tag"
     done
   fi
 done


### PR DESCRIPTION
* TODO: Pipeline stages really shouldn't rely on `secretless-*:latest`. We'll end up with race conditions on concurrent builds. A better alternative  is `secretless-*:$TAG`