### PR TITLE
103 note styling

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -33,10 +33,8 @@ footer-resources:
     url: /docs/get_started/kubernetes_tutorial.html
   - title: Community
     url: /community.html
-    target: target="_blank" rel="noopener noreferrer"
   - title: Blog
     url: /blog.html
-    target: target="_blank" rel="noopener noreferrer"
   - title: FAQ
     url: https://docs.secretless.io/Latest/en/Content/FAQ/faq.htm
     target: target="_blank" rel="noopener noreferrer"

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -3,6 +3,8 @@ main:
     url: https://docs.secretless.io
     target: target="_blank" rel="noopener noreferrer"
     section: /docs/
+  - title: Tutorial
+    url: /docs/get_started/kubernetes_tutorial.html
   - title: Community
     url: /community.html
   - title: Blog
@@ -29,7 +31,6 @@ footer-docs:
 footer-resources:
   - title: Tutorial
     url: /docs/get_started/kubernetes_tutorial.html
-    target: target="_blank" rel="noopener noreferrer"
   - title: Community
     url: /community.html
     target: target="_blank" rel="noopener noreferrer"

--- a/docs/_sass/_defaults.scss
+++ b/docs/_sass/_defaults.scss
@@ -105,12 +105,14 @@ h4 {
 
 .note {
   &:before {
-    content: 'Note: ';
+	content: 'Note: ';
+	font-weight: 800;
   }
   background: #F3FCFD;
   border-left: 40px solid #269D91;
-  margin-bottom: 10px;
-  padding: 10px;
+  border-radius: 0.3rem;
+  margin: 3rem 0;
+  padding: 1.5rem 2rem;
 }
 .change-role {
   background: pink;

--- a/docs/_sass/_defaults.scss
+++ b/docs/_sass/_defaults.scss
@@ -108,29 +108,39 @@ h4 {
 	content: 'Note: ';
 	font-weight: 800;
   }
+
   background: #F3FCFD;
   border-left: 40px solid #269D91;
   border-radius: 0.3rem;
   margin: 3rem 0;
   padding: 1.5rem 2rem;
 }
+
 .change-role {
-  background: pink;
-  border: 3px solid pink;
-  display: flex;
-  margin-bottom: 10px;
-  .character-icon { flex-grow: 1; }
+	background: pink;
+	border: 2px solid pink;
+	display: flex;
+	margin-bottom: 10px;
+	border-radius: 0.3rem;
+	padding: 1rem;
+  
+  .character-icon { 
+	  flex-grow: 1; 
+	  margin-right: 1rem;
+	}
+
   .content { 
     display: flex;
     flex-direction: column;
     flex-grow: 100;
-    justify-content: space-between;
-    padding: 0;
+	padding: 0;
+	
     .change-announcement {
-      font-size: 1.5rem;
+      font-size: 2rem;
       font-weight: bold;
-      padding: 15px;
-    }
+      padding: 1rem 1rem 0 1rem;
+	}
+	
     .message {
       padding: 15px;
     }
@@ -138,7 +148,5 @@ h4 {
 }
 
 .the-big-finish {
-  font-size: 18px;
-  text-align: center;
-  margin: 30px 0 30px 0;
+  margin: 3rem 0;
 }

--- a/docs/_sass/_defaults.scss
+++ b/docs/_sass/_defaults.scss
@@ -1,112 +1,125 @@
 // ***********************
 // Default values
 // ***********************
+
 html { 
-	font-size: 62.5%; 
-	font-family: $sless-font-primary;
-	color: $sless-text;
+  font-size: 62.5%; 
+  font-family: $sless-font-primary;
+  color: $sless-text;
 }
+
 body {
-	font-family: $sless-font-primary;
-	font-size: 1.5rem;
-	color: $sless-text;
-	display: flex;
-	flex-direction: column;
-	min-height: 100vh;
+  font-family: $sless-font-primary;
+  font-size: 1.5rem;
+  color: $sless-text;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
+
 p {
-	line-height: 1.8;
+  line-height: 1.8;
 }
+
 li {
-	font-size: 1.5rem;
-	line-height: 1.8;
+  font-size: 1.5rem;
+  line-height: 1.8;
 }
+
 code {
-	margin-left: 2.5rem;
-	color: #4d8fcc;
-	&.highlighter-rouge {
-		background-color: darken($sless-light-blue, 02);
-		padding: .2rem .4rem;
-		border-radius: .2rem;
-	}
+  margin-left: 2.5rem;
+  color: #4d8fcc;
+
+  &.highlighter-rouge {
+    background-color: darken($sless-light-blue, 02);
+    padding: .2rem .4rem;
+    border-radius: .2rem;
+  }
 }
+
 a {
-	text-decoration: none;
-	display: inline-block;
-	color: $sless-blue;
+  text-decoration: none;
+  display: inline-block;
+  color: $sless-blue;
 }
+
 hr {
-	position: relative;
+  position: relative;
 }
+
 button:focus {
-	outline: 0;
+  outline: 0;
 }
+
 pre {
-	background-color: white;
-	&.highlight {
-		padding: 2rem;
-	}
+  background-color: white;
+  
+  &.highlight {
+    padding: 2rem;
+  }
 }
+
 code {
-	margin: 0;
+  margin: 0;
 }
 
 .highlighter-rouge .highlight {
-	border-radius: $border-radius;
-	margin: 1rem 0;
-	background-color: $sless-dark-blue;
+  border-radius: $border-radius;
+  margin: 1rem 0;
+  background-color: $sless-dark-blue;
 }
+
 .page-title {
-	font-size: 4rem;
-	color: $sless-blue;
-	font-weight: 800;
-	margin-bottom: 3rem;
+  font-size: 4rem;
+  color: $sless-blue;
+  font-weight: 800;
+  margin-bottom: 3rem;
 }
 
 h1 {
-	color: $sless-blue;
-	margin-top: 0;
-	margin-bottom: 2rem;
-	font-weight: 800;
-	font-size: 4.5rem;
-	font-family: $sless-font-secondary;
+  color: $sless-blue;
+  margin-top: 0;
+  margin-bottom: 2rem;
+  font-weight: 800;
+  font-size: 4.5rem;
+  font-family: $sless-font-secondary;
 }
 
 h2 {
-	color: $sless-blue;
-	font-size: 3rem;
-	margin: 2rem 0 1rem 0;
-	font-family: $sless-font-secondary;
+  color: $sless-blue;
+  font-size: 3rem;
+  margin: 2rem 0 1rem 0;
+  font-family: $sless-font-secondary;
 }
 
 h3 {
-	color: $sless-blue;
-	font-size: 2rem;
-	margin: 2rem 0 2rem 0;
-	font-family: $sless-font-secondary;
+  color: $sless-blue;
+  font-size: 2rem;
+  margin: 2rem 0 2rem 0;
+  font-family: $sless-font-secondary;
 }
 
 h4 {
-	text-transform: uppercase;
-	color: $sless-text;
-	font-family: $sless-font-secondary;
-	font-weight: bold;
-	margin: 2rem 0 2rem 0;
+  text-transform: uppercase;
+  color: $sless-text;
+  font-family: $sless-font-secondary;
+  font-weight: bold;
+  margin: 2rem 0 2rem 0;
 }
 
 .container {
-	flex: 1;
-	padding-bottom: 6rem;
+  flex: 1;
+  padding-bottom: 6rem;
 }
 
 .content {
-	padding-top: 3rem;
+  padding-top: 3rem;
 }
 
 .note {
   &:before {
-	content: 'Note: ';
-	font-weight: 800;
+  content: 'Note: ';
+  font-weight: 800;
   }
 
   background: #F3FCFD;
@@ -117,17 +130,17 @@ h4 {
 }
 
 .change-role {
-	background: pink;
-	border: 2px solid pink;
-	display: flex;
-	margin-bottom: 10px;
-	border-radius: 0.3rem;
-	padding: 1rem;
+  background: pink;
+  border: 2px solid pink;
+  display: flex;
+  margin-bottom: 10px;
+  border-radius: 0.3rem;
+  padding: 1rem;
   
   .character-icon { 
-	  flex-grow: 1; 
-	  margin-right: 1rem;
-	}
+    flex-grow: 1; 
+    margin-right: 1rem;
+  }
 
   .content { 
     display: flex;
@@ -139,7 +152,7 @@ h4 {
       font-size: 2rem;
       font-weight: bold;
       padding: 1rem 1rem 0 1rem;
-	}
+  }
 	
     .message {
       padding: 15px;

--- a/docs/_sass/_defaults.scss
+++ b/docs/_sass/_defaults.scss
@@ -2,8 +2,8 @@
 // Default values
 // ***********************
 
-html {
-  font-size: 62.5%;
+html { 
+  font-size: 62.5%; 
   font-family: $sless-font-primary;
   color: $sless-text;
 }
@@ -118,8 +118,8 @@ h4 {
 
 .note {
   &:before {
-	content: 'Note: ';
-	font-weight: 800;
+  content: 'Note: ';
+  font-weight: 800;
   }
 
   background: #F3FCFD;
@@ -136,23 +136,23 @@ h4 {
   margin-bottom: 10px;
   border-radius: 0.3rem;
   padding: 1rem;
-
-  .character-icon {
-    flex-grow: 1;
+  
+  .character-icon { 
+    flex-grow: 1; 
     margin-right: 1rem;
   }
 
-  .content {
+  .content { 
     display: flex;
     flex-direction: column;
     flex-grow: 100;
-	padding: 0;
+    padding: 0;
 
     .change-announcement {
       font-size: 2rem;
       font-weight: bold;
       padding: 1rem 1rem 0 1rem;
-	}
+  }
 
     .message {
       padding: 15px;

--- a/docs/_sass/_defaults.scss
+++ b/docs/_sass/_defaults.scss
@@ -133,7 +133,7 @@ h4 {
     display: flex;
     flex-direction: column;
     flex-grow: 100;
-	padding: 0;
+    padding: 0;
 	
     .change-announcement {
       font-size: 2rem;

--- a/docs/_sass/_defaults.scss
+++ b/docs/_sass/_defaults.scss
@@ -118,8 +118,8 @@ h4 {
 
 .note {
   &:before {
-  content: 'Note: ';
-  font-weight: 800;
+    content: 'Note: ';
+    font-weight: 800;
   }
 
   background: #F3FCFD;

--- a/docs/docs/get_started/kubernetes_tutorial.md
+++ b/docs/docs/get_started/kubernetes_tutorial.md
@@ -550,6 +550,7 @@ role "quick-start-backend-credentials-reader" created
 rolebinding "read-quick-start-backend-credentials" created
 </pre>
 
+
 ## Steps for the Application Developer
 
 <div class="change-role">


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Adds some light css styling to .note & .change-role callouts

#### What ticket does this PR close?
Connected to https://github.com/cyberark/secretless-docs/issues/103

#### Where should the reviewer start?
1. Run the site locally, and go to: /docs/get_started/kubernetes_tutorial.html
2. Check that **note** and **change-role** styling is updated

#### What is the status of the manual tests?
n/a
Have you run the following manual tests to verify existing functionality continues to function as expected? no
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes: No. Only minimal style changes.
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
n/a
#### Links to open issues for related documentation (in READMEs, docs, etc)
n/a
#### Screenshots (if appropriate)
<img width="775" alt="Screen Shot 2019-03-11 at 10 01 34 AM" src="https://user-images.githubusercontent.com/123787/54138519-049e2680-43f6-11e9-85d3-1e198ddf571a.png">
<img width="768" alt="Screen Shot 2019-03-11 at 10 01 42 AM" src="https://user-images.githubusercontent.com/123787/54138526-07991700-43f6-11e9-9bef-d7bd02d71455.png">

