### PR TITLE
Update footer link for Google Group

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -29,7 +29,7 @@
 								<ul class="link-col">
 										<p class="footer-title">Contribute</p>
 									<li class="footer-resource"><i class="fab fa-github"></i><a target="_blank" href="https://github.com/cyberark/secretless-broker" target="_blank">GitHub</a></li>
-									<li class="footer-resource"><i class="fas fa-comment-alt"></i><a target="_blank" href="https://groups.google.com/forum/#!forum/secretless" target="_blank">Secretless@</a></li>
+									<li class="footer-resource"><i class="fas fa-comment-alt"></i><a target="_blank" href="https://groups.google.com/forum/#!forum/secretless" target="_blank">Google Group</a></li>
 								</ul>
 							</div>
 				</div>


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Updates Google Group link text
#### What ticket does this PR close?
#560 
#### Where should the reviewer start?
• Run the website locally, and confirm that the link to the Google Group reads "Google Group" (screenshot below)
• Confirm that the link sends you to: https://groups.google.com/forum/#!forum/secretless
#### What is the status of the manual tests?
n/a
#### Links to open issues for related automated integration and unit tests
n/a
#### Links to open issues for related documentation (in READMEs, docs, etc)n/a
#### Screenshots (if appropriate)
<img width="1064" alt="secretless_footer_desktop" src="https://user-images.githubusercontent.com/123787/49654338-89e3fa80-fa05-11e8-95c5-0b0ffeddd0c4.png">
<img width="402" alt="secretless_footer_mobile" src="https://user-images.githubusercontent.com/123787/49654339-89e3fa80-fa05-11e8-8d35-730ff725a9ec.png">
