### PR TITLE
661 unify pg and mysql configs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -268,29 +268,24 @@ replace `<GOOS>/<GOARCH>` with your particular operating system and compilation 
 1. Create a sample secretless.yml file in the project root that has:
 
    ```
-   listeners:
-     - name: pg_tcp
+   version: "2"
+   services:
+     pg_tcp:
        protocol: pg
-       address: 0.0.0.0:15432
-
-   handlers:
-     - name: pg_via_tcp
-       listener: pg_tcp
+       listenOn: tcp://0.0.0.0:15432
        credentials:
-         - name: address
-           provider: env
-           id: PG_ADDRESS
-         - name: username
-           provider: literal
-           id: test
-         - name: password
-           provider: env
-           id: PG_PASSWORD
+         host:
+           from: env
+           get: PG_HOST
+         username: test
+         password:
+           from: env
+           get: PG_PASSWORD
     ```
 
 1. The type of profiling is explicitly defined in the initial command that runs Secretless. Run Secretless with the profile desired like so:
    ```
-   $ PG_ADDRESS=localhost:5432/postgres \
+   $ PG_HOST=localhost \
        PG_PASSWORD=test \
        ./dist/<GOOS>/<GOARCH>/secretless-broker \
        -profile=<cpu or memory> \

--- a/README.md
+++ b/README.md
@@ -256,9 +256,9 @@ Example:
 ```
 ...
     credentials:
-      - name: accessToken
-        provider: conjur
-        id: path/to/the/token
+    accessToken:
+        from: conjur
+        get: path/to/the/token
 ...
 ```
 
@@ -272,9 +272,9 @@ Example:
 ```
 ...
     credentials:
-      - name: accessToken
-        provider: vault
-        id: path/to/the/token
+      accessToken:
+        from: vault
+        get: path/to/the/token
 ...
 ```
 
@@ -286,9 +286,9 @@ Example:
 ```
 ...
     credentials:
-      - name: accessToken
-        provider: kubernetes
-        id: secret_identifier#key
+      accessToken:
+        from: kubernetes
+        get: secret_identifier#key
 ...
 ```
 
@@ -301,9 +301,9 @@ Example:
 ```
 ...
     credentials:
-      - name: rsa
-        provider: file
-        id: /path/to/file
+      rsa:
+        from: file
+        get: /path/to/file
 ...
 ```
 
@@ -315,9 +315,9 @@ Example:
 ```
 ...
     credentials:
-      - name: accessToken
-        provider: env
-        id: ACCESS_TOKEN
+      accessToken:
+        from: env
+        get: ACCESS_TOKEN
 ...
 ```
 
@@ -332,9 +332,7 @@ Example:
 ```
 ...
     credentials:
-      - name: accessToken
-        provider: literal
-        id: supersecretaccesstoken
+      accessToken: "supersecretaccesstoken"
 ...
 ```
 
@@ -350,9 +348,9 @@ Example:
 ```
 ...
     credentials:
-      - name: rsa
-        provider: keychain
-        id: servicename#accountname
+      rsa:
+        from: keychain
+        get: servicename#accountname
 ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ services:
     protocol: pg
     listenOn: tcp://0.0.0.0:5432 # can be a socket as well (same name for both)
     credentials:
-      address: "postgres.my-service.internal:5432"
+      host: "postgres.my-service.internal"
       password:
         from: conjur
         get: id-of-secret-in-conjur
