### PR TITLE
Updating website build to gen godocs in go img

### DIFF
--- a/bin/Dockerfile.website
+++ b/bin/Dockerfile.website
@@ -1,7 +1,6 @@
 FROM ruby:2.5-alpine
 
-RUN apk add --update alpine-sdk \
-                     go-tools && \
+RUN apk add --update alpine-sdk && \
     mkdir -p /tmp/gems
 
 WORKDIR /tmp/gems

--- a/bin/build_website
+++ b/bin/build_website
@@ -54,7 +54,7 @@ godoc_package: ${package}
   docker run --rm \
              -t \
              -v "${TOPLEVEL_DIR}:/go/src/${REPOSITORY}" \
-             "${IMAGE_NAME}" godoc -html \
+             golang:1.11.4-stretch godoc -html \
                                    -links=false \
                                    "/go/src/${REPOSITORY}/${package}" | sed 1,19d >> "${output_file}"
 


### PR DESCRIPTION
Previously we were trying to install go-tools to be able to run the godoc
command in the website Docker image, but this was broken when godoc was merged
into the main go binary. To address this, we no longer install go-tools in the
ruby image, but instead build the godocs using the same go image we use for
the project build.