### PR TITLE
fix quick start docs so any psql CLI works

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $ docker run \
 In a new window, if we try to connect to PostgreSQL directly via port 5432 (guessing at the `postgres` username), our attempt will fail:
 
 ```sh-session
-$ psql -h localhost -p 5432 -U postgres -d quickstart
+$ psql "host=localhost port=5432 user=postgres dbname=quickstart sslmode=disable"
 Password for user postgres:
 psql: FATAL:  password authentication failed for user "postgres"
 ```
@@ -113,11 +113,7 @@ psql: FATAL:  password authentication failed for user "postgres"
 But the Secretless Broker is listening on port 5454, and will add authentication credentials (both username and password) to our connection request and proxy our connection to the PostgreSQL server:
 
 ```sh-session
-$ psql \
-  -h localhost \
-  -p 5454 \
-  --set=sslmode=disable \
-  -d quickstart
+$ psql "host=localhost port=5454 user=postgres dbname=quickstart sslmode=disable"
 psql (10.3, server 9.6.9)
 Type "help" for help.
 

--- a/docs/_includes/quick_start.html
+++ b/docs/_includes/quick_start.html
@@ -21,11 +21,7 @@ cyberark/secretless-broker-quickstart</pre>
       username):</p>
       <pre>
 $ psql \
---host localhost \
---port 5432 \
---set=sslmode=disable \
---username secretless \
--d quickstart \
+"host=localhost port=5432 user=secretless dbname=quickstart sslmode=disable" \
 -c 'select * from counties;'
 
 Password for user secretless:
@@ -38,11 +34,7 @@ psql: FATAL:  password authentication failed for user "secretless"</pre>
       password.</i> Give it a try:</p>
       <pre>
 $ psql \
---host localhost \
---port 5454 \
---set=sslmode=disable \
---username secretless \
--d quickstart \
+"host=localhost port=5454 user=secretless dbname=quickstart sslmode=disable" \
 -c 'select * from counties;'
 
 id |    name


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?

Resolves https://github.com/cyberark/secretless-broker/issues/375
Resolves https://github.com/cyberark/secretless-docs/issues/95

#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
