### PR TITLE
fix:ssh: fail without exiting program when server config can not be resolved

### DIFF
--- a/internal/app/secretless/handlers/ssh/handler.go
+++ b/internal/app/secretless/handlers/ssh/handler.go
@@ -94,7 +94,8 @@ func (h *Handler) Run() {
 	var server ssh.Conn
 
 	if serverConfig, err = h.serverConfig(); err != nil {
-		log.Fatalf("ERROR: Could not resolve server config\n", err)
+		log.Printf("ERROR: Could not resolve server config\n", err)
+		return
 	}
 
 	// TODO: Ensure that we don't print credentials here before uncommenting


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Prevents the Secretless process being terminated when server configuration can not be resolved by SSH handler

Some context:
> Initially, I thought about that for a bit and concluded that it’s just a bug, precisely because I assumed that handlers should never panic. My assumption was grounded in the fact that handlers don’t explicitly panic anywhere nor do they use fatalf. This was the exception.
>
> With that reasoning there wouldn’t be a next time as long as we document clearly that handlers should never panic and that perhaps listeners is when panics might happen because of failed config validation.
>
> But now that I’m here thinking about the UX I wonder if  we might want the whole process to terminate if any given handler is unable to do it’s job (e.g. secret resolution fails). At the moment all handlers log the issue and some terminate the connection to the client (e.g. there’s a presumably unaddressed TODO for the ssh handler to terminate the client connection on errors). An argument can be made for not panicking as much as panicking.
>
> It’d be good to have a consistent error handling stategy

#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
