### PR TITLE
WIP - refactor: BASH_SOURCE for script location + prebaked pipeline container + .gitlab-ci.yml to independent script

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,4 @@
-image: docker:stable-git
-
-variables:
-  IMAGE_TAGS: |
-    secretless-broker
-    secretless-dev
-    secretless-broker-quickstart
+image: codebykumbi/docker-compose-bash:stable-git
 
 stages:
   - build
@@ -99,68 +93,5 @@ website:
   only:
     - branches
 
-.utils: &utils |
-  # variables and functions
-  [[ "$TRACE" ]] && set -x
-  export CI_APPLICATION_REPOSITORY=$CI_REGISTRY_IMAGE/$CI_COMMIT_REF_SLUG
-  export CI_APPLICATION_TAG=$CI_COMMIT_SHA
-  export CI_CONTAINER_NAME=ci_job_build_${CI_JOB_ID}
-
-  export ALL_TAGS="";
-  VERSION=$(cat VERSION);
-
-  ALL_TAGS=$(echo "$IMAGE_TAGS" | sed '/^$/d' | while read -r line; do
-    echo "$line:latest"
-  done
-  )
-
-  function login_ci_registry() {
-    if [[ -n "$CI_REGISTRY_USER" ]]; then
-      echo "Logging to GitLab Container Registry with CI credentials..."
-      docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" "$CI_REGISTRY"
-      echo ""
-    fi
-  }
-
-  function setup_docker() {
-    login_ci_registry
-  }
-  
-  function save_image() {
-    tag=$(echo $1 | sed -e 's/\:/-/' -e 's/\//-/')
-    docker tag $1 "$CI_APPLICATION_REPOSITORY:$CI_APPLICATION_TAG-$tag"
-    docker push "$CI_APPLICATION_REPOSITORY:$CI_APPLICATION_TAG-$tag"
-  }
-  
-  function get_image() {
-    tag=$(echo $1 | sed -e 's/\:/-/' -e 's/\//-/')
-
-    docker pull "$CI_APPLICATION_REPOSITORY:$CI_APPLICATION_TAG-$tag"
-    docker tag "$CI_APPLICATION_REPOSITORY:$CI_APPLICATION_TAG-$tag" $1
-  }
-  
-  function save_images() {
-    echo "$ALL_TAGS" | while read -r line; do
-      save_image "$line"; 
-    done
-  }
-  
-  function optional_get_images() {
-    echo "$ALL_TAGS" | while read -r line; do
-      get_image "$line" 2> /dev/null || true; 
-    done
-  }
-  
-  function get_images() {
-    echo "$ALL_TAGS" | while read -r line; do
-      get_image "$line"; 
-    done
-  }
-
-  echo "loaded utils"
-
 before_script:
-  - apk add --no-cache bash
-  - apk add --no-cache py-pip
-  - pip install docker-compose
-  - *utils
+  - . ./bin/build_utils_gitlab

--- a/bin/build
+++ b/bin/build
@@ -4,11 +4,14 @@
 # usage: ./bin/build
 set -ex
 
-. bin/build_utils
-
-CURRENT_DIR=$($(dirname $0)/abspath)
+CURRENT_DIR=$(cd $(dirname ${BASH_SOURCE[0]}); pwd)
 TOPLEVEL_DIR="$CURRENT_DIR/.."
 KEEP_ALIVE=${KEEP_ALIVE:-}
+
+# source build utilities
+pushd ${CURRENT_DIR}
+  . ./build_utils
+popd || true
 
 TAG="$(version_tag)"
 QUICK_START_DIR="$TOPLEVEL_DIR/demos/quick-start/docker"

--- a/bin/build
+++ b/bin/build
@@ -4,14 +4,14 @@
 # usage: ./bin/build
 set -ex
 
-CURRENT_DIR=$(cd $(dirname ${BASH_SOURCE[0]}); pwd)
+CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
 TOPLEVEL_DIR="$CURRENT_DIR/.."
 KEEP_ALIVE=${KEEP_ALIVE:-}
 
 # source build utilities
 pushd ${CURRENT_DIR}
   . ./build_utils
-popd || true
+popd
 
 TAG="$(version_tag)"
 QUICK_START_DIR="$TOPLEVEL_DIR/demos/quick-start/docker"

