### PR TITLE
Replace check_style linting with codeclimate golint engine

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,12 @@
 engines:
+  golint:
+    enabled: true
+    exclude_patterns:
+    - "**/"                # exclude all
+    - "!./cmd/"            # unexclude just the ones we want to lint
+    - "!./internal/"
+    - "!./pkg/"
+    - "!./test/"
   shellcheck:
     enabled: true
     checks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,8 @@ stage('Integration: PG Handler') {
 
 ### OSX Keychain provider Test
 
+**OSX Keychain provider**
+
 If you are on a Mac, you may also test the OSX Keychain provider:
 ```sh-session
 cd test/manual/keychain_provider/
@@ -179,6 +181,18 @@ cd test/manual/k8s_crds
 ./deploy
 ```
 This test currently does not run as part of the test suite.
+
+**Code Climate**
+
+We use Code Climate in our CI pipeline to perform linting and other style
+checks.  The specific engines we use and their configuration is in
+`.codeclimate.yml`.
+
+To run linting checks via the Code Climate golint engine, simply run:
+
+```sh-session
+./bin/check_style
+```
 
 ## Documentation
 Secretless has a few sources for documentation: a website, a documentation subdomain, and godocs.

--- a/bin/check_style
+++ b/bin/check_style
@@ -1,65 +1,14 @@
-#!/bin/bash -e
+#!/bin/bash
 
-PROJECT_ROOT="/secretless/"
-ROOT_DIR_LENGTH=${#PROJECT_ROOT}
-
-# accepts an input string of style errs and outputs XML
-# the style err string is a newline-delimited list of
-# style errors of the form "file:line:[0-9]*: error"
-# the output is checkstyle-format XML, with a list of
-# errors for each file
-output_xml() {
-  style_errs="${1}"
-
-  echo "<checkstyle>"
-  if [[ ! -z "$style_errs" ]]; then
-    current_file=""
-
-    # loop through each file with errors
-    while IFS= read -r err_line; do
-      # get the filename and line # of the error
-      file_and_line_length=$(echo "$err_line" | awk '{ print $1 }')
-      file_and_line=${err_line:0:${#file_and_line_length}-1}
-
-      IFS=":" read -r -a file_data <<< "$file_and_line"
-      file=${file_data[0]:$ROOT_DIR_LENGTH}
-      line=${file_data[1]}
-
-      # get the error
-      error=${err_line:${#file_and_line}+2}
-
-      # Because the error will appear in an XML _attribute_, we need to escape
-      # double quotes.  Time for a nice, juicy bash pattern substitution.
-      error=${error//\"/&quot;}
-
-      # output the file (if haven't already) and error
-      if [ "$current_file" != "$file" ]; then
-        if [[ ! -z "$current_file" ]]; then
-          echo "  </file>"
-        fi
-        echo "  <file name=\"$file\">"
-        current_file=$file
-      fi
-
-      echo "    <error line=\"$line\" severity=\"error\" message=\"$error\"></error>"
-    done <<< "$style_errs"
-
-    echo "  </file>"
-  fi
-  echo "</checkstyle>"
-}
-
-style_errs=$(docker run \
-  --rm \
-  secretless-dev \
-  bash -ec "
-    # https://github.com/golang/lint/issues/397
-    go get golang.org/x/lint@v0.0.0-20180702182130-06c8688daad
-    go get golang.org/x/lint/golint
-    golint ${PROJECT_ROOT}cmd/...
-    golint ${PROJECT_ROOT}internal/...
-    golint ${PROJECT_ROOT}pkg/...
-    golint ${PROJECT_ROOT}test/...
-  ")
-
-output_xml "$style_errs" 2>&1 | tee ./test/golint.xml
+# This runs golint using the same settings that will be used by hosted Code
+# Climate in our CI pipeline
+#
+# See:
+#     https://github.com/codeclimate/codeclimate#usage
+docker run \
+  --interactive --tty --rm \
+  --env CODECLIMATE_CODE="$PWD" \
+  --volume "$PWD":/code \
+  --volume /var/run/docker.sock:/var/run/docker.sock \
+  --volume /tmp/cc:/tmp/cc \
+  codeclimate/codeclimate analyze -e golint .codeclimate.yml

--- a/bin/check_style
+++ b/bin/check_style
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # This runs golint using the same settings that will be used by hosted Code
 # Climate in our CI pipeline
 #


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?



From the commit message:

    - Change bin/check_style script to call codeclimate via Docker
    - Remove check_style task from Jenkinsfile, since it will now be run by
    Code Climate
    - Turn on codeclimate golint engine and configure it to match the
    directories we were testing with check_style
    - Update CONTRIBUTING.md to document the new codeclimate use

I also created a test branch and PR to verify that Code Climate will in fact now fail on linting errors:

https://github.com/cyberark/secretless-broker/pull/783

This confirmed CC is failing linting errors as expected.

#### What is the status of the manual tests?

Not performed.