### PR TITLE
fixing broken link in footer

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -14,7 +14,7 @@ main:
 
 footer-docs:
   - title: Why Secretless?
-    url: https://docs.secretless.io/Latest/en/Content/Overview/WhySecretless.htm
+    url: https://docs.secretless.io/Latest/en/Content/Overview/overview.htm#WhySecretless
     target: target="_blank" rel="noopener noreferrer"
   - title: Key Terms
     url: https://docs.secretless.io/Latest/en/Content/Overview/key_terms.htm


### PR DESCRIPTION
Linking to "Why Secretless"

#### What does this PR do (include background context, if relevant)?
Fixes a broken link to _Why Secretless_ in the footer
#### What ticket does this PR close?
Connected to #655
#### Where should the reviewer start?
Run the site locally, and confirm that the _Why Secretless_ link in the footer links to:  https://docs.secretless.io/Latest/en/Content/Overview/overview.htm#WhySecretless
#### What is the status of the manual tests? n/a
Have you run the following manual tests to verify existing functionality continues to function as expected? n/a
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
n/a
#### Links to open issues for related documentation (in READMEs, docs, etc)
n/a
#### Screenshots (if appropriate)
<img width="1437" alt="why_secretless_footer_link" src="https://user-images.githubusercontent.com/123787/54382538-9613cf80-4666-11e9-8745-fbc5f4ac7c54.png">

