### PR TITLE
Made more handlers/listeners not dump credentials in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Sanitized remaining listeners/handlers from dumping data on the CLI when debug mode is on
+
 ## [0.6.1] 2019-01-08
 
 ### Changed
 - Updated conjur-api-go dependency
 
-#### Added
+### Added
 - Added `/ready` and `/live` endpoints on port 5335 for checking if the broker is ready/live
 
 ## [0.6.0] 2018-12-20

--- a/internal/app/secretless/handlers/http/aws.go
+++ b/internal/app/secretless/handlers/http/aws.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 
@@ -99,10 +98,15 @@ func (h AWSHandler) Authenticate(values map[string][]byte, r *http.Request) erro
 	serviceName := matches[2]
 
 	signer := v4.NewSigner(creds)
-	if h.GetConfig().Debug {
-		signer.Debug = aws.LogDebugWithSigning
-		signer.Logger = aws.NewDefaultLogger()
-	}
+
+	// TODO: Make this dependent on a build flag instead of handler flag
+	// https://github.com/cyberark/secretless-broker/issues/593
+	//
+	// if h.GetConfig().Debug {
+	// 	signer.Debug = aws.LogDebugWithSigning
+	// 	signer.Logger = aws.NewDefaultLogger()
+	// }
+
 	if _, err := signer.Sign(r, bytes.NewReader(bodyBytes), serviceName, region, amzDate); err != nil {
 		return err
 	}

