### PR TITLE
Correct notes styling so that they match with the README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,8 +160,8 @@ Profiling can be used to monitor the impact of Secretless on CPU and Memory cons
 
 We've provided sample instructions below for profiling the PostgreSQL handler.
 
-*Note*: that if you are running through these instructions yourself, you'll want to
-replace `<GOOS>/<GOARCH>` with your particular operating system and compilation architecture.
+*Note: If you are running through these instructions yourself, you'll want to
+replace `<GOOS>/<GOARCH>` with your particular operating system and compilation architecture.*
 
 1. [Build](#building) Secretless locally
 1. Run a Postgres backend named ```sample-pg```:
@@ -212,13 +212,13 @@ replace `<GOOS>/<GOARCH>` with your particular operating system and compilation 
        -profile=<cpu or memory> \
        -f secretless.yml
    ```
-   *Note*: the location of the binary might vary across different OS
+   *Note: The location of the binary may vary across different OS*
 
 1. Once Secretless is running, the type of profiling defined in the previous step should state that it has been enabled. It should look something like:
    ```
    2018/11/21 10:17:13 profile: cpu profiling enabled, /var/folders/wy/f9qn852d5_d4s_g06s1kwjcr0000gn/T/profile789228879/cpu.pprof
    ```
-   *Note:* the hash observed will be different each time a profile is run.
+   *Note: The hash observed will be different each time a profile is run.*
 
 1. Once the Postgres database and Secretless are spun up, query the database through Secretless by running the provided scripts.
 
@@ -226,7 +226,7 @@ replace `<GOOS>/<GOARCH>` with your particular operating system and compilation 
 
    Script for Memory profile: `./bin/memory_profiling`
 
-   *Note*: ensure that these scripts are given the proper permissions to run
+   *Note: Ensure that these scripts are given the proper permissions to run*
 
 1. Observe results in a PDF format by running:
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -159,7 +159,8 @@ Profiling can be used to monitor the impact of Secretless on CPU and Memory cons
 - [Postgresql](https://www.postgresql.org/download/) to install Postgres
 
 We've provided sample instructions below for profiling the PostgreSQL handler.
-Note that if you are running through these instructions yourself, you'll want to
+
+*Note*: that if you are running through these instructions yourself, you'll want to
 replace `<GOOS>/<GOARCH>` with your particular operating system and compilation architecture.
 
 1. [Build](#building) Secretless locally
@@ -211,13 +212,13 @@ replace `<GOOS>/<GOARCH>` with your particular operating system and compilation 
        -profile=<cpu or memory> \
        -f secretless.yml
    ```
-   Note: the location of the binary might vary across different OS
+   *Note*: the location of the binary might vary across different OS
 
 1. Once Secretless is running, the type of profiling defined in the previous step should state that it has been enabled. It should look something like:
    ```
    2018/11/21 10:17:13 profile: cpu profiling enabled, /var/folders/wy/f9qn852d5_d4s_g06s1kwjcr0000gn/T/profile789228879/cpu.pprof
    ```
-   **NOTE:** The hash observed will be different each time a profile is run.
+   *Note:* the hash observed will be different each time a profile is run.
 
 1. Once the Postgres database and Secretless are spun up, query the database through Secretless by running the provided scripts.
 
@@ -225,7 +226,7 @@ replace `<GOOS>/<GOARCH>` with your particular operating system and compilation 
 
    Script for Memory profile: `./bin/memory_profiling`
 
-   Note: ensure that these scripts are given the proper permissions to run
+   *Note*: ensure that these scripts are given the proper permissions to run
 
 1. Observe results in a PDF format by running:
    ```


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Previously, the secretless contributing docs had 'notes' that were not uniform. Some were capitalized, bolded, or not given its own line. Our aim should keep the styling uniform across the Secretless GH docs. I made the styling uniformed with the README.md docs, italics.

#### What ticket does this PR close?
Connected to #576 
#### Where should the reviewer start?
CONTRIBUTING.MD
#### What is the status of the manual tests? N/A
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
BEFORE:
<img width="462" alt="screen shot 2018-12-24 at 11 48 56" src="https://user-images.githubusercontent.com/19418506/50396609-aad17d00-0773-11e9-8147-b7e21e1db94e.png">
<img width="460" alt="screen shot 2018-12-24 at 11 48 49" src="https://user-images.githubusercontent.com/19418506/50396611-ac02aa00-0773-11e9-83b5-da7fb49bf2c0.png">

AFTER:
<img width="457" alt="screen shot 2018-12-24 at 12 04 24" src="https://user-images.githubusercontent.com/19418506/50396696-3814d180-0774-11e9-9390-74c195dd8613.png">
<img width="471" alt="screen shot 2018-12-24 at 12 05 08" src="https://user-images.githubusercontent.com/19418506/50396699-39de9500-0774-11e9-8d30-f9adbfc47553.png">


