### PR TITLE
734 Additional Performance Tests

### DIFF
--- a/bin/juxtaposer/Dockerfile
+++ b/bin/juxtaposer/Dockerfile
@@ -17,6 +17,6 @@ RUN go build -a -ldflags '-extldflags "-static"' -o juxtaposer ./main.go
 # =================== MAIN CONTAINER ===================
 FROM alpine:3.9
 
-ENTRYPOINT [ "/juxtaposer" ]
+ENTRYPOINT [ "/bin/juxtaposer" ]
 
-COPY --from=perftool-builder /perftool/juxtaposer /juxtaposer
+COPY --from=perftool-builder /perftool/juxtaposer /bin/juxtaposer

--- a/bin/juxtaposer/README.md
+++ b/bin/juxtaposer/README.md
@@ -15,6 +15,13 @@ alongside Secretless to compare the following scenarios:
 | MySQL         | Direct connection | Secretless (persistent connection) | TCP port        |
 | Postgres      | Direct connection | Secretless (persistent connection) | Unix socket     |
 | Postgres      | Direct connection | Secretless (persistent connection) | TCP port        |
+| MySQL         | Direct connection | Secretless (recreated connection)  | Unix socket     |
+| MySQL         | Direct connection | Secretless (recreated connection)  | TCP port        |
+| Postgres      | Direct connection | Secretless (recreated connection)  | Unix socket     |
+| Postgres      | Direct connection | Secretless (recreated connection)  | TCP port        |
+
+All scenarios can be run with limits as either minimum number of rounds completed or a
+time-limited duration.
 
 We compare the following results:
 
@@ -108,7 +115,13 @@ only `select` is supported.
 This setting decides how many loops the main test run will iterate over all
 the defined backends. This setting is ignored if time-based CLI flag is used.
 This field also supports a special keyword `infinity` that lets the tests run
-forever or until the user sends an interrupt signal.
+forever or until the user sends an interrupt signal. Note that this indicates
+only the _minimum_ amount of runs that all backends will be iterated over.
+
+1. (optional) `threads`, `int`, default: `1`
+This setting selects how many parallel routines (threads) will be used for each
+backend testing. Increasing this setting will mean that there will be a proportional
+load testing increase on the service per unit of time.
 
 1. (optional) `baselineMaxThresholdPercent`, `int`, default: `120`
 This setting decides how slow (percentage-wise) can a non-baseline backend be

--- a/bin/juxtaposer/README.md
+++ b/bin/juxtaposer/README.md
@@ -96,9 +96,9 @@ backends:
 This setting is linked to a named backend to indicate the baseline backend
 against which all calculation will be compared.
 
-1. (optional) `type`, `string`, default: `sql`
-This setting decides what type of comparison will be run. Only `sql` is
-currently supported.
+1. (optional) `type`, `string`, default: `sql/persistent`
+This setting decides what type of comparison will be run. Only the following
+are currently supported: `sql/persistent` and `sql/recreate`.
 
 1. (optional) `style`, `string`, default: `select`
 This setting decides what style (subtype) of comparison will be run. Currently