--- a/bin/build_utils_gitlab
+++ b/bin/build_utils_gitlab
@@ -1,0 +1,63 @@
+#!/bin/bash -e
+
+if [[ "${TRACE}" ]]; then
+  set -x;
+fi
+
+CONTAINER_IMAGES=(
+  secretless-broker
+  secretless-dev
+  secretless-broker-quickstart
+)
+export REQ_CONTAINER_IMAGE_TAGS=();
+for CONTAINER_IMAGE in ${CONTAINER_IMAGES[@]}; do
+    REQ_CONTAINER_IMAGE_TAGS+=("${CONTAINER_IMAGE}:latest");
+done
+
+# variables and functions
+export CI_APPLICATION_REPOSITORY=${CI_REGISTRY_IMAGE}/${CI_COMMIT_REF_SLUG}
+export CI_APPLICATION_TAG=${CI_COMMIT_SHA}
+export CI_CONTAINER_NAME=ci_job_build_${CI_JOB_ID}
+
+function login_ci_registry() {
+  if [[ -n "${CI_REGISTRY_USER}" ]]; then
+    echo "Logging to GitLab Container Registry with CI credentials..."
+    docker login -u "${CI_REGISTRY_USER}" -p "${CI_REGISTRY_PASSWORD}" "${CI_REGISTRY}"
+    echo ""
+  fi
+}
+
+function setup_docker() {
+  login_ci_registry
+}
+
+function save_image() {
+  tag=$(echo $1 | sed -e 's/\:/-/' -e 's/\//-/')
+  docker tag $1 "${CI_APPLICATION_REPOSITORY}:${CI_APPLICATION_TAG}-${tag}"
+  docker push "${CI_APPLICATION_REPOSITORY}:${CI_APPLICATION_TAG}-${tag}"
+}
+
+function get_image() {
+  tag=$(echo $1 | sed -e 's/\:/-/' -e 's/\//-/')
+
+  docker pull "${CI_APPLICATION_REPOSITORY}:${CI_APPLICATION_TAG}-${tag}"
+  docker tag "${CI_APPLICATION_REPOSITORY}:${CI_APPLICATION_TAG}-${tag}" $1
+}
+
+function save_images() {
+  echo "Saving required container images..."
+  for CONTAINER_IMAGE_TAG in ${REQ_CONTAINER_IMAGE_TAGS[@]}; do
+    echo "Saving ${CONTAINER_IMAGE_TAG}...";
+    save_image "${CONTAINER_IMAGE_TAG}";
+  done
+}
+
+function get_images() {
+  echo "Getting required container images..."
+  for CONTAINER_IMAGE_TAG in ${REQ_CONTAINER_IMAGE_TAGS[@]}; do
+    echo "Getting ${CONTAINER_IMAGE_TAG}...";
+    get_image "${CONTAINER_IMAGE_TAG}";
+  done
+}
+
+echo "Loaded utilities"

--- a/bin/publish
+++ b/bin/publish
@@ -1,11 +1,11 @@
 #!/bin/bash -e
 
-CURRENT_DIR=$(cd $(dirname ${BASH_SOURCE[0]}); pwd)
+CURRENT_DIR=$(cd $(dirname "${BASH_SOURCE[0]}"); pwd)
 
 # source build utilities
 pushd ${CURRENT_DIR}
   . ./build_utils
-popd || true
+popd
 
 readonly TAG="${1:-$(version_tag)}"
 readonly VERSION="$(cat VERSION)"

--- a/bin/publish
+++ b/bin/publish
@@ -1,6 +1,11 @@
 #!/bin/bash -e
 
-. bin/build_utils
+CURRENT_DIR=$(cd $(dirname ${BASH_SOURCE[0]}); pwd)
+
+# source build utilities
+pushd ${CURRENT_DIR}
+  . ./build_utils
+popd || true
 
 readonly TAG="${1:-$(version_tag)}"
 readonly VERSION="$(cat VERSION)"


### PR DESCRIPTION
1. Improve portability of pipeline shell scripts. Use BASH_SOURCE over $0 to determine location of bash script. See https://stackoverflow.com/questions/35006457/choosing-between-0-and-bash-source

2. Improve developer experience by moving lengthy shell scripts from `.gitlab-ci.yml` to independent shell script

3. Improve gitlab-ci pipeline execution time by using docker image baked with all dependencies i.e. `bash`, `docker-compose`. This is `codebykumbi/docker-compose-bash:stable-git` for now until an official image is made. Dockerfile ->
    ```
    FROM docker:stable-git
    RUN apk add --no-cache bash
    RUN apk add --no-cache py-pip
    RUN pip install docker-compose
    ```

4.  ~~Fix gitlab pipeline by replace the cached `VERSION` tagged image in `.gitlab-ci.yml` with the new `$(version_tag)` tagged image~~. This tag isn't necessary for subsequent pipeline stages so it ought to be removed altogether as is done in the master branch :)