@@ -175,7 +175,7 @@ services:
       optionalStuff: foo
 ```
 
-In this sample, Secretless Broker is configured to connect to a service named `postgres-db`. Clients send connection requests to this service via localhost using port 5432. This service uses the `pg` protocol, which indicates that the PostgreSQL service connector should process requests that come in via this port. Credentials from this connection will be retrieved from multiple sources; the `address` is given as a string value, the `password` will be retrieved from the Conjur variable with ID `id-of-secret-in-conjur`, and the `username` is retrieved from the environment variable named `username`.
+In this sample, Secretless Broker is configured to connect to a service named `postgres-db`. Clients send connection requests to this service via localhost using the default port 5432. This service uses the `pg` protocol, which indicates that the PostgreSQL service connector should process requests that come in via this port. Credentials from this connection will be retrieved from multiple sources; the `host` is given as a literal string value, the `password` will be retrieved from the Conjur variable with ID `id-of-secret-in-conjur`, and the `username` is retrieved from the environment variable named `username`.
 
 ## Service Connectors
 
@@ -464,10 +464,10 @@ services:
     protocol: pg
     listenOn: tcp://0.0.0.0:4321
     credentials:
+      host: localhost
       username: postgres
       password: mysecretpassword
       sslmode: disable
-      address: localhost:5432
 ```
 and run Secretless:
 ```

--- a/bin/juxtaposer/README.md
+++ b/bin/juxtaposer/README.md
@@ -110,7 +110,8 @@ services:
     credentials:
       username: myuser
       password: mypassword
-      address: 127.0.0.1:5433
+      host: 127.0.0.1
+      port: 5433
       sslmode: disable
 ```
 

--- a/demos/quick-start/docker/Dockerfile
+++ b/demos/quick-start/docker/Dockerfile
@@ -35,6 +35,9 @@ RUN apk add --no-cache apache2-utils \
     && sed \
         -i 's/#PasswordAuthentication yes/PasswordAuthentication no/g' \
         /etc/ssh/sshd_config \
+    # Go DNS resolution doesn't read /etc/hosts by default. See
+    # for more info: https://github.com/golang/go/issues/22846
+    && echo "hosts: files dns" > /etc/nsswitch.conf \
     && chown postgres:postgres /var/lib/postgresql/server.key \
     && chown postgres:postgres /var/lib/postgresql/server.crt \
     && chmod 0600 /var/lib/postgresql/server.key

--- a/demos/quick-start/docker/etc/secretless.yml
+++ b/demos/quick-start/docker/etc/secretless.yml
@@ -2,9 +2,10 @@ version: "2"
 services:
   quick-start-postgres:
     protocol: pg
+    debug: true
     listenOn: tcp://0.0.0.0:5454
     credentials:
-      address: localhost:5432
+      host: localhost
       username:
         from: env
         get: QUICKSTART_USERNAME

--- a/design/simpler-configuration.md
+++ b/design/simpler-configuration.md
@@ -140,7 +140,7 @@ services:
     protocol: pg
     listenOn: tcp://0.0.0.0:5432 # can be a socket as well (same name for both)
     credentials:
-      address: postgres.my-service.internal:5432
+      host: postgres.my-service.internal
       password:
         from: vault
         get: id-of-secret-in-vault

