### PR TITLE
Mark HCV provider as alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,8 @@ Example:
 
 ### HashiCorp Vault Provider
 
+**Note: this provider is in an _alpha_ state due to its lack of support for [native Kubernetes auth](https://www.vaultproject.io/docs/auth/kubernetes.html).**
+
 Vault (`vault`) provider allows use of [HashiCorp Vault](https://www.vaultproject.io/) for fetching secrets.
 
 Example:


### PR DESCRIPTION
We currently only support authenticating with HCV using `VAULT_ADDR` and `VAULT_TOKEN`, but this isn't the [recommended way](https://www.vaultproject.io/docs/auth/kubernetes.html) to auth with HCV in K8s. Until we add support for recommended auth mechanisms this provider is listed as `alpha`.