--- a/bin/juxtaposer/config/config.go
+++ b/bin/juxtaposer/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -34,27 +33,16 @@ type Backend struct {
 type Comparison struct {
 	BaselineBackend             string `yaml:"baselineBackend"`
 	BaselineMaxThresholdPercent int    `yaml:"baselineMaxThresholdPercent"`
+	RecreateConnections         bool   `yaml:"recreateConnections"`
 	Rounds                      string `yaml:"rounds"`
 	Silent                      bool   `yaml:"silent"`
-	Style                       string `yaml:"style"`
+	SqlStatementType            string `yaml:"sqlStatementType"`
 	Threads                     int    `yaml:"threads"`
-	Type                        string `yaml:"type"`
 }
 
 func (configuration *Config) verify() error {
-	if !strings.HasPrefix(configuration.Comparison.Type, "sql/") {
-		return fmt.Errorf("comparison type not supported: %s", configuration.Comparison.Type)
-	}
-
-	connectionType := configuration.Comparison.Type[4:]
-	if connectionType != "persistent" &&
-		connectionType != "recreate" {
-		return fmt.Errorf("comparison connection type not supported: %s",
-			connectionType)
-	}
-
-	if configuration.Comparison.Style != "select" {
-		return fmt.Errorf("comparison style supported: %s", configuration.Comparison.Style)
+	if configuration.Comparison.SqlStatementType != "select" {
+		return fmt.Errorf("comparison style supported: %s", configuration.Comparison.SqlStatementType)
 	}
 
 	if configuration.Comparison.Threads < 1 {
@@ -89,9 +77,9 @@ func NewConfiguration(configFile string) (*Config, error) {
 	configuration := Config{
 		Comparison: Comparison{
 			BaselineMaxThresholdPercent: 120,
+			RecreateConnections:         false,
 			Rounds:                      "1000",
-			Style:                       "select",
-			Type:                        "sql/persistent",
+			SqlStatementType:            "select",
 			Threads:                     1,
 		},
 		Formatters: map[string]formatter_api.FormatterOptions{

--- a/bin/juxtaposer/config/config.go
+++ b/bin/juxtaposer/config/config.go
@@ -37,6 +37,7 @@ type Comparison struct {
 	Rounds                      string `yaml:"rounds"`
 	Silent                      bool   `yaml:"silent"`
 	Style                       string `yaml:"style"`
+	Threads                     int    `yaml:"threads"`
 	Type                        string `yaml:"type"`
 }
 
@@ -54,6 +55,11 @@ func (configuration *Config) verify() error {
 
 	if configuration.Comparison.Style != "select" {
 		return fmt.Errorf("comparison style supported: %s", configuration.Comparison.Style)
+	}
+
+	if configuration.Comparison.Threads < 1 {
+		return fmt.Errorf("comparison.Threads must be >= 1. Current value: %d",
+			configuration.Comparison.Threads)
 	}
 
 	if len(configuration.Formatters) == 0 {
@@ -86,6 +92,7 @@ func NewConfiguration(configFile string) (*Config, error) {
 			Rounds:                      "1000",
 			Style:                       "select",
 			Type:                        "sql/persistent",
+			Threads:                     1,
 		},
 		Formatters: map[string]formatter_api.FormatterOptions{
 			"stdout": formatter_api.FormatterOptions{},

--- a/bin/juxtaposer/config/config.go
+++ b/bin/juxtaposer/config/config.go
@@ -1,0 +1,115 @@
+package config
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	formatter_api "github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/api"
+)
+
+// Config is the main structure used to define the perfagent parameters
+type Config struct {
+	Backends   map[string]Backend                        `yaml:"backends"`
+	Comparison Comparison                                `yaml:"comparison"`
+	Driver     string                                    `yaml:"driver"`
+	Formatters map[string]formatter_api.FormatterOptions `yaml:"formatters"`
+}
+
+type Backend struct {
+	Database    string `yaml:"database"`
+	Debug       bool   `yaml:"debug"`
+	Description string `yaml:"description"`
+	Host        string `yaml:"host"`
+	Ignore      bool   `yaml:"ignore"`
+	Password    string `yaml:"password"`
+	Port        string `yaml:"port"`
+	SslMode     string `yaml:"sslmode"`
+	Socket      string `yaml:"socket"`
+	Username    string `yaml:"username"`
+}
+
+type Comparison struct {
+	BaselineBackend             string `yaml:"baselineBackend"`
+	BaselineMaxThresholdPercent int    `yaml:"baselineMaxThresholdPercent"`
+	Rounds                      string `yaml:"rounds"`
+	Silent                      bool   `yaml:"silent"`
+	Style                       string `yaml:"style"`
+	Type                        string `yaml:"type"`
+}
+
+func (configuration *Config) verify() error {
+	if !strings.HasPrefix(configuration.Comparison.Type, "sql/") {
+		return fmt.Errorf("comparison type not supported: %s", configuration.Comparison.Type)
+	}
+
+	connectionType := configuration.Comparison.Type[4:]
+	if connectionType != "persistent" &&
+		connectionType != "recreate" {
+		return fmt.Errorf("comparison connection type not supported: %s",
+			connectionType)
+	}
+
+	if configuration.Comparison.Style != "select" {
+		return fmt.Errorf("comparison style supported: %s", configuration.Comparison.Style)
+	}
+
+	if len(configuration.Formatters) == 0 {
+		return fmt.Errorf("no formatters defined")
+	}
+
+	baselineBackend := configuration.Comparison.BaselineBackend
+	if baselineBackend == "" {
+		return fmt.Errorf("comparison baselineBackend must be specified")
+	}
+
+	if _, ok := configuration.Backends[baselineBackend]; !ok {
+		return fmt.Errorf("comparison baseline backend '%s' not found",
+			baselineBackend)
+	}
+
+	return nil
+}
+
+func NewConfiguration(configFile string) (*Config, error) {
+	yamlFile, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	// Default options
+	configuration := Config{
+		Comparison: Comparison{
+			BaselineMaxThresholdPercent: 120,
+			Rounds:                      "1000",
+			Style:                       "select",
+			Type:                        "sql/persistent",
+		},
+		Formatters: map[string]formatter_api.FormatterOptions{
+			"stdout": formatter_api.FormatterOptions{},
+		},
+	}
+	err = yaml.Unmarshal(yamlFile, &configuration)
+	if err != nil {
+		return nil, err
+	}
+
+	// Slice out any backends which are ignored
+	filteredBackends := map[string]Backend{}
+	for backendName, backendConfig := range configuration.Backends {
+		if backendConfig.Ignore == false {
+			filteredBackends[backendName] = backendConfig
+		}
+	}
+
+	configuration.Backends = filteredBackends
+
+	err = configuration.verify()
+	if err != nil {
+		return nil, err
+	}
+
+	return &configuration, nil
+}

--- a/bin/juxtaposer/deploy/juxtaposer_deployment_template.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_deployment_template.yml
@@ -42,8 +42,9 @@ spec:
         image: ${PERFTOOL_IMAGE}
         imagePullPolicy: Always
         # command: [ "/bin/sleep", "999d" ]
-        # args: ["-c", "-t", "${TEST_DURATION}", "-f", "/etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml"]
-        args: ["-c", "-f", "/etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml"]
+        args: ["-c", "-t", "${TEST_DURATION}", "-f", "/etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml"]
+        # command: ["sh", "-c", "juxtaposer -t ${TEST_DURATION} -f /etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml &> /tmp/output.txt && echo 'done' && ls -la /tmp/output.txt && sleep 999d"]
+        # args: ["-c", "-f", "/etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml"]
 
         volumeMounts:
           - mountPath: /etc/${APP_NAME}

--- a/bin/juxtaposer/deploy/juxtaposer_deployment_template.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_deployment_template.yml
@@ -42,7 +42,8 @@ spec:
         image: ${PERFTOOL_IMAGE}
         imagePullPolicy: Always
         # command: [ "/bin/sleep", "999d" ]
-        args: ["-c", "-t", "${TEST_DURATION}", "-f", "/etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml"]
+        # args: ["-c", "-t", "${TEST_DURATION}", "-f", "/etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml"]
+        args: ["-c", "-f", "/etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml"]
 
         volumeMounts:
           - mountPath: /etc/${APP_NAME}

--- a/bin/juxtaposer/deploy/juxtaposer_mysql.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_mysql.yml
@@ -3,12 +3,10 @@ driver: mysql-5.7
 
 comparison:
   baselineBackend: mysql_direct
-  #  type: sql/persistent
-  type: sql/recreate
-#  style: select
+#  recreateConnections: true
   rounds: 10000
-#  baselineMaxThresholdPercent: 120
-  silent: true
+  threads: 10
+  silent: false
 
 formatters:
   json:

--- a/bin/juxtaposer/deploy/juxtaposer_mysql.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_mysql.yml
@@ -3,7 +3,8 @@ driver: mysql-5.7
 
 comparison:
   baselineBackend: mysql_direct
-#  type: sql
+  #  type: sql/persistent
+  type: sql/recreate
 #  style: select
   rounds: 10000
 #  baselineMaxThresholdPercent: 120

--- a/bin/juxtaposer/deploy/juxtaposer_pg.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_pg.yml
@@ -3,12 +3,10 @@ driver: postgres
 
 comparison:
   baselineBackend: pg_direct
-  #  type: sql/persistent
-  type: sql/recreate
-#  style: select
+#  recreateConnections: true
   rounds: 10000
-#  baselineMaxThresholdPercent: 120
-  silent: true
+  silent: false
+  threads: 10
 
 formatters:
   json:

--- a/bin/juxtaposer/deploy/juxtaposer_pg.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_pg.yml
@@ -3,7 +3,8 @@ driver: postgres
 
 comparison:
   baselineBackend: pg_direct
-#  type: sql
+  #  type: sql/persistent
+  type: sql/recreate
 #  style: select
   rounds: 10000
 #  baselineMaxThresholdPercent: 120

--- a/bin/juxtaposer/formatter/api/formatter.go
+++ b/bin/juxtaposer/formatter/api/formatter.go
@@ -1,37 +1,12 @@
 package api
 
 import (
-	"time"
+	"github.com/cyberark/secretless-broker/bin/juxtaposer/timing"
 )
 
-type BackendTiming struct {
-	BaselineDivergencePercent map[int]int
-	Count                     int
-	Duration                  time.Duration
-	Errors                    []TestRunError `json:"errors"`
-	MaximumDuration           time.Duration
-	MinimumDuration           time.Duration
-}
-
 type OutputFormatter interface {
-	ProcessResults([]string, map[string]BackendTiming, int) error
-}
-
-type TestRunError struct {
-	Error error `json:"error"`
-	Round int   `json:"round"`
+	ProcessResults([]string, map[string]timing.BackendTiming, int) error
 }
 
 type FormatterOptions map[string]string
 type FormatterConstructor func(FormatterOptions) (OutputFormatter, error)
-
-func NewBackendTiming() BackendTiming {
-	return BackendTiming{
-		BaselineDivergencePercent: map[int]int{},
-		Count:                     0,
-		Duration:                  0 * time.Second,
-		MinimumDuration:           0 * time.Second,
-		MaximumDuration:           0 * time.Second,
-		Errors:                    []TestRunError{},
-	}
-}

--- a/bin/juxtaposer/formatter/json/json.go
+++ b/bin/juxtaposer/formatter/json/json.go
@@ -9,6 +9,7 @@ import (
 
 	formatter_api "github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/api"
 	"github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/util"
+	"github.com/cyberark/secretless-broker/bin/juxtaposer/timing"
 )
 
 type JsonFormatter struct {
@@ -22,17 +23,17 @@ type ConfidenceIntervalJson struct {
 }
 
 type BackendTimingDataJson struct {
-	AverageDurationNs        int64                        `json:"averageDurationNs"`
-	ConfidenceInterval       ConfidenceIntervalJson       `json:"confidenceInterval"`
-	Errors                   []formatter_api.TestRunError `json:"errors"`
-	FailedRounds             int                          `json:"failedRounds"`
-	MaximumDurationNs        int64                        `json:"maximumDurationNs"`
-	MinimumDurationNs        int64                        `json:"minimumDurationNs"`
-	SuccessfulRounds         int                          `json:"successfulRounds"`
-	SuccessPercentage        float64                      `json:"successPercentage"`
-	ThresholdBreachedPercent float64                      `json:"thresholdBreachedPercent"`
-	TotalDurationNs          int64                        `json:"totalDurationNs"`
-	TotalRounds              int                          `json:"totalRounds"`
+	AverageDurationNs        int64                  `json:"averageDurationNs"`
+	ConfidenceInterval       ConfidenceIntervalJson `json:"confidenceInterval"`
+	Errors                   []timing.TestRunError  `json:"errors"`
+	FailedRounds             int                    `json:"failedRounds"`
+	MaximumDurationNs        int64                  `json:"maximumDurationNs"`
+	MinimumDurationNs        int64                  `json:"minimumDurationNs"`
+	SuccessfulRounds         int                    `json:"successfulRounds"`
+	SuccessPercentage        float64                `json:"successPercentage"`
+	ThresholdBreachedPercent float64                `json:"thresholdBreachedPercent"`
+	TotalDurationNs          int64                  `json:"totalDurationNs"`
+	TotalRounds              int                    `json:"totalRounds"`
 }
 
 type JsonOutput struct {
@@ -46,7 +47,7 @@ func NewFormatter(options formatter_api.FormatterOptions) (formatter_api.OutputF
 }
 
 func (formatter *JsonFormatter) ProcessResults(backendNames []string,
-	aggregatedTimings map[string]formatter_api.BackendTiming, baselineThresholdMaxPercent int) error {
+	aggregatedTimings map[string]timing.BackendTiming, baselineThresholdMaxPercent int) error {
 
 	jsonOutput := JsonOutput{
 		Backends: map[string]BackendTimingDataJson{},

--- a/bin/juxtaposer/formatter/stdout/stdout.go
+++ b/bin/juxtaposer/formatter/stdout/stdout.go
@@ -18,19 +18,19 @@ func NewFormatter(options formatter_api.FormatterOptions) (formatter_api.OutputF
 func (formatter *StdoutFormatter) ProcessResults(backendNames []string, aggregatedTimings map[string]timing.BackendTiming, baselineThresholdMaxPercent int) error {
 	fields := []map[string]string{
 		map[string]string{"name": "Name", "nameFormat": "%-30s", "valueFormat": "%-30s"},
-		map[string]string{"name": "Min", "nameFormat": "%12s", "valueFormat": "%12v"},
-		map[string]string{"name": "Max", "nameFormat": "%12s", "valueFormat": "%12v"},
-		map[string]string{"name": "Avg", "nameFormat": "%12s", "valueFormat": "%12v"},
+		map[string]string{"name": "Min", "nameFormat": "%13s", "valueFormat": "%13v"},
+		map[string]string{"name": "Max", "nameFormat": "%13s", "valueFormat": "%13v"},
+		map[string]string{"name": "Avg", "nameFormat": "%13s", "valueFormat": "%13v"},
 		map[string]string{"name": "90% Lower %", "nameFormat": "%12s", "valueFormat": "%12.2f"},
 		map[string]string{"name": "90% Upper %", "nameFormat": "%12s", "valueFormat": "%12.2f"},
-		map[string]string{"name": "Total", "nameFormat": "%13s", "valueFormat": "%13v"},
-		map[string]string{"name": "Rounds", "nameFormat": "%7s", "valueFormat": "%7d"},
-		map[string]string{"name": "Errors", "nameFormat": "%7s", "valueFormat": "%7d"},
+		map[string]string{"name": "Total", "nameFormat": "%18s", "valueFormat": "%18v"},
+		map[string]string{"name": "Rounds", "nameFormat": "%9s", "valueFormat": "%9d"},
+		map[string]string{"name": "Errors", "nameFormat": "%9s", "valueFormat": "%9d"},
 		map[string]string{"name": "Succ %", "nameFormat": "%9s", "valueFormat": "%9.2f"},
 		map[string]string{"name": "Thresh %", "nameFormat": "%9s", "valueFormat": "%9.2f"},
 	}
 
-	dividerString := strings.Repeat("-", 146)
+	dividerString := strings.Repeat("-", 158)
 
 	fmt.Printf("%s\n", dividerString)
 	formatValueString := ""

--- a/bin/juxtaposer/formatter/stdout/stdout.go
+++ b/bin/juxtaposer/formatter/stdout/stdout.go
@@ -6,6 +6,7 @@ import (
 
 	formatter_api "github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/api"
 	"github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/util"
+	"github.com/cyberark/secretless-broker/bin/juxtaposer/timing"
 )
 
 type StdoutFormatter struct{}
@@ -14,7 +15,7 @@ func NewFormatter(options formatter_api.FormatterOptions) (formatter_api.OutputF
 	return &StdoutFormatter{}, nil
 }
 
-func (formatter *StdoutFormatter) ProcessResults(backendNames []string, aggregatedTimings map[string]formatter_api.BackendTiming, baselineThresholdMaxPercent int) error {
+func (formatter *StdoutFormatter) ProcessResults(backendNames []string, aggregatedTimings map[string]timing.BackendTiming, baselineThresholdMaxPercent int) error {
 	fields := []map[string]string{
 		map[string]string{"name": "Name", "nameFormat": "%-30s", "valueFormat": "%-30s"},
 		map[string]string{"name": "Min", "nameFormat": "%12s", "valueFormat": "%12v"},

--- a/bin/juxtaposer/formatter/util/util.go
+++ b/bin/juxtaposer/formatter/util/util.go
@@ -4,15 +4,15 @@ import (
 	"math"
 	"time"
 
-	formatter_api "github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/api"
+	"github.com/cyberark/secretless-broker/bin/juxtaposer/timing"
 )
 
-func GetSuccessPercentage(timingInfo *formatter_api.BackendTiming) float64 {
+func GetSuccessPercentage(timingInfo *timing.BackendTiming) float64 {
 	successfulRounds := timingInfo.Count - len(timingInfo.Errors)
 	return (float64(successfulRounds) / float64(timingInfo.Count)) * 100
 }
 
-func GetAverageDuration(timingInfo *formatter_api.BackendTiming) time.Duration {
+func GetAverageDuration(timingInfo *timing.BackendTiming) time.Duration {
 	averageDuration := 0 * time.Second
 	successfulRounds := timingInfo.Count - len(timingInfo.Errors)
 	if successfulRounds > 0 {
@@ -42,7 +42,7 @@ func GetMean(mappedCounts *map[int]int) float64 {
 		return 0.0
 	}
 
-	total := 0.0
+	var total float64
 	for valueAmount, occurrences := range *mappedCounts {
 		total += float64(valueAmount * occurrences)
 	}
@@ -56,7 +56,7 @@ func GetStandardDeviation(mappedCounts *map[int]int) float64 {
 	}
 
 	mean := GetMean(mappedCounts)
-	totalDeviation := 0.0
+	var totalDeviation float64
 	for valueAmount, occurrences := range *mappedCounts {
 		deviation := math.Pow(float64(valueAmount) - mean, 2)
 		totalDeviation += deviation * float64(occurrences)
@@ -76,10 +76,10 @@ func GetConfidenceInterval90(mappedCounts *map[int]int) (lowerBound float64, upp
 }
 
 func GetThresholdBreachedPercent(mappedCounts *map[int]int, thresholdPercent int) (percent float64) {
-	count := 0
+	var count int64
 	for valueAmount, occurrences := range *mappedCounts {
 		if valueAmount >= thresholdPercent {
-			count += occurrences
+			count += int64(occurrences)
 		}
 	}
 	return float64(count) / float64(getMappedDataPointCount(mappedCounts)) * 100.0

--- a/bin/juxtaposer/formatter/util/util_test.go
+++ b/bin/juxtaposer/formatter/util/util_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/api"
+	"github.com/cyberark/secretless-broker/bin/juxtaposer/timing"
 )
 
 func TestGetStandardDeviation(t *testing.T) {
@@ -68,24 +68,24 @@ func TestGetMean(t *testing.T) {
 func TestGetAverageDuration(t *testing.T) {
 
 	t.Run("empty input", func(t *testing.T) {
-		input := &api.BackendTiming{}
+		input := &timing.BackendTiming{}
 		res := GetAverageDuration(input)
 
 		assert.Equal(t, res, time.Duration(0))
 	})
 
 	t.Run("nil input", func(t *testing.T) {
-		input := &api.BackendTiming{}
+		input := &timing.BackendTiming{}
 		res := GetAverageDuration(input)
 
 		assert.Equal(t, res, time.Duration(0))
 	})
 
 	t.Run("valid input result is rounded down", func(t *testing.T) {
-		input := &api.BackendTiming{
+		input := &timing.BackendTiming{
 			Count:    20,
 			Duration: time.Duration(50),
-			Errors:   make([]api.TestRunError, 4),
+			Errors:   make([]timing.TestRunError, 4),
 		}
 		res := GetAverageDuration(input)
 

--- a/bin/juxtaposer/go.mod
+++ b/bin/juxtaposer/go.mod
@@ -5,5 +5,5 @@ go 1.12
 require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/lib/pq v1.1.1
-	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae // indirect
+	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
 )

--- a/bin/juxtaposer/go.mod
+++ b/bin/juxtaposer/go.mod
@@ -5,5 +5,6 @@ go 1.12
 require (
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/lib/pq v1.1.1
+	github.com/stretchr/testify v1.3.0
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
 )

--- a/bin/juxtaposer/go.sum
+++ b/bin/juxtaposer/go.sum
@@ -1,7 +1,14 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae h1:ehhBuCxzgQEGk38YjhFv/97fMIc2JGHZAhAWMmEjmu0=

--- a/bin/juxtaposer/go.sum
+++ b/bin/juxtaposer/go.sum
@@ -2,6 +2,7 @@ github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZp
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae h1:ehhBuCxzgQEGk38YjhFv/97fMIc2JGHZAhAWMmEjmu0=
 gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/bin/juxtaposer/juxtaposer.yml
+++ b/bin/juxtaposer/juxtaposer.yml
@@ -4,7 +4,7 @@ driver: postgres
 
 comparison:
   baselineBackend: pg_direct
-#  type: sql
+#  type: sql/persistent
 #  style: select
 #  rounds: 1000
 #  rounds: infinity

--- a/bin/juxtaposer/juxtaposer.yml
+++ b/bin/juxtaposer/juxtaposer.yml
@@ -9,6 +9,7 @@ comparison:
 #  rounds: 1000
 #  rounds: infinity
 #  baselineMaxThresholdPercent: 120
+#  threads: 1
   silent: true
 
 formatters:

--- a/bin/juxtaposer/juxtaposer.yml
+++ b/bin/juxtaposer/juxtaposer.yml
@@ -4,8 +4,9 @@ driver: postgres
 
 comparison:
   baselineBackend: pg_direct
-#  type: sql/persistent
-#  style: select
+#  baselineBackend: mysql_direct
+#  recreateConnections: true
+#  sqlStatementType: select
 #  rounds: 1000
 #  rounds: infinity
 #  baselineMaxThresholdPercent: 120

--- a/bin/juxtaposer/main.go
+++ b/bin/juxtaposer/main.go
@@ -50,6 +50,8 @@ func createBackendTesters(config *conf.Config,
 	backendInstances := map[string]tester_api.DriverManager{}
 
 	log.Println("Backends:", len(config.Backends))
+	log.Println("Threads:", config.Comparison.Threads)
+
 	for backendName, backendConfig := range config.Backends {
 		backendNames = append(backendNames, backendName)
 
@@ -170,11 +172,11 @@ func processAllResults(backendNames []string, config *conf.Config,
 func runMainTestingLoop(config *conf.Config, backendNames *[]string,
 	backendInstances map[string]tester_api.DriverManager,
 	baselineBackendName string,
-	rounds int,
+	maxRounds int,
 	shutdownChannel <-chan bool) (map[string]timing.BackendTiming, error) {
 
 	aggregateTimings := timing.NewAggregateTimings(backendNames, baselineBackendName,
-		config.Comparison.Silent)
+		config.Comparison.Threads, config.Comparison.Silent)
 
 	round := 0
 	shuttingDown := false
@@ -192,7 +194,7 @@ func runMainTestingLoop(config *conf.Config, backendNames *[]string,
 		}
 
 		round++
-		if rounds != -1 && round > rounds {
+		if maxRounds != -1 && round > maxRounds {
 			break
 		}
 
@@ -208,7 +210,7 @@ func runMainTestingLoop(config *conf.Config, backendNames *[]string,
 				BaselineTestDuration: baselineTestDuration,
 				BackendName:          backendName,
 				Duration:             singleTestRunDuration,
-				MaxRounds:            rounds,
+				MaxRounds:            maxRounds,
 				Round:                round,
 				TestError:            testErr,
 			})

--- a/bin/juxtaposer/main.go
+++ b/bin/juxtaposer/main.go
@@ -53,13 +53,10 @@ func createBackendTesters(config *conf.Config,
 
 		log.Printf("Setting up backend: %s", backendName)
 
-		// Sanity check
-		if !strings.HasPrefix(config.Comparison.Type, "sql/") {
-			return nil, nil, fmt.Errorf("ERROR: Comparison type not supported: %s", config.Comparison.Type)
+		connectionType := "persistent"
+		if config.Comparison.RecreateConnections {
+			connectionType = "recreate"
 		}
-
-		// TODO: Make this more robust
-		connectionType := config.Comparison.Type[4:]
 
 		options := tester_api.DbTesterOptions{
 			ConnectionType: connectionType,
@@ -81,7 +78,7 @@ func createBackendTesters(config *conf.Config,
 		}
 
 		backendTestManager, err := db.NewTestDriver(backendName, config.Driver,
-			config.Comparison.Style, options)
+			config.Comparison.SqlStatementType, options)
 
 		if backendConfig.Debug {
 			fmt.Printf("%s\n", strings.Repeat("^", 85))
@@ -301,7 +298,7 @@ func main() {
 	}
 
 	log.Println("Driver:", config.Driver)
-	log.Println("Comparison type:", config.Comparison.Type)
+	log.Println("Recreate connections:", config.Comparison.RecreateConnections)
 	log.Println("Backends:", len(config.Backends))
 	log.Println("Threads:", config.Comparison.Threads)
 	log.Println("Rounds:", config.Comparison.Rounds)

--- a/bin/juxtaposer/main.go
+++ b/bin/juxtaposer/main.go
@@ -204,7 +204,7 @@ func runMainTestingLoop(config *conf.Config, backendNames *[]string,
 				baselineTestDuration = singleTestRunDuration
 			}
 
-			aggregateTimings.UpdateTimingData(&timing.SingleRunTiming{
+			aggregateTimings.AddTimingData(&timing.SingleRunTiming{
 				BaselineTestDuration: baselineTestDuration,
 				BackendName:          backendName,
 				Duration:             singleTestRunDuration,
@@ -213,7 +213,10 @@ func runMainTestingLoop(config *conf.Config, backendNames *[]string,
 				TestError:            testErr,
 			})
 		}
+
 	}
+
+	aggregateTimings.Process()
 
 	return aggregateTimings.Timings, nil
 }

--- a/bin/juxtaposer/tester/api/db_tester.go
+++ b/bin/juxtaposer/tester/api/db_tester.go
@@ -1,14 +1,15 @@
 package api
 
 type DbTesterOptions struct {
-	DatabaseName string
-	Debug        bool
-	Host         string
-	Password     string
-	Port         string
-	SslMode      string
-	Socket       string
-	Username     string
+	ConnectionType string
+	DatabaseName   string
+	Debug          bool
+	Host           string
+	Password       string
+	Port           string
+	SslMode        string
+	Socket         string
+	Username       string
 }
 
 type DbTester interface {

--- a/bin/juxtaposer/tester/api/driver_manager.go
+++ b/bin/juxtaposer/tester/api/driver_manager.go
@@ -5,6 +5,7 @@ import (
 )
 
 type DriverManager interface {
+	GetName() string
 	RunSingleTest() (time.Duration, error)
 	RotatePassword(string) error
 	Shutdown() error

--- a/bin/juxtaposer/tester/db/db.go
+++ b/bin/juxtaposer/tester/db/db.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cyberark/secretless-broker/bin/juxtaposer/tester/api"
 	mysql "github.com/cyberark/secretless-broker/bin/juxtaposer/tester/db/mysql"
 	postgres "github.com/cyberark/secretless-broker/bin/juxtaposer/tester/db/postgres"
+	"github.com/cyberark/secretless-broker/bin/juxtaposer/timing"
 )
 
 type DriverManager struct {
@@ -21,8 +22,6 @@ var DbTesterImplementatons = map[string]func() (api.DbTester, error){
 	"mysql-5.7": mysql.NewTester,
 	"postgres":  postgres.NewTester,
 }
-
-const ZeroDuration = 0 * time.Second
 
 const DefaultDatabaseName = "mydb"
 const DefaultTableName = "mytable"
@@ -146,7 +145,7 @@ func (manager *DriverManager) RunSingleTest() (time.Duration, error) {
 	if manager.Options.ConnectionType == "recreate" {
 		err := manager.Tester.Connect(*manager.Options)
 		if err != nil {
-			return ZeroDuration, err
+			return timing.ZeroDuration, err
 		}
 		defer manager.Tester.Shutdown()
 	}
@@ -154,12 +153,12 @@ func (manager *DriverManager) RunSingleTest() (time.Duration, error) {
 	rows, err := manager.Tester.QueryRows("name", QueryTypes[manager.TestType])
 	if err != nil {
 		log.Printf("ERROR! Query failed!")
-		return ZeroDuration, err
+		return timing.ZeroDuration, err
 	}
 
 	err = ensureCorrectReturnedData(rows)
 	if err != nil {
-		return ZeroDuration, err
+		return timing.ZeroDuration, err
 	}
 
 	testDuration := time.Now().Sub(startTime)

--- a/bin/juxtaposer/tester/db/db.go
+++ b/bin/juxtaposer/tester/db/db.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
+	"strings"
 	"time"
 
 	"github.com/cyberark/secretless-broker/bin/juxtaposer/tester/api"
@@ -13,6 +14,7 @@ import (
 )
 
 type DriverManager struct {
+	Name     string
 	Options  *api.DbTesterOptions
 	Tester   api.DbTester
 	TestType string
@@ -140,6 +142,13 @@ func ensureCorrectReturnedData(rows []string) error {
 }
 
 func (manager *DriverManager) RunSingleTest() (time.Duration, error) {
+	if manager.Options.Debug {
+		fmt.Printf("%s %s %s\n",
+			strings.Repeat("v", 35),
+			manager.Name,
+			strings.Repeat("v", 35))
+	}
+
 	startTime := time.Now()
 
 	if manager.Options.ConnectionType == "recreate" {
@@ -165,9 +174,18 @@ func (manager *DriverManager) RunSingleTest() (time.Duration, error) {
 
 	if manager.Options.Debug {
 		log.Printf("DB query: OK")
+		fmt.Printf("%s\n", strings.Repeat("^", 85))
 	}
 
 	return testDuration, nil
+}
+
+func (manager *DriverManager) GetName() string {
+	return manager.Name
+}
+
+func (manager *DriverManager) DebugEnabled() bool {
+	return manager.Options.Debug
 }
 
 func (manager *DriverManager) RotatePassword(newPassword string) error {
@@ -178,7 +196,9 @@ func (manager *DriverManager) Shutdown() error {
 	return manager.Tester.Shutdown()
 }
 
-func NewTestDriver(driver string, testType string, options api.DbTesterOptions) (api.DriverManager, error) {
+func NewTestDriver(name string, driver string, testType string,
+	options api.DbTesterOptions) (api.DriverManager, error) {
+
 	if options.DatabaseName == "" {
 		options.DatabaseName = DefaultDatabaseName
 	}
@@ -189,6 +209,7 @@ func NewTestDriver(driver string, testType string, options api.DbTesterOptions) 
 	}
 
 	manager := DriverManager{
+		Name:     name,
 		Options:  &options,
 		TestType: testType,
 	}

--- a/bin/juxtaposer/tester/db/sql/sql.go
+++ b/bin/juxtaposer/tester/db/sql/sql.go
@@ -57,6 +57,13 @@ func (tester *SqlDatabaseTester) Shutdown() error {
 		log.Println("Shutting down database connection...")
 	}
 
-	tester.Database.Close()
-	return nil
+	if tester.Database == nil {
+		log.Println("WARN: Closing an already-closed connection!")
+		return nil
+	}
+
+	err := tester.Database.Close()
+	tester.Database = nil
+
+	return err
 }

--- a/bin/juxtaposer/timing/timing.go
+++ b/bin/juxtaposer/timing/timing.go
@@ -37,17 +37,20 @@ type AggregateTimings struct {
 	timingReceiverChan  chan *SingleRunTiming
 }
 
+const TimingBufferScalingFactor = 100
 const ZeroDuration = 0 * time.Second
 
 func NewAggregateTimings(backendNames *[]string, baselineBackendName string,
-	silent bool) AggregateTimings {
+	threads int, silent bool) AggregateTimings {
+
+	timingChannelbufferSize := threads * len(*backendNames) * TimingBufferScalingFactor
 
 	aggregateTimings := AggregateTimings{
 		BaselineBackendName: baselineBackendName,
 		Timings:             map[string]BackendTiming{},
 		Silent:              silent,
 		processingDoneChan:  make(chan bool),
-		timingReceiverChan:  make(chan *SingleRunTiming),
+		timingReceiverChan:  make(chan *SingleRunTiming, timingChannelbufferSize),
 	}
 
 	for _, backendName := range *backendNames {

--- a/bin/juxtaposer/timing/timing.go
+++ b/bin/juxtaposer/timing/timing.go
@@ -86,16 +86,11 @@ func (aggregateTimings *AggregateTimings) Process() {
 
 func (aggregateTimings *AggregateTimings) setupTimingReceiver() {
 	go func() {
-		for {
-			runTiming, more := <-aggregateTimings.timingReceiverChan
-			if !more {
-				log.Println("Timing channel closed. Exiting...")
-				aggregateTimings.processingDoneChan <- true
-				return
-			}
-
+		for runTiming := range aggregateTimings.timingReceiverChan {
 			aggregateTimings.updateBackendTiming(runTiming)
 		}
+
+		aggregateTimings.processingDoneChan <- true
 	}()
 }
 

--- a/bin/juxtaposer/timing/timing.go
+++ b/bin/juxtaposer/timing/timing.go
@@ -1,0 +1,110 @@
+package timing
+
+import (
+	"fmt"
+	"log"
+	"time"
+)
+
+type AggregateTimings struct {
+	BaselineBackendName string
+	Silent              bool
+	Timings             map[string]BackendTiming
+}
+
+type BackendTiming struct {
+	BaselineDivergencePercent map[int]int
+	Count                     int
+	Duration                  time.Duration
+	Errors                    []TestRunError `json:"errors"`
+	MaximumDuration           time.Duration
+	MinimumDuration           time.Duration
+}
+
+type TestRunError struct {
+	Error error `json:"error"`
+	Round int   `json:"round"`
+}
+
+type SingleRunTiming struct {
+	BaselineTestDuration time.Duration
+	BackendName          string
+	Duration             time.Duration
+	MaxRounds            int
+	Round                int
+	TestError            error
+}
+
+const ZeroDuration = 0 * time.Second
+
+func NewAggregateTimings(backendNames *[]string, baselineBackendName string,
+	silent bool) AggregateTimings {
+
+	aggregateTimings := AggregateTimings{
+		BaselineBackendName: baselineBackendName,
+		Timings:             map[string]BackendTiming{},
+		Silent:              silent,
+	}
+	for _, backendName := range *backendNames {
+		aggregateTimings.Timings[backendName] = BackendTiming{
+			BaselineDivergencePercent: map[int]int{},
+			Count:                     0,
+			Duration:                  ZeroDuration,
+			MinimumDuration:           ZeroDuration,
+			MaximumDuration:           ZeroDuration,
+			Errors:                    []TestRunError{},
+		}
+	}
+
+	return aggregateTimings
+}
+
+func (aggregateTimings *AggregateTimings) UpdateTimingData(runTiming *SingleRunTiming) {
+	backendTiming := aggregateTimings.Timings[runTiming.BackendName]
+	backendTiming.Count++
+
+	if runTiming.TestError != nil {
+		log.Printf("[%.3d/%s] %-35s=> %v", runTiming.Round, runTiming.MaxRounds,
+			runTiming.BackendName, runTiming.TestError)
+		backendTiming.Errors = append(backendTiming.Errors,
+			TestRunError{
+				Error: runTiming.TestError,
+				Round: runTiming.Round,
+			})
+		aggregateTimings.Timings[runTiming.BackendName] = backendTiming
+		return
+	}
+
+	backendTiming.Duration = backendTiming.Duration + runTiming.Duration
+
+	if backendTiming.MinimumDuration == ZeroDuration {
+		backendTiming.MinimumDuration = backendTiming.Duration
+	}
+
+	if runTiming.Duration > backendTiming.MaximumDuration {
+		backendTiming.MaximumDuration = runTiming.Duration
+	}
+
+	if runTiming.Duration < backendTiming.MinimumDuration {
+		backendTiming.MinimumDuration = runTiming.Duration
+	}
+
+	baselineDivergencePercent := 100
+	if runTiming.BackendName != aggregateTimings.BaselineBackendName {
+		baselineDivergencePercent = int(float32(runTiming.Duration) /
+			float32(runTiming.BaselineTestDuration) * 100.0)
+	}
+
+	if !aggregateTimings.Silent {
+		log.Printf("[%d/%s], %-35s=>%15v, %3d%%", runTiming.Round, runTiming.MaxRounds,
+			runTiming.BackendName, runTiming.Duration, baselineDivergencePercent)
+	} else {
+		if runTiming.BackendName == aggregateTimings.BaselineBackendName && runTiming.Round%1000 == 0 {
+			fmt.Printf(".")
+		}
+	}
+
+	backendTiming.BaselineDivergencePercent[baselineDivergencePercent]++
+
+	aggregateTimings.Timings[runTiming.BackendName] = backendTiming
+}


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?

This PR adds the following perf agent (juxtaposer) capabilities:
- Ability to test reopened connections
- Ability to test backends with user-set number of parallel threads

Additional features added/changed:
- Added ability to stream-process results asynchronously
- Added ability to stream-process test runs
- Cleaned up timing-related logic
- Made round-based limit be the minimum rounds for all backends (ensures proper comparison)

#### What ticket does this PR close?
Connected to #739 

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/734-additional-performance-tests/)

#### What is the status of the manual tests?
N/A - this _is_ the testing tool

