### PR TITLE
Remove debug from all demos and examples

### DIFF
--- a/cmd/secretless-broker/main.go
+++ b/cmd/secretless-broker/main.go
@@ -45,8 +45,10 @@ func main() {
 	// Acceptable values to input: cpu or memory
 	profileSwitch := flag.String("profile", "", "Enable and set the profiling mode to the value provided. Acceptable values are 'cpu' or 'memory'.")
 
-	configManagerSpecString := flag.String("config-mgr", "configfile", configManagerHelp)
+	// For development use only; enable more verbose debug logging
 	debugSwitch := flag.Bool("debug", false, "Enable debug logging.")
+
+	configManagerSpecString := flag.String("config-mgr", "configfile", configManagerHelp)
 	fsWatchSwitch := flag.Bool("watch", false, "Enable automatic reloads when configuration file changes.")
 	pluginDir := flag.String("p", "/usr/local/lib/secretless", "Directory containing Secretless plugins")
 	flag.Parse()

--- a/demos/full-demo/conjur/docker-compose.yml
+++ b/demos/full-demo/conjur/docker-compose.yml
@@ -31,7 +31,6 @@ services:
 
   ansible_secretless:
     image: secretless-broker
-    command: "-debug"
     environment:
       CONJUR_APPLIANCE_URL: http://conjur
       CONJUR_ACCOUNT: dev
@@ -64,7 +63,6 @@ services:
 
   myapp_secretless:
     image: secretless-broker
-    command: "-debug"
     environment:
       CONJUR_APPLIANCE_URL: http://conjur
       CONJUR_ACCOUNT: dev

--- a/demos/k8s-demo/etc/secretless.yml
+++ b/demos/k8s-demo/etc/secretless.yml
@@ -6,7 +6,6 @@ listeners:
 handlers:
   - name: pg
     listener: pg
-    debug: true
     credentials:
       - name: address
         provider: kubernetes

--- a/docs/docs/get_started/kubernetes_tutorial.md
+++ b/docs/docs/get_started/kubernetes_tutorial.md
@@ -384,13 +384,11 @@ cat << EOF > secretless.yml
 listeners:
   - name: pets-pg-listener
     protocol: pg
-    debug: true
     address: localhost:5432
 
 handlers:
   - name: pets-pg-handler
     listener: pets-pg-listener
-    debug: true
     credentials:
       - name: address
         provider: kubernetes

--- a/docs/docs/reference/handlers/http/aws.md
+++ b/docs/docs/reference/handlers/http/aws.md
@@ -50,7 +50,6 @@ handlers:
     type: aws
     match:
       - .*
-    debug: true
     credentials:
       - name: accessKeyId
         value:
@@ -73,7 +72,6 @@ handlers:
     type: aws
     match:
       - ^https\:\/\/ec2\..*\.amazonaws.com
-    debug: true
     credentials:
       - name: accessKeyId
         provider: env

--- a/test/aws_handler/secretless.yml
+++ b/test/aws_handler/secretless.yml
@@ -8,7 +8,6 @@ handlers:
     listener: http_default
     match:
       - ".*"
-    debug: true
     credentials:
       - name: accessKeyId
         value:

--- a/test/conjur/secretless.dev.yml
+++ b/test/conjur/secretless.dev.yml
@@ -6,7 +6,6 @@ listeners:
 handlers:
   - name: conjur
     listener: http_default
-    debug: true
     match:
       - ".*"
     credentials:

--- a/test/conjur/secretless.yml
+++ b/test/conjur/secretless.yml
@@ -6,7 +6,6 @@ listeners:
 handlers:
   - name: conjur
     listener: http_default
-    debug: true
     match:
       - ^http\:\/\/conjur\/
     credentials:

--- a/test/http_basic_auth/secretless.yml
+++ b/test/http_basic_auth/secretless.yml
@@ -1,10 +1,8 @@
 listeners:
   - name: http_good_basic_auth
-    debug: true
     protocol: http
     address: 0.0.0.0:8080
   - name: http_bad_basic_auth
-    debug: true
     protocol: http
     address: 0.0.0.0:8081
 
@@ -12,7 +10,6 @@ handlers:
   - name: http_good_basic_auth_handler
     type: basic_auth
     listener: http_good_basic_auth
-    debug: true
     match:
       - ^http.*
     credentials:
@@ -26,7 +23,6 @@ handlers:
   - name: http_bad_basic_auth_handler
     type: basic_auth
     listener: http_bad_basic_auth
-    debug: true
     match:
       - ^http.*
     credentials:

--- a/test/plugin/secretless.dev.yml
+++ b/test/plugin/secretless.dev.yml
@@ -9,7 +9,6 @@ listeners:
 handlers:
   - name: echo_via_tcp
     listener: echo_tcp
-    debug: true
     credentials:
       - name: host
         provider: literal
@@ -23,7 +22,6 @@ handlers:
 
   - name: echo_denied_via_tcp
     listener: echo_denied_tcp
-    debug: true
     credentials:
       - name: host
         provider: literal

--- a/test/plugin/secretless.yml
+++ b/test/plugin/secretless.yml
@@ -9,7 +9,6 @@ listeners:
 handlers:
   - name: echo_via_tcp
     listener: echo_tcp
-    debug: true
     credentials:
       - name: host
         provider: env
@@ -23,7 +22,6 @@ handlers:
 
   - name: echo_denied_via_tcp
     listener: echo_denied_tcp
-    debug: true
     credentials:
       - name: host
         provider: env

--- a/test/ssh_agent_handler/secretless.dev.yml
+++ b/test/ssh_agent_handler/secretless.dev.yml
@@ -6,7 +6,6 @@ listeners:
 handlers:
   - name: ssh-agent
     listener: sshagent
-    debug: true
     credentials:
       - name: rsa
         provider: file

--- a/test/ssh_agent_handler/secretless.yml
+++ b/test/ssh_agent_handler/secretless.yml
@@ -6,7 +6,6 @@ listeners:
 handlers:
   - name: ssh-agent
     listener: sshagent
-    debug: true
     credentials:
       - name: rsa
         provider: file

--- a/test/ssh_handler/secretless.yml
+++ b/test/ssh_handler/secretless.yml
@@ -1,13 +1,11 @@
 listeners:
   - name: ssh_listener
-    debug: true
     protocol: ssh
     address: 0.0.0.0:2222
 
 handlers:
   - name: ssh_handler
     listener: ssh_listener
-    debug: true
     credentials:
       - name: privateKey
         provider: file


### PR DESCRIPTION
Also updates the secretless main.go to note that the debug flag is for
development purposes only. This caveat should remain in place until such time
as we are auto-reviewing logs to ensure no leakage of secret data even in debug
mode, and the debug values are actually set up to be helpful to an end user who
is trying to debug the broker (as opposed to being useful to a developer, who
has a deep knowledge of the product and is trying to understand its internals).

#### What ticket does this PR close?
Connected to #584 