--- a/internal/app/secretless/handlers/mysql/backend.go
+++ b/internal/app/secretless/handlers/mysql/backend.go
@@ -5,6 +5,7 @@ import (
 	"github.com/cyberark/secretless-broker/internal/app/secretless/handlers/ssl"
 	"log"
 	"net"
+	"reflect"
 	"strconv"
 
 	"github.com/cyberark/secretless-broker/internal/app/secretless/handlers/mysql/protocol"
@@ -26,7 +27,8 @@ func (h *Handler) ConfigureBackend() (err error) {
 	}
 
 	if h.GetConfig().Debug {
-		log.Printf("MySQL backend connection parameters: %s", connectionDetails)
+		keys := reflect.ValueOf(connectionDetails).MapKeys()
+		log.Printf("%s backend connection parameters: %s", h.GetConfig().Name, keys)
 	}
 
 	if host := connectionDetails["host"]; host != nil {
@@ -110,9 +112,9 @@ func (h *Handler) ConnectToBackend() (err error) {
 	// requested SSL but server doesn't support it
 	if requestedSSL && serverHandshake.ServerCapabilities&protocol.ClientSSL == 0 {
 		return &protocol.Error{
-			Code:     protocol.CRSSLConnectionError,
-			SQLSTATE: protocol.ErrorCodeInternalError,
-			Message:  ErrNoTLS.Error(),
+			Code:       protocol.CRSSLConnectionError,
+			SQLSTATE:   protocol.ErrorCodeInternalError,
+			Message:    ErrNoTLS.Error(),
 			SequenceID: 2,
 		}
 	}

--- a/internal/app/secretless/handlers/pg/backend.go
+++ b/internal/app/secretless/handlers/pg/backend.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net"
 	"net/url"
+	"reflect"
 
 	"github.com/cyberark/secretless-broker/internal/app/secretless/handlers/pg/protocol"
 	"github.com/cyberark/secretless-broker/internal/pkg/util"
@@ -24,7 +25,8 @@ func (h *Handler) ConfigureBackend() (err error) {
 	}
 
 	if h.GetConfig().Debug {
-		log.Printf("PG backend connection parameters: %s", values)
+		keys := reflect.ValueOf(values).MapKeys()
+		log.Printf("%s backend connection parameters: %s", h.GetConfig().Name, keys)
 	}
 
 	if address := values["address"]; address != nil {
@@ -95,12 +97,12 @@ func (h *Handler) ConnectToBackend() (err error) {
 	if tlsConf.UseTLS {
 		// Start SSL Check
 		/*
-		* First determine if SSL is allowed by the backend. To do this, send an
-		* SSL request. The response from the backend will be a single byte
-		* message. If the value is 'S', then SSL connections are allowed and an
-		* upgrade to the connection should be attempted. If the value is 'N',
-		* then the backend does not support SSL connections.
-		*/
+		 * First determine if SSL is allowed by the backend. To do this, send an
+		 * SSL request. The response from the backend will be a single byte
+		 * message. If the value is 'S', then SSL connections are allowed and an
+		 * upgrade to the connection should be attempted. If the value is 'N',
+		 * then the backend does not support SSL connections.
+		 */
 
 		/* Create the SSL request message. */
 		message := protocol.NewMessageBuffer([]byte{})

--- a/internal/app/secretless/handlers/ssh/handler.go
+++ b/internal/app/secretless/handlers/ssh/handler.go
@@ -22,13 +22,16 @@ type ServerConfig struct {
 // Handler contains the configuration and channels
 type Handler struct {
 	plugin_v1.BaseHandler
-	Channels      <-chan ssh.NewChannel
+	Channels <-chan ssh.NewChannel
 }
 
 func (h *Handler) serverConfig() (config ServerConfig, err error) {
 	var values map[string][]byte
 
-	log.Printf("%s", h.GetConfig().Credentials)
+	// TODO: Ensure that we don't print credentials here before uncommenting
+	// Issue: https://github.com/cyberark/secretless-broker/issues/593
+	//
+	// log.Printf("%s", h.GetConfig().Credentials)
 
 	if values, err = h.Resolver.Resolve(h.GetConfig().Credentials); err != nil {
 		return
@@ -94,9 +97,12 @@ func (h *Handler) Run() {
 		log.Fatalf("ERROR: Could not resolve server config\n", err)
 	}
 
-	if h.HandlerConfig.Debug {
-		log.Printf("Using config\n%v", serverConfig.ClientConfig)
-	}
+	// TODO: Ensure that we don't print credentials here before uncommenting
+	// Issue: https://github.com/cyberark/secretless-broker/issues/593
+	//
+	// if h.HandlerConfig.Debug {
+	// 	log.Printf("Using config\n%v", serverConfig.ClientConfig)
+	// }
 
 	if server, err = ssh.Dial(serverConfig.Network, serverConfig.Address, &serverConfig.ClientConfig); err != nil {
 		log.Printf("Failed to dial SSH backend '%s': %s", serverConfig.Address, err)
@@ -193,7 +199,7 @@ func (h *Handler) Run() {
 func HandlerFactory(options plugin_v1.HandlerOptions) plugin_v1.Handler {
 	handler := &Handler{
 		BaseHandler: plugin_v1.NewBaseHandler(options),
-		Channels:      options.Channels,
+		Channels:    options.Channels,
 	}
 
 	handler.Run()

--- a/internal/app/secretless/handlers/sshagent/handler.go
+++ b/internal/app/secretless/handlers/sshagent/handler.go
@@ -87,9 +87,12 @@ func (h *Handler) LoadKeys(keyring agent.Agent) (err error) {
 		}
 	}
 
-	if h.GetConfig().Debug {
-		log.Printf("ssh-agent adding key : %s", key)
-	}
+	// TODO: Ensure that we don't print credentials here before uncommenting
+	// Issue: https://github.com/cyberark/secretless-broker/issues/593
+	//
+	// if h.GetConfig().Debug {
+	// 	log.Printf("ssh-agent adding key : %s", key)
+	// }
 
 	err = keyring.Add(key)
 	return

--- a/internal/app/secretless/listeners/http/listener.go
+++ b/internal/app/secretless/listeners/http/listener.go
@@ -162,9 +162,12 @@ func (l *Listener) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	r.RequestURI = "" // this must be reset when serving a request with the client
 
-	if listenerDebug || handlerDebug {
-		log.Printf("Sending request %v", r)
-	}
+	// TODO: Ensure that we don't print credentials here before uncommenting
+	// Issue: https://github.com/cyberark/secretless-broker/issues/593
+	//
+	// if listenerDebug || handlerDebug {
+	// 	log.Printf("Sending request %v", r)
+	// }
 
 	resp, err := l.Transport.RoundTrip(r)
 	if err != nil {


### PR DESCRIPTION
We still had a few handlers/listeners that were dumping information to
the CLI when debug was turned on so we now don't do that in any of them
hopefully.

#### What does this PR do (include background context, if relevant)?
Redacts pg/mysql/aws credentials from debug output

#### What ticket does this PR close?
Connected to #593 

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/view/cyberark/job/cyberark--secretless-broker/job/593-redact-backend-vars/)

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

#### Links to open issues for related automated integration and unit tests
https://github.com/cyberark/secretless-broker/issues/495

#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
