### PR TITLE
fix/handler/mysql: handle authPluginName mismatch + consistent sequenceIds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/cenkalti/backoff v2.0.0+incompatible
+	github.com/cespare/reflex v0.2.0 // indirect
 	github.com/codegangsta/cli v1.20.0
 	github.com/containerd/continuity v0.0.0-20180712174259-0377f7d76720 // indirect
 	github.com/cyberark/conjur-api-go v0.5.1-0.20190103154352-bb43c2b86d76
@@ -65,6 +66,7 @@ require (
 	github.com/joho/godotenv v1.2.0
 	github.com/json-iterator/go v0.0.0-20180806060727-1624edc4454b // indirect
 	github.com/jtolds/gls v4.2.1+incompatible // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/keybase/go-crypto v0.0.0-20180627172517-670ebd3adf7a // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/lib/pq v0.0.0-20180123210206-19c8e9ad0095
@@ -79,6 +81,7 @@ require (
 	github.com/mitchellh/reflectwalk v0.0.0-20170726202117-63d60e9d0dbc // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v0.0.0-20180718012357-94122c33edd3 // indirect
+	github.com/ogier/pflag v0.0.1 // indirect
 	github.com/oklog/run v1.0.0 // indirect
 	github.com/onsi/ginkgo v1.6.0 // indirect
 	github.com/onsi/gomega v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/cenkalti/backoff v2.0.0+incompatible h1:5IIPUHhlnUZbcHQsQou5k1Tn58nJkeJL9U+ig5CHJbY=
 github.com/cenkalti/backoff v2.0.0+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/cespare/reflex v0.2.0 h1:6d9WpWJseKjJvZEevKP7Pk42nPx2+BUTqmhNk8wZPwM=
+github.com/cespare/reflex v0.2.0/go.mod h1:ooqOLJ4algvHP/oYvKWfWJ9tFUzCLDk5qkIJduMYrgI=
 github.com/codegangsta/cli v1.20.0 h1:iX1FXEgwzd5+XN6wk5cVHOGQj6Q3Dcp20lUeS4lHNTw=
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
 github.com/containerd/continuity v0.0.0-20180712174259-0377f7d76720 h1:T5LkgEMACPq7+VPRnkh51WhyV+Q0waOGGtp37Y82org=
@@ -136,10 +138,13 @@ github.com/json-iterator/go v0.0.0-20180806060727-1624edc4454b h1:X61dhFTE1Au92S
 github.com/json-iterator/go v0.0.0-20180806060727-1624edc4454b/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jtolds/gls v4.2.1+incompatible h1:fSuqC+Gmlu6l/ZYAoZzx2pyucC8Xza35fpRVWLVmUEE=
 github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/keybase/go-crypto v0.0.0-20180627172517-670ebd3adf7a h1:CXtue2isytULR47PBcKqp7F9tBMAMb2WYeEDlyoYyIE=
 github.com/keybase/go-crypto v0.0.0-20180627172517-670ebd3adf7a/go.mod h1:ghbZscTyKdM07+Fw3KSi0hcJm+AlEUWj8QLlPtijN/M=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -169,6 +174,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180718012357-94122c33edd3 h1:YFBuDro+e1UCqlJpDWGucQaO/UNhBX1GlS8Du0GNfPw=
 github.com/modern-go/reflect2 v0.0.0-20180718012357-94122c33edd3/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/ogier/pflag v0.0.1 h1:RW6JSWSu/RkSatfcLtogGfFgpim5p7ARQ10ECk5O750=
+github.com/ogier/pflag v0.0.1/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFPE+g=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/onsi/ginkgo v1.6.0 h1:Ix8l273rp3QzYgXSR+c8d1fTG7UPgYkOSELPhiY/YGw=

--- a/internal/app/secretless/handlers/mysql/backend.go
+++ b/internal/app/secretless/handlers/mysql/backend.go
@@ -153,7 +153,7 @@ func (h *Handler) ConnectToBackend() (err error) {
 
 	// TODO: add tests cases for authentication plugins support
 	// Disable CapabilityFlag for authentication plugins support
-	clientHandshakeResponse.CapabilityFlags &= ~protocol.ClientPluginAuth
+	clientHandshakeResponse.CapabilityFlags &^= protocol.ClientPluginAuth
 
 	// TODO: add tests cases for client secure connection
 	// Enable CapabilityFlag for client secure connection

--- a/internal/app/secretless/handlers/mysql/backend.go
+++ b/internal/app/secretless/handlers/mysql/backend.go
@@ -153,7 +153,9 @@ func (h *Handler) ConnectToBackend() (err error) {
 
 	// TODO: add tests cases for authentication plugins support
 	// Disable CapabilityFlag for authentication plugins support
-	clientHandshakeResponse.CapabilityFlags ^= protocol.ClientPluginAuth
+	if clientHandshakeResponse.CapabilityFlags&protocol.ClientPluginAuth > 0 {
+		clientHandshakeResponse.CapabilityFlags ^= protocol.ClientPluginAuth
+	}
 	// TODO: add tests cases for client secure connection
 	// Enable CapabilityFlag for client secure connection
 	clientHandshakeResponse.CapabilityFlags |= protocol.ClientSecureConnection

--- a/internal/app/secretless/handlers/mysql/backend.go
+++ b/internal/app/secretless/handlers/mysql/backend.go
@@ -153,9 +153,8 @@ func (h *Handler) ConnectToBackend() (err error) {
 
 	// TODO: add tests cases for authentication plugins support
 	// Disable CapabilityFlag for authentication plugins support
-	if clientHandshakeResponse.CapabilityFlags&protocol.ClientPluginAuth > 0 {
-		clientHandshakeResponse.CapabilityFlags ^= protocol.ClientPluginAuth
-	}
+	clientHandshakeResponse.CapabilityFlags &= ~protocol.ClientPluginAuth
+
 	// TODO: add tests cases for client secure connection
 	// Enable CapabilityFlag for client secure connection
 	clientHandshakeResponse.CapabilityFlags |= protocol.ClientSecureConnection

--- a/internal/app/secretless/handlers/mysql/handler.go
+++ b/internal/app/secretless/handlers/mysql/handler.go
@@ -26,6 +26,11 @@ type BackendConfig struct {
 //
 // Handler requires "host", "port", "username" and "password" credentials.
 type Handler struct {
+	// SequenceIds keep track of packet no. for client and backend
+	// MySQL uses this to ensure packets arrive in order
+	// values indicate appropriate value to use on subsequent write
+	clientSequenceId byte
+	backendSequenceId byte
 	plugin_v1.BaseHandler
 	BackendConfig *BackendConfig
 }
@@ -39,11 +44,10 @@ func (h *Handler) abort(err error) {
 				Code:     protocol.CRUnknownError,
 				SQLSTATE: protocol.ErrorCodeInternalError,
 				Message:  err.Error(),
-				SequenceID: 0,
 			}
 		}
 
-		h.GetClientConnection().Write(mysqlError.GetMessage())
+		h.ClientWrite(mysqlError.GetMessage())
 	}
 }
 

--- a/internal/app/secretless/handlers/mysql/handler.go
+++ b/internal/app/secretless/handlers/mysql/handler.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strconv"
 
 	"github.com/cyberark/secretless-broker/internal/app/secretless/handlers/mysql/protocol"
 	plugin_v1 "github.com/cyberark/secretless-broker/pkg/secretless/plugin/v1"
@@ -18,6 +19,10 @@ type BackendConfig struct {
 	Username string
 	Password string
 	Options  map[string]string
+}
+
+func (bc *BackendConfig) Address() string {
+	return bc.Host + ":" + strconv.FormatUint(uint64(bc.Port), 10)
 }
 
 // Handler connects a client to a backend. It uses the handler Config and Providers to

--- a/internal/app/secretless/handlers/mysql/handler.go
+++ b/internal/app/secretless/handlers/mysql/handler.go
@@ -39,7 +39,7 @@ func (h *Handler) abort(err error) {
 				Code:     protocol.CRUnknownError,
 				SQLSTATE: protocol.ErrorCodeInternalError,
 				Message:  err.Error(),
-				SequenceID: 1,
+				SequenceID: 0,
 			}
 		}
 

--- a/internal/app/secretless/handlers/mysql/protocol/error.go
+++ b/internal/app/secretless/handlers/mysql/protocol/error.go
@@ -25,7 +25,7 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("ERROR: %s (%s): %s", e.Code, e.SQLSTATE, e.Message)
+	return fmt.Sprintf("ERROR: %v (%s): %s", e.Code, e.SQLSTATE, e.Message)
 }
 
 const ERR_HEADER = 0xff

--- a/internal/app/secretless/handlers/mysql/protocol/error.go
+++ b/internal/app/secretless/handlers/mysql/protocol/error.go
@@ -22,7 +22,6 @@ type Error struct {
 	Code        uint16
 	SQLSTATE    string
 	Message     string
-	SequenceID  byte
 }
 
 func (e *Error) Error() string {
@@ -48,7 +47,9 @@ func (e *Error) GetMessage() []byte {
 	data[0] = byte(length)
 	data[1] = byte(length >> 8)
 	data[2] = byte(length >> 16)
-	data[3] = e.SequenceID
+	//sequenceID defaults to 0
+	//expected to be overwritten by writer
+	data[3] = byte(0)
 
 	return data
 }

--- a/internal/app/secretless/handlers/mysql/protocol/protocol.go
+++ b/internal/app/secretless/handlers/mysql/protocol/protocol.go
@@ -373,7 +373,7 @@ type HandshakeResponse41 struct {
 	ClientCharset   uint8
 	Username        string
 	AuthLength      int64
-	AuthnPluginName string
+	AuthPluginName  string
 	AuthResponse    []byte
 	Database        string
 	PacketTail      []byte
@@ -458,11 +458,6 @@ func UnpackHandshakeResponse41(packet []byte) (*HandshakeResponse41, error) {
 	var authPluginName string
 	if capabilityFlags&ClientPluginAuth > 0 {
 		authPluginName = ReadNullTerminatedString(r)
-
-		// TODO: determine if there's a failure case as a result of authPlugin mismatch
-		//if authPluginName != defaultAuthPluginName {
-		//	return nil, errors.New("Error in server handshake " + authPluginName)
-		//}
 	}
 
 	// get the rest of the packet
@@ -482,7 +477,7 @@ func UnpackHandshakeResponse41(packet []byte) (*HandshakeResponse41, error) {
 		ClientCharset:   charset,
 		Username:        username,
 		AuthLength:      authLength,
-		AuthnPluginName: authPluginName,
+		AuthPluginName:  authPluginName,
 		AuthResponse:    auth,
 		Database:        database,
 		PacketTail:      packetTail}, nil
@@ -502,7 +497,7 @@ func InjectCredentials(clientHandshake *HandshakeResponse41, salt []byte, userna
 	// Reset the payload length for the packet
 	payloadLengthDiff := int32(len(username) - len(clientHandshake.Username))
 	payloadLengthDiff += int32(len(authResponse) - int(clientHandshake.AuthLength))
-	payloadLengthDiff += int32(len(defaultAuthPluginName) - len(clientHandshake.AuthnPluginName))
+	payloadLengthDiff += int32(len(defaultAuthPluginName) - len(clientHandshake.AuthPluginName))
 
 	clientHandshake.Header, err = UpdateHeaderPayloadLength(clientHandshake.Header, payloadLengthDiff)
 	if err != nil {

--- a/internal/app/secretless/handlers/mysql/protocol/protocol.go
+++ b/internal/app/secretless/handlers/mysql/protocol/protocol.go
@@ -399,7 +399,7 @@ func UnpackHandshakeResponse41(packet []byte) (*HandshakeResponse41, error) {
 
 	// Check that the server is using protocol 4.1
 	if capabilityFlags&ClientProtocol41 == 0 {
-		return nil, errors.New("Protocol mismatch")
+		return nil, errors.New("Client Protocol mismatch")
 	}
 
 	// client requesting SSL, we don't support it
@@ -455,11 +455,12 @@ func UnpackHandshakeResponse41(packet []byte) (*HandshakeResponse41, error) {
 
 	// check whether the auth method was specified
 	if capabilityFlags&ClientPluginAuth > 0 {
-		authPluginName := ReadNullTerminatedString(r)
+		ReadNullTerminatedString(r)
 
-		if authPluginName != defaultAuthPluginName {
-			return nil, errors.New("Error in server handshake")
-		}
+		// TODO: determine if there's a failure case as a result of authPlugin mismatch
+		//if authPluginName != defaultAuthPluginName {
+		//	return nil, errors.New("Error in server handshake " + authPluginName)
+		//}
 	}
 
 	// get the rest of the packet

--- a/internal/app/secretless/handlers/mysql/protocol/protocol_test.go
+++ b/internal/app/secretless/handlers/mysql/protocol/protocol_test.go
@@ -201,6 +201,7 @@ func TestUnpackHandshakeResponse41(t *testing.T) {
 		ClientCharset:   uint8(8),
 		Username:        "roger",
 		AuthLength:      int64(20),
+		AuthPluginName:  "mysql_native_password",
 		AuthResponse: []byte{0xc0, 0xb, 0xbc, 0xb6, 0x6, 0xf5,
 			0x4f, 0x4e, 0xf4, 0x1b, 0x87, 0xc0, 0xb8, 0x89, 0xae,
 			0xc4, 0x49, 0x7c, 0x46, 0xf3},
@@ -250,7 +251,8 @@ func TestInjectCredentials(t *testing.T) {
 
 	// test with handshake response that already has auth set to another value
 	handshake := HandshakeResponse41{
-		AuthLength: int64(20),
+		AuthLength:     int64(20),
+		AuthPluginName: "mysql_native_password",
 		AuthResponse: []byte{0xc0, 0xb, 0xbc, 0xb6, 0x6, 0xf5, 0x4f, 0x4e,
 			0xf4, 0x1b, 0x87, 0xc0, 0xb8, 0x89, 0xae, 0xc4, 0x49, 0x7c, 0x46, 0xf3},
 		Username: "madeupusername",
@@ -268,10 +270,11 @@ func TestInjectCredentials(t *testing.T) {
 	// test with handshake response with empty auth
 	expectedHeader = []byte{0xb8, 0x0, 0x0, 0x1}
 	handshake = HandshakeResponse41{
-		AuthLength:   0,
-		AuthResponse: []byte{},
-		Username:     "madeupusername",
-		Header:       []byte{0xaa, 0x0, 0x0, 0x1},
+		AuthLength:     0,
+		AuthPluginName: "mysql_native_password",
+		AuthResponse:   []byte{},
+		Username:       "madeupusername",
+		Header:         []byte{0xaa, 0x0, 0x0, 0x1},
 	}
 
 	err = InjectCredentials(&handshake, salt, username, password)

--- a/internal/app/secretless/handlers/mysql/protocol/protocol_test.go
+++ b/internal/app/secretless/handlers/mysql/protocol/protocol_test.go
@@ -240,22 +240,23 @@ func TestUnpackHandshakeResponse41(t *testing.T) {
 }
 
 func TestInjectCredentials(t *testing.T) {
-	username := "testuser"
+	username := "testuser" // 8
 	password := "testpass"
 	salt := []byte{0x2f, 0x50, 0x25, 0x34, 0x78, 0x17, 0x1, 0x44, 0x1d,
 		0xc, 0x61, 0x4f, 0x5c, 0x69, 0x65, 0x6f, 0x25, 0x66, 0x7c, 0x64}
 	expectedAuth := []byte{0xf, 0xf8, 0xe1, 0xa3, 0xe7, 0xe3, 0x5f, 0xd2,
 		0xb1, 0x69, 0x8c, 0x39, 0x5b, 0xfa, 0x99, 0x4f, 0x53, 0xdd, 0xe5,
-		0x35}
-	expectedHeader := []byte{0xa4, 0x0, 0x0, 0x1}
+		0x35} // 20
+	expectedHeader := []byte{0x99, 0x0, 0x0, 0x1}
+	// expectedHeader[0] = 0xaa + (8 - 14) + (20 - 20) + (21 - 32)
 
 	// test with handshake response that already has auth set to another value
 	handshake := HandshakeResponse41{
 		AuthLength:     int64(20),
-		AuthPluginName: "mysql_native_password",
+		AuthPluginName: "non_native_mysql_native_password", // 32
 		AuthResponse: []byte{0xc0, 0xb, 0xbc, 0xb6, 0x6, 0xf5, 0x4f, 0x4e,
-			0xf4, 0x1b, 0x87, 0xc0, 0xb8, 0x89, 0xae, 0xc4, 0x49, 0x7c, 0x46, 0xf3},
-		Username: "madeupusername",
+			0xf4, 0x1b, 0x87, 0xc0, 0xb8, 0x89, 0xae, 0xc4, 0x49, 0x7c, 0x46, 0xf3}, // 20
+		Username: "madeupusername", // 14
 		Header:   []byte{0xaa, 0x0, 0x0, 0x1},
 	}
 
@@ -267,13 +268,14 @@ func TestInjectCredentials(t *testing.T) {
 	assert.Equal(t, expectedHeader, handshake.Header)
 	assert.Equal(t, nil, err)
 
-	// test with handshake response with empty auth
+	// test with handshake response with empty auth and mysql_native_password
 	expectedHeader = []byte{0xb8, 0x0, 0x0, 0x1}
+	// expectedHeader[0] = 0xaa + (8 - 14) + (20 - 0) + (21 - 21)
 	handshake = HandshakeResponse41{
 		AuthLength:     0,
-		AuthPluginName: "mysql_native_password",
-		AuthResponse:   []byte{},
-		Username:       "madeupusername",
+		AuthPluginName: "mysql_native_password", // 21
+		AuthResponse:   []byte{}, // 0
+		Username:       "madeupusername", // 14
 		Header:         []byte{0xaa, 0x0, 0x0, 0x1},
 	}
 

--- a/pkg/secretless/plugin/v1/handler.go
+++ b/pkg/secretless/plugin/v1/handler.go
@@ -77,6 +77,13 @@ func (h *BaseHandler) GetConfig() config.Handler {
 	return h.HandlerConfig
 }
 
+// Debug: Print only if Debug is enabled
+func (h *BaseHandler) PrintDebug(msg string) {
+	if h.GetConfig().Debug {
+		log.Print(msg)
+	}
+}
+
 // GetClientConnection implements plugin_v1.Handler
 func (h *BaseHandler) GetClientConnection() net.Conn {
 	return h.ClientConnection

--- a/test/mysql_handler/docker-compose.yml
+++ b/test/mysql_handler/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.dev
-    command: go test -v ./test/mysql_handler/tests
+    command: sleep 999d
     environment:
       TEST_ROOT: /secretless/test/mysql_handler
       DB_PROTOCOL: mysql

--- a/test/mysql_handler/pkg/run_test_case.go
+++ b/test/mysql_handler/pkg/run_test_case.go
@@ -32,6 +32,9 @@ func RunQuery(clientConfig test.ClientConfiguration, connectPort test.Connection
 		panic("Listener Type can only be TCP or Socket")
 	}
 
+	// ensures mysql can handle non-native auth
+	args = append(args, "--default-auth=mysql_clear_password")
+
 	// Pre command logs
 	convey.Println("")
 	convey.Println("---<< EXECUTED")

--- a/test/mysql_handler/start
+++ b/test/mysql_handler/start
@@ -1,9 +1,10 @@
 #!/bin/bash -ex
 
 SECRETLESS_HOST=secretless
+devmode=false
 while getopts :d opt; do
     case $opt in
-        d) SECRETLESS_HOST=secretless-dev;;
+        d) SECRETLESS_HOST=secretless-dev; devmode=true;;
        \?) echo "Unknown option -$OPTARG"; exit 1;;
     esac
 done
@@ -18,9 +19,7 @@ cp -rf ../util/ssl ssl
 docker-compose build
 rm -rf ssl
 
-docker-compose up \
-  -d \
-  mysql mysql_no_tls
+docker-compose up -d mysql mysql_no_tls
 
 ./wait-for-mysql mysql_no_tls
 ./wait-for-mysql mysql
@@ -35,13 +34,16 @@ mkdir fixtures
 #
 ## secretless.yml
 docker-compose run --rm test \
-  bash -c "
-  go run ./test/util/test/cmd/generate_secretless_yml.go
-"
+  bash -c "go run ./test/util/test/cmd/generate_secretless_yml.go"
 
 # start secretless once mysql is running
-docker-compose up \
-  -d \
-  ${SECRETLESS_HOST}
+docker-compose up -d "$SECRETLESS_HOST"
 
-./wait-for-secretless ${SECRETLESS_HOST}
+./wait-for-secretless "$SECRETLESS_HOST"
+
+# In dev mode, start the test container and leave it running
+#
+if [[ "$devmode" = true ]]; then
+  echo 'Starting test container in dev mode...'
+  docker-compose up -d test
+fi

--- a/test/mysql_handler/test
+++ b/test/mysql_handler/test
@@ -38,7 +38,8 @@ if [[ ! -z $(docker-compose ps -q secretless-dev) ]]; then
   export SECRETLESS_HOST=secretless-dev
 
   # use exec because the container is already running
-  docker_compose_cmd="docker-compose exec"
+  #TODO uncomment below when i figure out why reflex is failing...
+  # docker_compose_cmd="docker-compose exec"
 fi
 
 ${docker_compose_cmd} \

--- a/test/mysql_handler/test
+++ b/test/mysql_handler/test
@@ -3,8 +3,15 @@
 help_and_exit() {
   local retval=${1:-1}
   cat <<EOF
+This script detects if you're in "dev" mode by the existence of
+the secretless-dev container.  That container will exist only if
+the development process was started using the "./dev" command.
+
+If in dev mode, all tests will be run against the "secretless-dev"
+container, which will not be torn down.  If not, they will be run
+in a fresh test container which will be torn down afterward.
+
 Options:
-  -d runs tests against secretless-dev container
   -v verbose mode; provides more verbose output for test cases
 EOF
   exit "$retval"
@@ -12,15 +19,28 @@ EOF
 
 export SECRETLESS_HOST=secretless
 export VERBOSE=false
-while getopts :dv opt; do
+docker_compose_cmd="docker-compose run --rm --no-deps"
+
+while getopts :v opt; do
     case $opt in
-        d) SECRETLESS_HOST=secretless-dev;;
         v) VERBOSE=true;;
        \?) echo "Unknown option -$OPTARG"; help_and_exit 1;;
     esac
 done
 
-docker-compose run \
-  --rm \
-  --no-deps \
-  test
+# Automatically detect if we're devmode based on the existence
+# of the secretless-dev container.  We assume that you started
+# your workflow using `./dev` if you are developing, and this
+# command will use the secretless-dev container.
+
+
+if [[ ! -z $(docker-compose ps -q secretless-dev) ]]; then
+  export SECRETLESS_HOST=secretless-dev
+
+  # use exec because the container is already running
+  docker_compose_cmd="docker-compose exec"
+fi
+
+${docker_compose_cmd} \
+  -e SECRETLESS_HOST="$SECRETLESS_HOST" \
+  test bash -c "go test -v ./test/mysql_handler/tests"

--- a/test/pg_handler/test
+++ b/test/pg_handler/test
@@ -23,7 +23,7 @@ export VERBOSE=false
 benchmark=false
 docker_compose_cmd="docker-compose run --rm --no-deps"
 
-while getopts :bdv opt; do
+while getopts :bv opt; do
     case $opt in
         b) benchmark=true;;
         v) VERBOSE=true;;
@@ -51,9 +51,9 @@ if $benchmark; then
   pg_cid=$(docker-compose ps -q pg)
   secretless_cid=$(docker-compose ps -q $SECRETLESS_HOST)
   pg_ip=$(docker inspect \
-    -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $pg_cid)
+    -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$pg_cid")
   secretless_ip=$(docker inspect \
-    -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $secretless_cid)
+    -f "{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}" "$secretless_cid")
 
   export PG_ADDRESS=$pg_ip:5432
   export SECRETLESS_ADDRESS=$secretless_ip:5432
@@ -66,19 +66,18 @@ if $benchmark; then
   echo "working with $SECRETLESS_HOST"
 
   docker-compose run --rm --no-deps \
-    test bash -c '
-      echo "--- QUERYING POSTGRES DIRECTLY ---" && \
+    test bash -c "
+      echo '--- QUERYING POSTGRES DIRECTLY ---' && \
       BENCH_ADDRESS=$PG_ADDRESS go test -v -bench=. -test.benchtime=10s ./test/pg_handler/bench_test.go | tee bench.old && \
 
-      echo "--- QUERYING VIA SECRETLESS ---" && \
+      echo '--- QUERYING VIA SECRETLESS ---' && \
       BENCH_ADDRESS=$SECRETLESS_ADDRESS go test -v -bench=. -test.benchtime=10s ./test/pg_handler/bench_test.go | tee bench.new && \
 
-      echo "--- COMPARING BENCHMARKS ---" && \
+      echo '--- COMPARING BENCHMARKS ---' && \
       benchcmp bench.old bench.new
-    '
+    "
 else
   ${docker_compose_cmd} \
     -e SECRETLESS_HOST="$SECRETLESS_HOST" \
     test bash -c "go test -v ./test/pg_handler/tests"
 fi
-


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
#### What ticket does this PR close?
Connected to #613
Connected to #614

TODO: Add comments to `/internal/app/secretless/handlers/mysql/protocol/protocol_test.go` of how expected values were generated

#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)