### PR TITLE
Made permissions fixes for OpenShift deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Permissions have been fixed for OpenShift non-root integration and use
+
 ## [0.6.2] 2019-01-09
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,16 @@ RUN apk add -u shadow libc6-compat && \
     # Make and setup a directory for the Conjur client certificate/access token
     mkdir -p /etc/conjur/ssl && \
     mkdir -p /run/conjur && \
-    chown secretless:secretless /usr/local/lib/secretless \
-                                /sock \
-                                /etc/conjur/ssl \
-                                /run/conjur
+    # Use GID of 0 since that is what OpenShift will want to be able to read things
+    chown secretless:0 /usr/local/lib/secretless \
+                       /sock \
+                       /etc/conjur/ssl \
+                       /run/conjur && \
+    # We need open group permissions in these directories since OpenShift won't
+    # match our UID when we try to write files to them
+    chmod 770 /sock \
+              /etc/conjur/ssl \
+              /run/conjur
 
 USER secretless
 


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Old setup would fail on OpenShift since UID would not match the random
UID that is forced in those environments so here we ensure that all
writable directories have write permission by GID 0.

#### What ticket does this PR close?
Connected to https://github.com/conjurdemos/kubernetes-conjur-demo/issues/23

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/view/cyberark/job/cyberark--secretless-broker/job/fix-oc-permissions/)

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [x] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)