### PR TITLE
Remove go.sum hacks from Dockerfiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ to enforce its license terms. Please email a signed copy to
 
 ## Prerequisites
 
+### Go version
+To work in this codebase, you will want to have at least Go 1.11.4 installed.
+
 ### Mercurial (`hg`)
 Due to a dependency on `k8s/client-go`, our project requires that you have
 installed Mercurial (`hg` on the CLI) on your system.
@@ -37,26 +40,6 @@ $ apk add -u mercurial
 $ apt update
 $ apt install mercurial
 ```
-
-### A note on go.sum fixes for `k8s/client-go`
-
-`k8s/client-go` downloads a package with mismatching `go.sum` which may present itself
-as something like this during builds or attempts to run the code:
-```
-go: verifying k8s.io/client-go@v0.0.0-20180806134042-1f13a808da65: checksum mismatch
-    downloaded: h1:wQUEIVcXYxsDE8RXfUufo1nfnkeH/BEPhT175YIzea4=
-    go.sum:     h1:3w7osyUaXe5a1wxJrqkfjRhqYMfi9pCiB64J9bmtszk=
-```
-
-If you see this problem, you need to remove the `k8s/client-go` checksum from the
-repository-provided file with the following code and retry your build/run command:
-
-```
-sed -i '/^k8s.io\/client-go\ /d' go.sum
-```
-
-In general, we get around this problem for now by editing the go.sum lines related
-to `k8s.io/client-go` in the Secretless Broker Dockerfiles.
 
 ## Pull Request Workflow
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,6 @@ ENV GOOS=linux \
 
 COPY go.mod go.sum /secretless/
 
-# There are checksum mismatches in various environments with client-go package
-# so we for now manually remove it from the checksum file.
-# Related gh issue: https://github.com/kubernetes/kubernetes/issues/69040
-RUN sed -i '/^k8s.io\/client-go\ /d' /secretless/go.sum
-
 RUN go mod download
 
 # secretless source files
@@ -23,10 +18,6 @@ COPY ./cmd /secretless/cmd
 COPY ./internal /secretless/internal
 COPY ./pkg /secretless/pkg
 COPY ./resource-definitions /secretless/resource-definitions
-
-# There are checksum mismatches in various environments with client-go package
-# so we for now manually remove it from the checksum file.
-RUN sed -i '/^k8s.io\/client-go\ /d' /secretless/go.sum
 
 RUN go build -o dist/$GOOS/$GOARCH/secretless-broker ./cmd/secretless-broker && \
     go build -o dist/$GOOS/$GOARCH/summon2 ./cmd/summon2

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -37,11 +37,6 @@ RUN go get -u github.com/jstemmer/go-junit-report && \
 # go mod dependency management for the secretless project
 COPY go.mod go.sum /secretless/
 
-# There are checksum mismatches in various environments with client-go package
-# so we for now manually remove it from the checksum file.
-# Related gh issue: https://github.com/kubernetes/kubernetes/issues/69040
-RUN sed -i '/^k8s.io\/client-go\ /d' /secretless/go.sum
-
 RUN go mod download
 
 # TODO: all the stuff below this line is not needed
@@ -62,10 +57,6 @@ COPY ./cmd ./cmd
 COPY ./internal ./internal
 COPY ./pkg ./pkg
 COPY ./resource-definitions ./resource-definitions
-
-# There are checksum mismatches in various environments with client-go package
-# so we for now manually remove it from the checksum file.
-RUN sed -i '/^k8s.io\/client-go\ /d' /secretless/go.sum
 
 # Not strictly needed but we might as well do this step too since
 # the dev may want to run the binary

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -13,15 +13,6 @@ RUN apk add -u curl \
 
 COPY go.mod go.sum /secretless/
 
-# There are checksum mismatches in various environments with client-go package
-# so we for now manually remove it from the checksum file.
-# Related gh issue: https://github.com/kubernetes/kubernetes/issues/69040
-RUN sed -i '/^k8s.io\/client-go\ /d' /secretless/go.sum
-
 RUN go mod download
 
 COPY . .
-
-# There are checksum mismatches in various environments with client-go package
-# so we for now manually remove it from the checksum file.
-RUN sed -i '/^k8s.io\/client-go\ /d' /secretless/go.sum


### PR DESCRIPTION
Also update the CONTRIBUTING documentation to ensure devs use a min Go version
of 1.11.4 and to remove the note about checksum conflicts in client-go.

Validated that running the manual keychain test did not lead to any conflicts in go.sum (prior to Go1.11.4, it would).

#### What ticket does this PR close?
Connected to #603

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [X] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)
