### PR TITLE
Made MySQL connector able to guess the 3306 port if it is not provided

### DIFF
--- a/internal/app/secretless/handlers/mysql/connection_details.go
+++ b/internal/app/secretless/handlers/mysql/connection_details.go
@@ -12,6 +12,46 @@ type ConnectionDetails struct {
 	Options  map[string]string
 }
 
+const DefaultMySQLPort = uint(3306)
+
+// NewConnectionDetails is a constructor of ConnectionDetails structure from a
+// map of credentials.
+func NewConnectionDetails(credentials map[string][]byte) (
+	*ConnectionDetails, error) {
+
+	connDetails := &ConnectionDetails{Options: make(map[string]string)}
+
+	if host := credentials["host"]; host != nil {
+		connDetails.Host = string(credentials["host"])
+	}
+
+	connDetails.Port = DefaultMySQLPort
+	if credentials["port"] != nil {
+		port64, _ := strconv.ParseUint(string(credentials["port"]), 10, 64)
+		connDetails.Port = uint(port64)
+	}
+
+	if credentials["username"] != nil {
+		connDetails.Username = string(credentials["username"])
+	}
+
+	if credentials["password"] != nil {
+		connDetails.Password = string(credentials["password"])
+	}
+
+	delete(credentials, "host")
+	delete(credentials, "port")
+	delete(credentials, "username")
+	delete(credentials, "password")
+
+	connDetails.Options = make(map[string]string)
+	for k, v := range credentials {
+		connDetails.Options[k] = string(v)
+	}
+
+	return connDetails, nil
+}
+
 // Address returns a string representing the network location (host and port)
 // of a MySQL server.  This is the string you would would typically use to
 // connect to the database -- eg, in cmd line tools.

--- a/internal/app/secretless/handlers/mysql/connection_details_test.go
+++ b/internal/app/secretless/handlers/mysql/connection_details_test.go
@@ -1,0 +1,91 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpectedFields(t *testing.T) {
+	credentials := map[string][]byte{
+		"host":     []byte("myhost"),
+		"port":     []byte("1234"),
+		"username": []byte("myusername"),
+		"password": []byte("mypassword"),
+	}
+
+	expectedConnDetails := ConnectionDetails{
+		Host:     "myhost",
+		Port:     1234,
+		Username: "myusername",
+		Password: "mypassword",
+		Options:  make(map[string]string),
+	}
+
+	actualConnDetails, err := NewConnectionDetails(credentials)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, expectedConnDetails, *actualConnDetails)
+	}
+}
+
+func TestDefaultPort(t *testing.T) {
+	credentials := map[string][]byte{
+		"host":     []byte("myhost"),
+		"username": []byte("myusername"),
+		"password": []byte("mypassword"),
+	}
+
+	expectedConnDetails := ConnectionDetails{
+		Host:     "myhost",
+		Port:     DefaultMySQLPort,
+		Username: "myusername",
+		Password: "mypassword",
+		Options:  make(map[string]string),
+	}
+
+	actualConnDetails, err := NewConnectionDetails(credentials)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, expectedConnDetails, *actualConnDetails)
+	}
+}
+
+func TestUnexpectedFieldsAreSavedAsOptions(t *testing.T) {
+	credentials := map[string][]byte{
+		"host":     []byte("myhost"),
+		"port":     []byte("1234"),
+		"foo":      []byte("5432"),
+		"username": []byte("myusername"),
+		"bar":      []byte("data"),
+		"password": []byte("mypassword"),
+	}
+
+	expectedOptions := map[string]string{
+		"foo": "5432",
+		"bar": "data",
+	}
+
+	actualConnDetails, err := NewConnectionDetails(credentials)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, expectedOptions, (*actualConnDetails).Options)
+	}
+}
+
+func TestAddress(t *testing.T) {
+	credentials := map[string][]byte{
+		"host": []byte("myhost2"),
+		"port": []byte("12345"),
+	}
+
+	actualConnDetails, err := NewConnectionDetails(credentials)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, "myhost2:12345", (*actualConnDetails).Address())
+	}
+}


### PR DESCRIPTION
Since in most cases, we know that the MySQL port is 3306, it is
superfluous to need that in the config if the user is connecting to the
default port setting. This commit also reorganizes the code a bit for
better testability and adds a few tests around this feature.

#### What ticket does this PR close?
Connected to https://github.com/cyberark/secretless-broker/issues/805

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/805-mysql-default-port-set/)

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