--- a/design/tls-support-plan.md
+++ b/design/tls-support-plan.md
@@ -251,84 +251,61 @@ depend on your use case.
 
 #### Listening on a network address with default `sslmode` of `require`
 ``` yaml
-listeners:
-  - name: pg_listener
+version: "2"
+services:
+  pg_connector:
     protocol: pg
-    address: 0.0.0.0:5432
-
-handlers:
-  - name: pg_handler
-    listener: pg_listener
+    listenOn: tcp://0.0.0.0:5432
     credentials:
-      - name: address
-        provider: literal
-        id: postgres.my-service.internal:5432
-      - name: username
-        provider: literal
-        id: my-service
-      - name: password
-        provider: env
-        id: PG_PASSWORD
+      host: postgres.my-service.internal
+      username: myservice
+      password:
+        from: env
+        get: PG_PASSWORD
 ```
 ---
 #### Listening on a network address with verifiable CA, revocation list and private key-pair
 ``` yaml
-listeners:
-  - name: pg_listener
+version: "2"
+services:
+  pg_connector:
     protocol: pg
-    address: 0.0.0.0:5432
-
-handlers:
-  - name: pg_handler
-    listener: pg_listener
+    listenOn: tcp://0.0.0.0:5432
     credentials:
-      - name: address
-        provider: literal
-        id: postgres.my-service.internal:5432
-      - name: username
-        provider: literal
-        id: my-service
-      - name: password
-        provider: env
-        id: PG_PASSWORD
-      - name: sslmode
-        provider: literal
-        id: verify-full
+      host: postgres.my-service.internal
+      username: myservice
+      password:
+        from: env
+        get: PG_PASSWORD
+      sslmode: verify-full
       # NOTE: if your CA is stored in the environment
       # or a secret store, rather than a file, you can
       # use the appropriate provider
-      - name: sslrootcert
-        provider: file
-        id: /etc/pg/root.crt
-      - name: sslcert
-        provider: file
-        id: /etc/pg/client.crt
-      - name: sslkey
-        provider: file
-        id: /etc/pg/client.key
-      - name: sslcrl
-        provider: file
-        id: /etc/pg/root.crl
+      sslrootcert:
+        from: file
+        get: /etc/pg/root.crt
+      sslcert:
+        from: file
+        get: /etc/pg/client.crt
+      sslkey:
+        from: file
+        get: /etc/pg/client.key
+      sslcrl:
+        from: file
+        get: /etc/pg/root.crl
 ```
 ---
 #### Listening on a Unix-domain socket
 ``` yaml
-listeners:
-  - name: pg_listener
+version: "2"
+services:
+  pg_connector:
     protocol: pg
-    socket: /sock/.s.PGSQL.5432
-
-handlers:
-  - name: pg_handler
-    listener: pg_listener
+    listenOn: unix:///sock/.s.PGSQL.5432
     credentials:
-      - name: address
-        provider: literal
-        id: postgres.my-service.internal:5432
-      - name: username
-        provider: literal
-        id: my-service
-      - name: password
-        provider: env
-        id: PG_PASSWORD
+      host: postgres.my-service.internal
+      username: myservice
+      password:
+        from: env
+        get: PG_PASSWORD
 ```

