### PR TITLE
add unit test for juxtaposer

### DIFF
--- a/bin/juxtaposer/formatter/util/util.go
+++ b/bin/juxtaposer/formatter/util/util.go
@@ -25,6 +25,11 @@ func GetAverageDuration(timingInfo *formatter_api.BackendTiming) time.Duration {
 
 func getMappedDataPointCount(mappedCounts *map[int]int) int {
 	countOfDataPoints := 0
+
+	if mappedCounts == nil {
+		return 0
+	}
+
 	for _, mappedCount := range *mappedCounts {
 		countOfDataPoints += mappedCount
 	}
@@ -53,10 +58,10 @@ func GetStandardDeviation(mappedCounts *map[int]int) float64 {
 	mean := GetMean(mappedCounts)
 	totalDeviation := 0.0
 	for valueAmount, occurrences := range *mappedCounts {
-		deviation := (float64(valueAmount) - mean) * (float64(valueAmount) - mean)
+		deviation := math.Pow(float64(valueAmount) - mean, 2)
 		totalDeviation += deviation * float64(occurrences)
 	}
-	standardDeviation := math.Pow(totalDeviation/float64(getMappedDataPointCount(mappedCounts)), 0.5)
+	standardDeviation := math.Pow(totalDeviation/float64(getMappedDataPointCount(mappedCounts) - 1), 0.5)
 
 	return standardDeviation
 }

--- a/bin/juxtaposer/formatter/util/util_test.go
+++ b/bin/juxtaposer/formatter/util/util_test.go
@@ -1,10 +1,12 @@
 package util
 
 import (
-	"github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/api"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/api"
 )
 
 func TestGetStandardDeviation(t *testing.T) {
@@ -81,9 +83,9 @@ func TestGetAverageDuration(t *testing.T) {
 
 	t.Run("valid input result is rounded down", func(t *testing.T) {
 		input := &api.BackendTiming{
-			Count:                     20,
-			Duration:                  time.Duration(50),
-			Errors:                    make([]api.TestRunError, 4),
+			Count:    20,
+			Duration: time.Duration(50),
+			Errors:   make([]api.TestRunError, 4),
 		}
 		res := GetAverageDuration(input)
 

--- a/bin/juxtaposer/formatter/util/util_test.go
+++ b/bin/juxtaposer/formatter/util/util_test.go
@@ -1,0 +1,120 @@
+package util
+
+import (
+	"github.com/cyberark/secretless-broker/bin/juxtaposer/formatter/api"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestGetStandardDeviation(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		input := &map[int]int{}
+		res := GetStandardDeviation(input)
+
+		assert.Equal(t, res, 0.0)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		input := &map[int]int{}
+		res := GetStandardDeviation(input)
+
+		assert.Equal(t, res, 0.0)
+	})
+
+	t.Run("valid input", func(t *testing.T) {
+		input := &map[int]int{
+			1: 2,
+			2: 3,
+			3: 4,
+		}
+		res := GetStandardDeviation(input)
+
+		// ((1 - 2.22...)^2 * 2 + (2 - 2.22...)^2 * 3 + (3 - 2.22...)^2 * 4) / (2 + 3 + 4 - 1))^0.5 = 0.833...
+		assert.InDelta(t, res, 0.833, 0.01)
+	})
+}
+
+func TestGetMean(t *testing.T) {
+	t.Run("nil input", func(t *testing.T) {
+		input := &map[int]int{}
+		res := GetMean(input)
+
+		assert.Equal(t, res, 0.0)
+	})
+
+	t.Run("empty input", func(t *testing.T) {
+		input := &map[int]int{}
+		res := GetMean(input)
+
+		assert.Equal(t, res, 0.0)
+	})
+
+	t.Run("valid input", func(t *testing.T) {
+		input := &map[int]int{
+			1: 2,
+			2: 3,
+			3: 4,
+		}
+		res := GetMean(input)
+
+		// (1 * 2 + 2 * 3 + 3 * 4) / (2 + 3 + 4) = 2.22...
+		assert.InDelta(t, res, 2.22, 0.01)
+	})
+}
+
+func TestGetAverageDuration(t *testing.T) {
+
+	t.Run("empty input", func(t *testing.T) {
+		input := &api.BackendTiming{}
+		res := GetAverageDuration(input)
+
+		assert.Equal(t, res, time.Duration(0))
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		input := &api.BackendTiming{}
+		res := GetAverageDuration(input)
+
+		assert.Equal(t, res, time.Duration(0))
+	})
+
+	t.Run("valid input result is rounded down", func(t *testing.T) {
+		input := &api.BackendTiming{
+			Count:                     20,
+			Duration:                  time.Duration(50),
+			Errors:                    make([]api.TestRunError, 4),
+		}
+		res := GetAverageDuration(input)
+
+		// 50 / (20 - 4) = 3.125
+		assert.Equal(t, res, time.Duration(3))
+	})
+}
+
+func Test_getMappedDataPointCount(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		input := &map[int]int{}
+		res := getMappedDataPointCount(input)
+
+		assert.Equal(t, res, 0)
+	})
+
+	t.Run("nil input", func(t *testing.T) {
+		res := getMappedDataPointCount(nil)
+
+		assert.Equal(t, res, 0)
+	})
+
+	t.Run("valid input", func(t *testing.T) {
+		input := &map[int]int{
+			0: 1,
+			5: 2,
+			6: 3,
+		}
+		res := getMappedDataPointCount(input)
+
+		// 1 + 2 + 3 = 6
+		assert.Equal(t, res, 6)
+	})
+}


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [K8s CRDs](https://github.com/cyberark/secretless-broker/tree/master/test/manual/k8s_crds)
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
- [ ] Manually run the [full demo](https://github.com/cyberark/secretless-broker/tree/master/demos/full-demo) (optional)

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
