### PR TITLE
Added aggregation script to perf tester code

### DIFF
--- a/bin/juxtaposer/aggregate.py
+++ b/bin/juxtaposer/aggregate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+
+RUN_PATTERN = re.compile('.* \[\d+\/')
+TIME_PATTERN = re.compile("^([\d\.]*)(\w*)$")
+
+CHECKPOINTS = [1.10, 1.15, 1.20, 1.30, 1.50, 1.60, 1.70]
+BASELINE_SMOOTHING_POINTS = 50
+
+
+def process_log(logfile_path, baseline_backend):
+    percentages = {}
+    baselines = []
+    with open(logfile_path) as log_file:
+        for line in log_file:
+            if not RUN_PATTERN.match(line):
+                continue
+
+            line = line.strip()
+            fields = line.split()
+
+            backend = re.sub(r"/.*", "", fields[3])
+            time = fields[5].replace('s,', 's')
+            (numbers, scale) = TIME_PATTERN.search(time).groups()
+            time = float(numbers)
+            if scale == "ms":
+                time *= 1000
+            elif scale == "s":
+                time *= 1000000
+
+            if backend == baseline_backend:
+                baselines.append(time)
+                baselines = baselines[-BASELINE_SMOOTHING_POINTS:]
+            else:
+                if not backend in percentages:
+                    percentages[backend] = []
+
+                baseline_average = 0.0
+                if baselines:
+                    baseline_average = sum(baselines) / len(baselines)
+
+                    percentages[backend].append(time / baseline_average)
+
+    print("Baseline backend:", baseline_backend)
+    if not baselines:
+        raise RuntimeError("ERROR: Could not find any datapoints for '{}'!".format(baseline_backend))
+
+    for backend in percentages.keys():
+        datapoint_count = len(percentages[backend])
+        print("Backend:", backend)
+        print("Count:", datapoint_count)
+        percentages[backend].sort()
+
+        for checkpoint in CHECKPOINTS:
+            index_of_next = next(x[0] for x in enumerate(percentages[backend]) if x[1] >= checkpoint)
+
+            datapoints_below_checkpoint = float(index_of_next) / datapoint_count * 100
+            print("Below %3.0f%% of baseline: %3.2f%% of requests." % \
+                    (checkpoint * 100, datapoints_below_checkpoint))
+
+        print()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Program use to take aggregate Juxtaposer logs and produce sample bounds',
+    )
+
+    parser.add_argument('logfile', action='store', type=str)
+    parser.add_argument('baseline_name', action='store', type=str)
+
+    args = parser.parse_args()
+    process_log(args.logfile, args.baseline_name)


### PR DESCRIPTION
This code takes the raw verbose output from Juxtaposer and produces the
results that we want to use for our metrics. Eventually this code will
be retired after Juxtaposer natively supports this type of output data.

#### What ticket does this PR close?
N/A but
Connected to #759 

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
