### PR TITLE
Upgrade Conjur authentication client dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/codegangsta/cli v1.20.0
 	github.com/containerd/continuity v0.0.0-20180712174259-0377f7d76720 // indirect
 	github.com/cyberark/conjur-api-go v0.5.1-0.20190103154352-bb43c2b86d76
-	github.com/cyberark/conjur-authn-k8s-client v0.12.0
+	github.com/cyberark/conjur-authn-k8s-client v0.13.0
 	github.com/cyberark/summon v0.0.0-20171226164112-07326408eaed
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20180707235734-242fa5aa1b45 // indirect
@@ -29,7 +29,6 @@ require (
 	github.com/duosecurity/duo_api_golang v0.0.0-20180315112207-d0530c80e49a // indirect
 	github.com/fatih/structs v1.0.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.7
-	github.com/fullsailor/pkcs7 v0.0.0-20180613152042-8306686428a5 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ozzo/ozzo-validation v0.0.0-20170913164239-85dcd8368eba
 	github.com/go-sql-driver/mysql v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/cyberark/conjur-api-go v0.5.1-0.20190103154352-bb43c2b86d76 h1:OIT4kC
 github.com/cyberark/conjur-api-go v0.5.1-0.20190103154352-bb43c2b86d76/go.mod h1:492M4gGHnfHHWtuewzmj+1fe0BiLzzsrsdGYcbP2lU8=
 github.com/cyberark/conjur-authn-k8s-client v0.12.0 h1:mwtVQzKjlax67HRnDxY4ogS5lvszV7VVonxPItxi+iQ=
 github.com/cyberark/conjur-authn-k8s-client v0.12.0/go.mod h1:hjpUeTkRMUCSR0EAEIko2RCp4+dncNeiIWHNJeLFuRg=
+github.com/cyberark/conjur-authn-k8s-client v0.13.0 h1:sKh0yS6lSHT34FnMRR738+Q0dP+ebC6N/h4Bm9rhq0A=
+github.com/cyberark/conjur-authn-k8s-client v0.13.0/go.mod h1:JTeGIeRO59J7mMEc5yF6FPtk1QnaAzs4GyZa4WldqZc=
 github.com/cyberark/summon v0.0.0-20171226164112-07326408eaed h1:0HPMF9Oa2FiN6inNtxlAL5iobtWygfhYlhv/T10RWFU=
 github.com/cyberark/summon v0.0.0-20171226164112-07326408eaed/go.mod h1:EDdy0BSD9OwcV/Rvz32HsX/QM44Zmi0P8tpdbQ6QwHY=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
@@ -160,6 +162,7 @@ github.com/sirupsen/logrus v1.0.6 h1:hcP1GmhGigz/O7h1WVUM5KklBp1JoNS9FggWKdj/j3s
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v0.0.0-20190306220146-200a235640ff/go.mod h1:KSQcGKpxUMHk3nbYzs/tIBAM2iDooCn0BmttHOJEbLs=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a h1:pa8hGb/2YqsZKovtsgrwcDH1RZhVbTKCjLp47XpqCDs=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/smartystreets/gunit v0.0.0-20180314194857-6f0d6275bdcd/go.mod h1:XUKj4gbqj2QvJk/OdLWzyZ3FYli0f+MdpngyryX0gcw=
@@ -171,6 +174,7 @@ golang.org/x/arch v0.0.0-20190312162104-788fe5ffcd8c h1:Rx/HTKi09myZ25t1SOlDHmHO
 golang.org/x/arch v0.0.0-20190312162104-788fe5ffcd8c/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20180416171110-a35a21de978d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181201002055-351d144fa1fc/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
Ticket status:

Steps to reproduce ongoing errors:
- Build Secretless by running `./bin/build`
- Build latest https://github.com/cyberark/conjur-authn-k8s-client by running `./bin/build`
- Run the deploy / demo scripts with `DEPLOY_MASTER_CLUSTER` and `LOCAL_AUTHENTICATOR` set to `true`
- Update the `app/domain/util/open_ssl/ca.rb:36` in `/opt/conjur/possum/` on the follower so that the life of the cert is `5.minutes` instead of `3.days` and `sv restart conjur/possum`

With the changes in this branch and described above:
- Secretless will authenticate once
- After 6 minutes will attempt to authenticate again
- Will see the [cert is expired](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/pkg/authenticator/authenticator.go#L184)
- Will [log in again](https://github.com/cyberark/conjur-authn-k8s-client/blob/master/pkg/authenticator/authenticator.go#L187)
- The login completes, as can be seen by a 200 response in the follower logs:
  ```
  2019-06-13T18:12:01.084+00:00 conjur-follower-7f6d75544-2zmtk nginx: 10.128.0.1 "POST /api/authn-k8s/madeup-id/inject_client_cert HTTP/1.1" 200 5 "-" "Go-http-client/1.1" 0.139 0.140
  ```
- Secretless hangs waiting for the Authenticate request to complete, as seen in the Secretless logs:
  ```
  2019/06/13 18:11:59 Info: Conjur provider is authenticating as host/conjur/authn-k8s/madeup-id/apps/geri-app-test/service_account/oc-test-app-secretless ...
  INFO: 2019/06/13 18:11:59 authenticator.go:163: Cert expires: 2019-06-13 18:10:59 +0000 UTC
  INFO: 2019/06/13 18:11:59 authenticator.go:164: Current date: 2019-06-13 18:11:59.957156855 +0000 UTC
  INFO: 2019/06/13 18:11:59 authenticator.go:165: Buffer time: 30s
  INFO: 2019/06/13 18:11:59 authenticator.go:185: Certificate expired. Re-logging in... 
  INFO: 2019/06/13 18:11:59 authenticator.go:107: Logging in as host/conjur/authn-k8s/madeup-id/apps/geri-app-test/service_account/oc-test-app-secretless. 
  INFO: 2019/06/13 18:11:59 requests.go:21: Login request to: https://conjur-follower.geri-conjur-test.svc.cluster.local/api/authn-k8s/madeup-id/inject_client_cert 
  ```  

#### What does this PR do (include background context, if relevant)?

#### What ticket does this PR close?
Connected to #743 

#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