--- a/internal/app/secretless/handlers/pg/handler.go
+++ b/internal/app/secretless/handlers/pg/handler.go
@@ -22,19 +22,19 @@ type ClientOptions struct {
 
 // BackendConfig stores the connection info to the real backend database.
 type BackendConfig struct {
-	Address  string
-	Username string
-	Password string
-	Database string
-	Options  map[string]string
-	QueryStrings  map[string]string
+	Host         string
+	Port         string
+	Username     string
+	Password     string
+	Options      map[string]string
+	QueryStrings map[string]string
 }
 
 // Handler connects a client to a backend. It uses the handler Config and Providers to
 // establish the connectionDetails, which is used to make the Backend connection. Then the data
 // is transferred bidirectionally between the Client and Backend.
 //
-// Handler requires "address", "username" and "password" credentials.
+// Handler requires "host", "port", "username" and "password" credentials.
 type Handler struct {
 	plugin_v1.BaseHandler
 	BackendConfig *BackendConfig

--- a/internal/app/secretless/listeners/pg/listener.go
+++ b/internal/app/secretless/listeners/pg/listener.go
@@ -29,8 +29,8 @@ func (hhc handlerHasCredentials) Validate(value interface{}) error {
 	hs := value.([]config_v1.Handler)
 	errors := validation.Errors{}
 	for i, h := range hs {
-		if !h.HasCredential("address") {
-			errors[strconv.Itoa(i)] = fmt.Errorf("must have credential 'address'")
+		if !h.HasCredential("host") {
+			errors[strconv.Itoa(i)] = fmt.Errorf("must have credential 'host'")
 		}
 		if !h.HasCredential("username") {
 			errors[strconv.Itoa(i)] = fmt.Errorf("must have credential 'username'")

--- a/pkg/secretless/config/v2/config_test.go
+++ b/pkg/secretless/config/v2/config_test.go
@@ -13,7 +13,7 @@ services:
     protocol: pg
     listenOn: tcp://0.0.0.0:5432 # can be a socket as well (same name for both)
     credentials:
-      address: postgres.my-service.internal:5432
+      host: postgres.my-service.internal
       password:
         from: vault
         get: name-in-vault
@@ -75,9 +75,9 @@ func TestNewConfig(t *testing.T) {
 		actualCreds := cfg.Services[0].Credentials
 		expectedCreds := []*Credential{
 			{
-				Name: "address",
+				Name: "host",
 				From: "literal",
-				Get:  "postgres.my-service.internal:5432",
+				Get:  "postgres.my-service.internal",
 			},
 			{
 				Name: "password",

--- a/test/util/testutil/config_generator.go
+++ b/test/util/testutil/config_generator.go
@@ -1,11 +1,8 @@
 package testutil
 
 import (
-	"fmt"
-
 	config_v1 "github.com/cyberark/secretless-broker/pkg/secretless/config/v1"
 )
-
 
 // GenerateConfigurations returns a Secretless Config along with a comprehensive
 // list of LiveConfigurations for use in tests.
@@ -61,9 +58,9 @@ func GenerateConfigurations() (config_v1.Config, LiveConfigurations) {
 				Debug:        true,
 				Credentials:  []config_v1.StoredSecret{
 					{
-						Name:     "address",
+						Name:     "host",
 						Provider: "literal",
-						ID:       fmt.Sprintf("%s:5432", sampleDbConfig.HostWithTLS),
+						ID:       sampleDbConfig.HostWithTLS,
 					},
 					{
 						Name:     "username",

--- a/test/util/testutil/config_generator.go
+++ b/test/util/testutil/config_generator.go
@@ -12,24 +12,24 @@ func GenerateConfigurations() (config_v1.Config, LiveConfigurations) {
 	secretlessConfig := config_v1.Config{
 		Listeners: []config_v1.Listener{
 			{
-				Debug:       true,
-				Name:        "health-check",
-				Protocol:    "mysql",
-				Socket:      "/sock/mysql.sock",
+				Debug:    true,
+				Name:     "health-check",
+				Protocol: "mysql",
+				Socket:   "/sock/mysql.sock",
 			},
 			{
-				Debug:       true,
-				Name:        "pg-bench",
-				Protocol:    "pg",
-				Address:     "0.0.0.0:5432",
+				Debug:    true,
+				Name:     "pg-bench",
+				Protocol: "pg",
+				Address:  "0.0.0.0:5432",
 			},
 		},
-		Handlers:  []config_v1.Handler{
+		Handlers: []config_v1.Handler{
 			{
 				Name:         "health-check",
 				ListenerName: "health-check",
 				Debug:        true,
-				Credentials:  []config_v1.StoredSecret{
+				Credentials: []config_v1.StoredSecret{
 					{
 						Name:     "host",
 						Provider: "literal",
@@ -56,7 +56,7 @@ func GenerateConfigurations() (config_v1.Config, LiveConfigurations) {
 				Name:         "pg-bench",
 				ListenerName: "pg-bench",
 				Debug:        true,
-				Credentials:  []config_v1.StoredSecret{
+				Credentials: []config_v1.StoredSecret{
 					{
 						Name:     "host",
 						Provider: "literal",
@@ -115,12 +115,12 @@ func GenerateConfigurations() (config_v1.Config, LiveConfigurations) {
 								}
 								liveConfiguration := LiveConfiguration{
 									AbstractConfiguration: AbstractConfiguration{
-										SocketType:       socketType,
-										TLSSetting:       serverTLSSetting,
-										SSLMode:          sslMode,
-										RootCertStatus:   rootCertStatus,
-										PrivateKeyStatus: privateKeyStatus,
-										PublicCertStatus: publicCertStatus,
+										SocketType:               socketType,
+										TLSSetting:               serverTLSSetting,
+										SSLMode:                  sslMode,
+										RootCertStatus:           rootCertStatus,
+										PrivateKeyStatus:         privateKeyStatus,
+										PublicCertStatus:         publicCertStatus,
 										AuthCredentialInvalidity: areAuthCredentialsInvalid,
 									},
 									ConnectionPort: connectionPort,
@@ -140,7 +140,7 @@ func GenerateConfigurations() (config_v1.Config, LiveConfigurations) {
 								// serverTLSSetting
 								handler.Credentials = append(
 									handler.Credentials,
-									serverTLSSetting.toSecrets(sampleDbConfig)...
+									serverTLSSetting.toSecrets(sampleDbConfig)...,
 								)
 
 								// socketType

--- a/test/util/testutil/types.go
+++ b/test/util/testutil/types.go
@@ -65,9 +65,14 @@ func (tlsSetting TLSSetting) toSecrets(dbConfig DBConfig) []config_v1.StoredSecr
 	switch dbConfig.Protocol {
 	case "pg":
 		secrets = append(secrets, config_v1.StoredSecret{
-			Name:     "address",
+			Name:     "host",
 			Provider: "literal",
-			ID:		  host + ":" + dbConfig.Port,
+			ID:       host,
+		})
+		secrets = append(secrets, config_v1.StoredSecret{
+			Name:     "port",
+			Provider: "literal",
+			ID:       dbConfig.Port,
 		})
 	case "mysql":
 		secrets = append(secrets, config_v1.StoredSecret{

--- a/test/util/testutil/types.go
+++ b/test/util/testutil/types.go
@@ -22,13 +22,13 @@ type SocketType string
 
 const (
 	// TCP is a socket type
-	TCP    SocketType = "TCP"
+	TCP SocketType = "TCP"
 	// Socket is a socket type
-	Socket            = "Unix Socket"
+	Socket = "Unix Socket"
 )
 
 // AllSocketTypes returns the available socket types.
-func AllSocketTypes()[]SocketType {
+func AllSocketTypes() []SocketType {
 	return []SocketType{TCP, Socket}
 }
 
@@ -37,13 +37,13 @@ type TLSSetting string
 
 const (
 	// TLS is a TLSSetting
-	TLS   TLSSetting = "DB_HOST_TLS"
+	TLS TLSSetting = "DB_HOST_TLS"
 	// NoTLS is a TLSSetting
-	NoTLS            = "DB_HOST_NO_TLS"
+	NoTLS = "DB_HOST_NO_TLS"
 )
 
 // AllTLSSettings returns the possible TLSSetting values: TLS or NoTLS
-func AllTLSSettings()[]TLSSetting {
+func AllTLSSettings() []TLSSetting {
 	return []TLSSetting{TLS, NoTLS}
 }
 
@@ -78,12 +78,12 @@ func (tlsSetting TLSSetting) toSecrets(dbConfig DBConfig) []config_v1.StoredSecr
 		secrets = append(secrets, config_v1.StoredSecret{
 			Name:     "host",
 			Provider: "literal",
-			ID:		  host,
+			ID:       host,
 		})
 		secrets = append(secrets, config_v1.StoredSecret{
 			Name:     "port",
 			Provider: "literal",
-			ID:		  dbConfig.Port,
+			ID:       dbConfig.Port,
 		})
 	default:
 		panic("Invalid DB_PROTOCOL provided")
@@ -97,19 +97,19 @@ type SSLMode string
 
 const (
 	// Default SSLMode
-	Default    SSLMode = ""
+	Default SSLMode = ""
 	// Disable SSLMode
-	Disable            = "disable"
+	Disable = "disable"
 	// Require SSLMode
-	Require            = "require"
+	Require = "require"
 	// VerifyCA SSLMode
-	VerifyCA           = "verify-ca"
+	VerifyCA = "verify-ca"
 	// VerifyFull SSLMode
-	VerifyFull         = "verify-full"
+	VerifyFull = "verify-full"
 )
 
 // AllSSLModes returns a list of all possible SSLMode values.
-func AllSSLModes()[]SSLMode {
+func AllSSLModes() []SSLMode {
 	return []SSLMode{Default, Disable, Require, VerifyCA, VerifyFull}
 }
 
@@ -119,7 +119,7 @@ func (sslMode SSLMode) toSecret() config_v1.StoredSecret {
 	return config_v1.StoredSecret{
 		Name:     "sslmode",
 		Provider: "literal",
-		ID:		   string(sslMode),
+		ID:       string(sslMode),
 	}
 }
 
@@ -129,7 +129,7 @@ type AuthCredentialInvalidity bool
 
 // AllAuthCredentialsInvalidity returns all possible values (which are just
 // "true" and "false") that this setting can assume.
-func AllAuthCredentialsInvalidity()[]AuthCredentialInvalidity {
+func AllAuthCredentialsInvalidity() []AuthCredentialInvalidity {
 	return []AuthCredentialInvalidity{true, false}
 }
 
@@ -160,15 +160,15 @@ const (
 	// Undefined RootCertStatus
 	Undefined RootCertStatus = ""
 	// Valid RootCertStatus
-	Valid                    = "/secretless/test/util/ssl/ca.pem"
+	Valid = "/secretless/test/util/ssl/ca.pem"
 	// Malformed RootCertStatus
-	Malformed                = "malformed"
+	Malformed = "malformed"
 	// Invalid RootCertStatus
-	Invalid                  = "/secretless/test/util/ssl/ca-invalid.pem"
+	Invalid = "/secretless/test/util/ssl/ca-invalid.pem"
 )
 
 // AllRootCertStatuses returns all possible values for RootCertStatus.
-func AllRootCertStatuses()[]RootCertStatus {
+func AllRootCertStatuses() []RootCertStatus {
 	return []RootCertStatus{Undefined, Valid, Invalid, Malformed}
 }
 
@@ -183,7 +183,7 @@ func (sslRootCertType RootCertStatus) toSecret() config_v1.StoredSecret {
 	return config_v1.StoredSecret{
 		Name:     "sslrootcert",
 		Provider: provider,
-		ID:		  string(sslRootCertType),
+		ID:       string(sslRootCertType),
 	}
 }
 
@@ -192,13 +192,13 @@ type PrivateKeyStatus string
 
 const (
 	// PrivateKeyUndefined PrivateKeyStatus
-	PrivateKeyUndefined     PrivateKeyStatus = ""
+	PrivateKeyUndefined PrivateKeyStatus = ""
 	// PrivateKeyValid PrivateKeyStatus
-	PrivateKeyValid                          = "/secretless/test/util/ssl/client-valid-key.pem"
+	PrivateKeyValid = "/secretless/test/util/ssl/client-valid-key.pem"
 	// PrivateKeyNotSignedByCA PrivateKeyStatus
-	PrivateKeyNotSignedByCA                  = "/secretless/test/util/ssl/client-different-ca-key.pem"
+	PrivateKeyNotSignedByCA = "/secretless/test/util/ssl/client-different-ca-key.pem"
 	// PrivateKeyMalformed PrivateKeyStatus
-	PrivateKeyMalformed                      = "malformed"
+	PrivateKeyMalformed = "malformed"
 )
 
 // AllPrivateKeyStatuses returns all possible values of PrivateKeyStatus.
@@ -227,13 +227,13 @@ type PublicCertStatus string
 
 const (
 	// PublicCertUndefined PublicCertStatus
-	PublicCertUndefined     PublicCertStatus = ""
+	PublicCertUndefined PublicCertStatus = ""
 	// PublicCertValid PublicCertStatus
-	PublicCertValid                          = "/secretless/test/util/ssl/client-valid.pem"
+	PublicCertValid = "/secretless/test/util/ssl/client-valid.pem"
 	// PublicCertNotSignedByCA PublicCertStatus
-	PublicCertNotSignedByCA                  = "/secretless/test/util/ssl/client-different-ca.pem"
+	PublicCertNotSignedByCA = "/secretless/test/util/ssl/client-different-ca.pem"
 	// PublicCertMalformed PublicCertStatus
-	PublicCertMalformed                      = "malformed"
+	PublicCertMalformed = "malformed"
 )
 
 // AllPublicCertStatuses returns all possible values for a PublicCertStatus


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?

Changes PG connector configuration to match MySQL. Effectively, it changes `address` field into `host` and `port` fields.

#### What ticket does this PR close?

Connected to https://github.com/cyberark/secretless-broker/issues/661

#### Where should the reviewer start?

[Jenkins Build](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/661-unify-pg-and-mysql-configs/)

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [N/A] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [x] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related documentation (in READMEs, docs, etc)
https://github.com/cyberark/secretless-docs/issues/181

#### Screenshots (if appropriate)
