### PR TITLE
WIP: Add tutorial boilerplate code for secretless tutorial

### DIFF
--- a/docs/_layouts/tutorial.html
+++ b/docs/_layouts/tutorial.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en-us">
+
+  {% include head.html %}
+  <body>
+    <link rel="stylesheet" href="/css/tutorial.css">
+
+  <!-- Google Tag Manager (noscript) -->
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5DGS7TG"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <!-- End Google Tag Manager (noscript) -->
+
+    {% include top_nav.html %}
+
+    <div class="container">
+      <div class="row">
+        <div class="col-md-12">
+          <h1 class="page-title" >{{ page.title }}</h1>
+          <div class="wrapper">
+            <div class="back item">
+              <p class="item-title">Overview</p>
+              <p>Applications and application developers should be **incapable of leaking secrets**.</p>
+
+              <p>To achieve that goal, you'll play two roles in this tutorial:</p>
+              <ol>
+                <li>A **Security Admin** who handles secrets, and has sole access to those secrets</li>
+                <li>An **Application Developer** with no access to secrets.</li>
+              </ol>
+              <p>The situation looks like this:</p>
+
+              ![Image](/img/secretless_overview.jpg)
+
+              <p>Specifically, we will:</p>
+
+              <p>**As the security admin:**</p>
+              <ol>
+              <li>Create a PostgreSQL database</li>
+              <li>Create a DB user for the application</li>
+              <li>Add that user's credentials to Kubernetes Secrets</li>
+              <li>Configure Secretless to connect to PostgreSQL using those credentials</li>
+              </ol>
+              <p>**As the application developer:**</p>
+              <ol>
+                <li>Configure the application to connect to PostgreSQL via Secretless</li>
+                <li>Deploy the application and the Secretless sidecar</li>
+              </ol>
+              <p class="item-title">Prerequisites</p>
+
+              <p>To run through this tutorial, you will need:</p>
+
+              <ul>
+                <li>A running Kubernetes cluster (you can use
+                [minikube](https://kubernetes.io/docs/tasks/tools/install-minikube/) to run a
+                cluster locally)</li>
+                <li>[kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) configured
+                to point to the cluster</li>
+                <li>[Docker CLI](https://docs.docker.com/install/)
+              </ul>
+            </div>
+
+            <div class="front item">
+              <p class="item-title">This is a detailed, step-by-step tutorial.</p>
+              <p>You will:</p>
+              <ol>
+                <li>Deploy a PostgreSQL database</li>
+                <li>Store its credentials in Kubernetes secrets</li>
+                <li>Setup Secretless Broker to proxy connections to it</li>
+                <li>Deploy an application that connects to the database **without knowing its password**</li>
+            </ol>
+              <p>Already a Kubernetes expert? You may prefer our:</p>
+
+              <div style="text-align: center">
+                <a href="https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo" class="button btn-primary gradient">Advanced Github Tutorial</a>
+              </div>
+
+              <p>complete with shell scripts to get **the whole thing working end to end fast**.</p>
+
+              <p class="item-title">Table of Contents</p>
+
+              <ul>
+                <li>[Overview](#overview)</li>
+                <li>Steps for Security Admin</li>
+                <ul>
+                  <li>[Create PostgreSQL Service in Kubernetes](#create-postgresql-service-in-kubernetes)</li>
+                  <li>[Create Application Database](#create-application-database)</li>
+                  <li>[Create Application Namespace and Store Credentials](#create-application-namespace-and-store-credentials)</li>
+                  <li>[Create Secretless Broker Configuration ConfigMap](#create-secretless-broker-configuration-configmap)</li>
+                  <li>[Create Application Service Account and Grant Entitlements](#create-application-service-account-and-grant-entitlements)</li>
+                </ul>
+                <li>Steps for Application Developer</li>
+                <ul>
+                  <li>[Sample Application Overview](#sample-application-overview)</li>
+                  <li>[Create Application Deployment Manifest](#create-application-deployment-manifest)</li>
+                  <li>[Deploy Application With Secretless Broker](#deploy-application-with-secretless-broker)</li>
+                  <li>[Expose Application Publicly](#expose-application-publicly)</li>
+                </ul>
+                <li>[Test the Application](#test-the-application)</li>
+                <li>[Appendix - Secretless Deployment Manifest Explained](#appendix---secretless-deployment-manifest-explained)</li>
+                <ul>
+                  <li>[Networking](#networking)</li>
+                  <li>[SSL](#ssl)</li>
+                  <li>[Credential Access](#credential-access)</li>
+                  <li>[Configuration Access](#configuration-access)</li>
+                </ul>
+              </ul>
+            </div>
+          </div>
+
+          <button id="bBtn">back</button>
+          <button id="fBtn">forward</button>
+        </div>
+      </div>
+    </div>
+    {% include cta-banner.html %}
+    {% include footer.html %}
+    <script src='/javascript/clipboard-buttons.js' type="text/javascript"></script>
+    <script src="/javascript/tutorial.js"></script>
+
+  </body>
+</html>

--- a/docs/css/tutorial.css
+++ b/docs/css/tutorial.css
@@ -1,0 +1,15 @@
+.wrapper {
+  position: relative;
+  min-height: 95rem;
+}
+
+.item {
+  position: absolute;
+  height: 90rem;
+  width: 100rem;
+  top: 0px;
+  left: 0px;
+  margin: 10px;
+  visibility: hidden;
+  background: white;
+}

--- a/docs/docs/tutorial.md
+++ b/docs/docs/tutorial.md
@@ -1,0 +1,45 @@
+---
+title: Using Secretless in Kubernetes
+id: overview
+layout: tutorial
+description: Secretless Broker Documentation
+permalink: /docs/tutorial_slides/intro.html
+---
+
+This is a detailed, step-by-step tutorial.
+
+You will:
+
+1. Deploy a PostgreSQL database
+2. Store its credentials in Kubernetes secrets
+3. Setup Secretless Broker to proxy connections to it
+4. Deploy an application that connects to the database **without knowing its password**
+
+Already a Kubernetes expert? You may prefer our:
+
+<div style="text-align: center">
+  <a href="https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo" class="button btn-primary gradient">Advanced Github Tutorial</a>
+</div>
+
+complete with shell scripts to get **the whole thing working end to end fast**.
+
+## Table of Contents
+
++ [Overview](#overview)
++ Steps for Security Admin
+  + [Create PostgreSQL Service in Kubernetes](#create-postgresql-service-in-kubernetes)
+  + [Create Application Database](#create-application-database)
+  + [Create Application Namespace and Store Credentials](#create-application-namespace-and-store-credentials)
+  + [Create Secretless Broker Configuration ConfigMap](#create-secretless-broker-configuration-configmap)
+  + [Create Application Service Account and Grant Entitlements](#create-application-service-account-and-grant-entitlements)
++ Steps for Application Developer
+  + [Sample Application Overview](#sample-application-overview)
+  + [Create Application Deployment Manifest](#create-application-deployment-manifest)
+  + [Deploy Application With Secretless Broker](#deploy-application-with-secretless-broker)
+  + [Expose Application Publicly](#expose-application-publicly)
++ [Test the Application](#test-the-application)
++ [Appendix - Secretless Deployment Manifest Explained](#appendix---secretless-deployment-manifest-explained)
+  + [Networking](#networking)
+  + [SSL](#ssl)
+  + [Credential Access](#credential-access)
+  + [Configuration Access](#configuration-access)

--- a/docs/javascript/tutorial.js
+++ b/docs/javascript/tutorial.js
@@ -1,0 +1,42 @@
+var items = document.querySelectorAll(".item")
+remainingItems = [].slice.call(items)
+
+var activeItems = []
+var fBtn = document.getElementById("fBtn")
+var bBtn = document.getElementById("bBtn")
+
+// update stack if user advances
+function stepForward() {
+  const nextItem = remainingItems.pop()
+  if (!nextItem) return
+  activeItems.push(nextItem)
+  // render update
+  renderItems()
+}
+
+// update stack if user regresses
+function stepBack() {
+  const previousItem = activeItems.pop()
+  if (!previousItem) return
+  remainingItems.push(previousItem)
+  if (activeItems.length < 1) return
+  renderItems()
+}
+
+function renderItems() {
+  let zIndex = 1
+  activeItems.forEach(item => {
+    item.style.visibility = 'visible'
+    item.style.zIndex = zIndex
+    zIndex += 1
+  })
+
+  remainingItems.forEach(item => {
+    item.style.visibility = 'hidden'
+  })
+}
+
+fBtn.addEventListener("click", stepForward)
+bBtn.addEventListener("click", stepBack)
+
+stepForward()


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
This PR adds the boilerplate code framework for the secretless tutorial so that users only see information that is relevant to the current step that they are on.

Complications:
- with stack implementation, there are lots of boilerplate code introduced in jekyll that cannot be separated or abstracted away by separate .md files. 
- makes additional addition of tiles and information more difficult at scale b/c cannot simply add tile info as .md
- difficult for viewing on mobile
- position absolute introduced by stack implementation makes styling a bit more difficult b/c each tile needs to be same length otherwise, it won't fit on page.
- hard to make it scalable for the reasons above
- Hashi uses multiple page implementation for their tutorials and it still looks sleek (https://learn.hashicorp.com/vault/getting-started/install) b/c of the way they load the page (with transitions)

At this moment, please ignore naming conventions and code messiness (:

#### What ticket does this PR close?
Connected to #666 

#### Where should the reviewer start?
Once pulled, navigate to http://localhost:4000/docs/tutorial_slides/intro.html

#### Screenshots (if appropriate)
Idea on smaller scale:
![image](https://user-images.githubusercontent.com/19418506/54930579-2fbd6580-4f20-11e9-916f-9525cb7bb664.png)

