### PR TITLE
update demos/quick-start/README.md to use universal psql command

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,18 @@
-image: docker:stable-git
+image: registry.gitlab.com/cyberark/secretless-broker/gitlab-dind:latest
+# 
+# This container image is used for running CI stages.
+# It contains all the common utilities; docker, git, docker-compose, openssl etc.
+# This image coupled with the docker:stable-dind service makes it possible to 
+# leverage the Gitlab runner's Docker daemon during CI stages.
+# 
+# This container image can be built by running the following:
+# 
+# echo "
+# FROM docker:stable-git
+# RUN apk add --no-cache bash openssl py-pip python-dev libffi-dev openssl-dev gcc libc-dev make
+# RUN pip install docker-compose
+# " | docker build -t registry.gitlab.com/cyberark/secretless-broker/gitlab-dind:latest -
+#
 
 variables:
   IMAGE_TAGS: |
@@ -14,7 +28,7 @@ stages:
 build:
   stage: build
   services:
-  - docker:stable-dind
+    - docker:stable-dind
   variables:
     DOCKER_DRIVER: overlay2
   script:
@@ -27,7 +41,7 @@ build:
 check_style:
   stage: test
   services:
-  - docker:stable-dind
+    - docker:stable-dind
   variables:
     DOCKER_DRIVER: overlay2
   script:
@@ -43,7 +57,7 @@ check_style:
 test_unit:
   stage: test
   services:
-  - docker:stable-dind
+    - docker:stable-dind
   variables:
     DOCKER_DRIVER: overlay2
   script:
@@ -59,7 +73,7 @@ test_unit:
 test_integration:
   stage: test
   services:
-  - docker:stable-dind
+    - docker:stable-dind
   variables:
     DOCKER_DRIVER: overlay2
   script:
@@ -75,7 +89,7 @@ test_integration:
 test_demo:
   stage: test
   services:
-  - docker:stable-dind
+    - docker:stable-dind
   variables:
     DOCKER_DRIVER: overlay2
   script:
@@ -88,7 +102,7 @@ test_demo:
 website:
   stage: website
   services:
-  - docker:stable-dind
+    - docker:stable-dind
   variables:
     DOCKER_DRIVER: overlay2
   script:
@@ -125,43 +139,39 @@ website:
   function setup_docker() {
     login_ci_registry
   }
-  
+
   function save_image() {
     tag=$(echo $1 | sed -e 's/\:/-/' -e 's/\//-/')
     docker tag $1 "$CI_APPLICATION_REPOSITORY:$CI_APPLICATION_TAG-$tag"
     docker push "$CI_APPLICATION_REPOSITORY:$CI_APPLICATION_TAG-$tag"
   }
-  
+
   function get_image() {
     tag=$(echo $1 | sed -e 's/\:/-/' -e 's/\//-/')
 
     docker pull "$CI_APPLICATION_REPOSITORY:$CI_APPLICATION_TAG-$tag"
     docker tag "$CI_APPLICATION_REPOSITORY:$CI_APPLICATION_TAG-$tag" $1
   }
-  
+
   function save_images() {
     echo "$ALL_TAGS" | while read -r line; do
-      save_image "$line"; 
+      save_image "$line";
     done
   }
-  
+
   function optional_get_images() {
     echo "$ALL_TAGS" | while read -r line; do
-      get_image "$line" 2> /dev/null || true; 
+      get_image "$line" 2> /dev/null || true;
     done
   }
-  
+
   function get_images() {
     echo "$ALL_TAGS" | while read -r line; do
-      get_image "$line"; 
+      get_image "$line";
     done
   }
 
   echo "loaded utils"
 
 before_script:
-  - apk add --no-cache bash
-  - apk add --no-cache openssl
-  - apk add --no-cache py-pip
-  - pip install docker-compose
   - *utils

--- a/demos/quick-start/README.md
+++ b/demos/quick-start/README.md
@@ -25,25 +25,29 @@ docker container run \
 2. Direct access to the PostgreSQL database is available over port `5432`. You
 can try querying some data, but you don't have the credentials required to
 connect:
+
+[//]: # "NOTE: The psql command below uses the universal Keyword/Value Connection Strings, see https://www.postgresql.org/docs/9.2/libpq-connect.html#LIBPQ-CONNSTRING. Do not change to flag-based connection options, they are not universal."
 ```
 psql \
-  --host localhost \
-  --port 5432 \
-  --set=sslmode=disable \
-  --username secretless \
-  -d quickstart \
+  "host=localhost
+  port=5432
+  sslmode=disable
+  user=secretless
+  dbname=quickstart" \
   -c 'select * from counties;'
 ```
 3. The good news is that you don't need any credentials! Instead, you can
 connect to the password-protected PostgreSQL database via the Secretless Broker
 on port `5454`, _without knowing the password_. Give it a try:
+
+[//]: # "NOTE: The psql command below uses the universal Keyword/Value Connection Strings, see https://www.postgresql.org/docs/9.2/libpq-connect.html#LIBPQ-CONNSTRING. Do not change to flag-based connection options, they are not universal."
 ```
 psql \
-  --host localhost \
-  --port 5454 \
-  --set=sslmode=disable \
-  --username secretless \
-  -d quickstart \
+  "host=localhost
+  port=5454
+  sslmode=disable
+  user=secretless
+  dbname=quickstart" \
   -c 'select * from counties;'
 ```
 

--- a/demos/quick-start/test/bin/entrypoint
+++ b/demos/quick-start/test/bin/entrypoint
@@ -24,11 +24,11 @@ apk add -U curl openssh expect &>/dev/null
 # Test postgres connection
 set +e
 psql \
-  --host quickstart \
-  --port 5454 \
-  --set=sslmode=disable \
-  --username secretless \
-  -d quickstart \
+  "host=quickstart
+  port=5454
+  sslmode=disable
+  user=secretless
+  dbname=quickstart" \
   -c 'select * from counties;'
 report_result "PostgreSQL"
 set -e


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?

+ update gitlab ci to use prebaked image
+ use universal psql command in quick-start README

#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
