### PR TITLE
add conjur provider k8s authenticator documentation

### DIFF
--- a/docs/docs/reference/providers/conjur.md
+++ b/docs/docs/reference/providers/conjur.md
@@ -25,7 +25,7 @@ with Conjur (activating the first non-empty method in this order):
   + Requires identical configuration environment variables as [authn-k8s-client](https://github.com/cyberark/conjur-authn-k8s-client)
   + See [Conjur docs](https://docs.conjur.org/Latest/en/Content/Integrations/Kubernetes_deployApplicationApplication.htm) for additional information on configuration
 
-Both methods also require `CONJUR_APPLIANCE_URL` and `CONJUR_ACCOUNT` to
+These methods also require `CONJUR_APPLIANCE_URL` and `CONJUR_ACCOUNT` to
 be set in the environment of the Secretless Broker. You may optionally
 also include any other configuration environment variables that are
 allowed by the [Conjur Go Client Library](https://github.com/cyberark/conjur-api-go).

--- a/docs/docs/reference/providers/conjur.md
+++ b/docs/docs/reference/providers/conjur.md
@@ -12,10 +12,18 @@ The Conjur provider (`conjur`) populates credentials from an external
 
 ### Secretless Broker Configuration
 To use the Conjur provider, Secretless must be configured to authenticate with
-Conjur. The Secretless Broker currently supports two methods of authenticating
-with Conjur:
-- `CONJUR_AUTHN_TOKEN_FILE` environment variable
+Conjur. The Secretless Broker currently supports several methods of authenticating
+with Conjur (activating the first non-empty method in this order):
+
 - `CONJUR_AUTHN_LOGIN` and `CONJUR_AUTHN_API_KEY` environment variables
+- `CONJUR_AUTHN_TOKEN_FILE` environment variable
+- Conjur Kubernetes authenticator-based authentication
+  
+  In this mode Secretless behaves as an [authn-k8s-client](https://github.com/cyberark/conjur-authn-k8s-client) 
+  and retrieves machine identity through orchestrator-facilitated attestation.
+  + Requires `CONJUR_AUTHN_URL` environment variable contains `authn-k8s`
+  + Requires identical configuration environment variables as [authn-k8s-client](https://github.com/cyberark/conjur-authn-k8s-client)
+  + See [Conjur docs](https://docs.conjur.org/Latest/en/Content/Integrations/Kubernetes_deployApplicationApplication.htm) for additional information on configuration
 
 Both methods also require `CONJUR_APPLIANCE_URL` and `CONJUR_ACCOUNT` to
 be set in the environment of the Secretless Broker. You may optionally


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
#### What ticket does this PR close?
Connected to #401 

#### Where should the reviewer start?
It's a single documentation page change

#### What is the status of the manual tests?

N/A

Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
