### PR TITLE
All relevant mkdir commands use portable -p instead  --parents

### DIFF
--- a/bin/test_unit
+++ b/bin/test_unit
@@ -6,7 +6,7 @@ current_dir=$("$(dirname "$0")"/abspath)
 toplevel_dir=$current_dir/..
 
 junit_output_dir=$toplevel_dir/test/unit-test-output
-mkdir --parents "$junit_output_dir"
+mkdir -p "$junit_output_dir"
 junit_output_file=$junit_output_dir/junit.output
 
 rm -f "$junit_output_file"

--- a/test/pg_handler/start
+++ b/test/pg_handler/start
@@ -23,7 +23,7 @@ docker-compose up -d pg pg_no_tls
 ./wait-for-pg pg
 
 # generate fixtures, parents option prevents error if existing
-mkdir --parents fixtures
+mkdir -p fixtures
 
 # NOTE: the tests depend on
 # + secretless.yml auto-generation (also depended on by the secretless container)


### PR DESCRIPTION
Hotfix to address linux portability issue with `mkdir --parents` discovered by @sgnn7:

https://conjurhq.slack.com/archives/CBTETAE20/p1564418130172200