### PR TITLE
807 Add back pg address support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Added ability to configure PG connector with `host`/`port` combination
+- Deprecated support for PG connector configurations with `address` field
+
 ## [1.0.0] 2019-07-03
 
 ### Added

--- a/internal/app/secretless/handlers/pg/backend_config.go
+++ b/internal/app/secretless/handlers/pg/backend_config.go
@@ -1,0 +1,101 @@
+package pg
+
+import (
+	"log"
+	"net"
+)
+
+// DefaultPostgresPort is the default port for Postgres database connections
+// over TCP
+const DefaultPostgresPort = "5432"
+
+var sslOptions = []string{
+	"sslrootcert",
+	"sslmode",
+	"sslkey",
+	"sslcert",
+}
+
+// BackendConfig stores the connection info to the real backend database.
+type BackendConfig struct {
+	Host       string
+	Port       string
+	Username   string
+	Password   string
+	Options    map[string]string
+	SSLOptions map[string]string
+}
+
+// Address provides an aggregation of Host and Port fields into a format
+// acceptable by consumers of this class (`net.Dial`).
+func (backendConfig *BackendConfig) Address() string {
+	return net.JoinHostPort(backendConfig.Host, backendConfig.Port)
+}
+
+// NewBackendConfig constructs a Backendconfig object based on the options passed
+// in that are based on resolved configuration fields.
+func NewBackendConfig(options map[string][]byte) (*BackendConfig, error) {
+	backendConfig := BackendConfig{
+		Options:    make(map[string]string),
+		SSLOptions: make(map[string]string),
+	}
+
+	if options["host"] != nil {
+		backendConfig.Host = string(options["host"])
+	}
+
+	backendConfig.Port = DefaultPostgresPort
+	if options["port"] != nil {
+		backendConfig.Port = string(options["port"])
+	}
+
+	// Deprecated. To be removed at a later date and only provided for
+	// temporary backwards compatibility.
+	if options["address"] != nil {
+		log.Printf("WARN: 'address' has been deprecated for PG connector. " +
+			"Please use 'host' and 'port' instead.'")
+
+		host, port, err := net.SplitHostPort(string(options["address"]))
+		if err != nil {
+			// Try one more time but this time assume it's just a hostname
+			host, _, err = net.SplitHostPort(string(options["address"]) + ":")
+			if err != nil {
+				return nil, err
+			}
+			port = DefaultPostgresPort
+		}
+
+		backendConfig.Host = host
+		backendConfig.Port = port
+	}
+
+	if options["username"] != nil {
+		backendConfig.Username = string(options["username"])
+	}
+
+	if options["password"] != nil {
+		backendConfig.Password = string(options["password"])
+	}
+
+	for _, sslOption := range sslOptions {
+		if options[sslOption] != nil {
+			value := string(options[sslOption])
+			if value != "" {
+				backendConfig.SSLOptions[sslOption] = value
+			}
+		}
+		delete(options, sslOption)
+	}
+
+	delete(options, "host")
+	delete(options, "port")
+	delete(options, "address")
+	delete(options, "username")
+	delete(options, "password")
+
+	for k, v := range options {
+		backendConfig.Options[k] = string(v)
+	}
+
+	return &backendConfig, nil
+}

--- a/internal/app/secretless/handlers/pg/backend_config_test.go
+++ b/internal/app/secretless/handlers/pg/backend_config_test.go
@@ -1,0 +1,156 @@
+package pg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpectedFields(t *testing.T) {
+	options := map[string][]byte{
+		"host":     []byte("myhost"),
+		"port":     []byte("1234"),
+		"username": []byte("myusername"),
+		"password": []byte("mypassword"),
+	}
+
+	expectedBackendConfig := BackendConfig{
+		Host:       "myhost",
+		Port:       "1234",
+		Username:   "myusername",
+		Password:   "mypassword",
+		Options:    map[string]string{},
+		SSLOptions: map[string]string{},
+	}
+
+	actualBackendConfig, err := NewBackendConfig(options)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, expectedBackendConfig, *actualBackendConfig)
+	}
+}
+
+func TestSSLOptions(t *testing.T) {
+	options := map[string][]byte{
+		"host":     []byte("myhost"),
+		"port":     []byte("1234"),
+		"username": []byte("myusername"),
+		"password": []byte("mypassword"),
+
+		"sslrootcert": []byte("mysslrootcert"),
+		"sslmode":     []byte("mysslmode"),
+		"sslkey":      []byte("mysslkey"),
+		"sslcert":     []byte("mysslcert"),
+	}
+
+	expectedBackendConfig := BackendConfig{
+		Host:     "myhost",
+		Port:     "1234",
+		Username: "myusername",
+		Password: "mypassword",
+		Options:  map[string]string{},
+		SSLOptions: map[string]string{
+			"sslrootcert": "mysslrootcert",
+			"sslmode":     "mysslmode",
+			"sslkey":      "mysslkey",
+			"sslcert":     "mysslcert",
+		},
+	}
+
+	actualBackendConfig, err := NewBackendConfig(options)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, expectedBackendConfig, *actualBackendConfig)
+	}
+}
+
+func TestDefaultPort(t *testing.T) {
+	options := map[string][]byte{
+		"host":     []byte("myhost"),
+		"username": []byte("myusername"),
+		"password": []byte("mypassword"),
+	}
+
+	expectedBackendConfig := BackendConfig{
+		Host:       "myhost",
+		Port:       DefaultPostgresPort,
+		Username:   "myusername",
+		Password:   "mypassword",
+		Options:    map[string]string{},
+		SSLOptions: map[string]string{},
+	}
+
+	actualBackendConfig, err := NewBackendConfig(options)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, expectedBackendConfig, *actualBackendConfig)
+	}
+}
+
+func TestUnexpectedFieldsAreSavedAsOptions(t *testing.T) {
+	options := map[string][]byte{
+		"host":     []byte("myhost"),
+		"port":     []byte("1234"),
+		"foo":      []byte("3306"),
+		"username": []byte("myusername"),
+		"bar":      []byte("data"),
+		"password": []byte("mypassword"),
+	}
+
+	expectedOptions := map[string]string{
+		"foo": "3306",
+		"bar": "data",
+	}
+
+	actualBackendConfig, err := NewBackendConfig(options)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, expectedOptions, (*actualBackendConfig).Options)
+	}
+}
+
+func TestAddressCanBeUsedInsteadOfHostAndPort(t *testing.T) {
+	options := map[string][]byte{
+		"address": []byte("myhost2:12345"),
+	}
+
+	actualBackendConfig, err := NewBackendConfig(options)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, "myhost2", (*actualBackendConfig).Host)
+		assert.EqualValues(t, "12345", (*actualBackendConfig).Port)
+	}
+}
+
+func TestAddressWithoutPortCanBeUsedInsteadOfHostAndPort(t *testing.T) {
+	options := map[string][]byte{
+		"address": []byte("myhost2"),
+	}
+
+	actualBackendConfig, err := NewBackendConfig(options)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, "myhost2", (*actualBackendConfig).Host)
+		assert.EqualValues(t, "5432", (*actualBackendConfig).Port)
+	}
+}
+
+func TestAddress(t *testing.T) {
+	options := map[string][]byte{
+		"host": []byte("myhost2"),
+		"port": []byte("12345"),
+	}
+
+	actualBackendConfig, err := NewBackendConfig(options)
+	assert.Nil(t, err)
+
+	if err == nil {
+		assert.EqualValues(t, "myhost2:12345", (*actualBackendConfig).Address())
+	}
+}

--- a/internal/app/secretless/handlers/pg/handler.go
+++ b/internal/app/secretless/handlers/pg/handler.go
@@ -20,16 +20,6 @@ type ClientOptions struct {
 	Options  map[string]string
 }
 
-// BackendConfig stores the connection info to the real backend database.
-type BackendConfig struct {
-	Host         string
-	Port         string
-	Username     string
-	Password     string
-	Options      map[string]string
-	QueryStrings map[string]string
-}
-
 // Handler connects a client to a backend. It uses the handler Config and Providers to
 // establish the connectionDetails, which is used to make the Backend connection. Then the data
 // is transferred bidirectionally between the Client and Backend.

--- a/internal/app/secretless/listeners/pg/listener.go
+++ b/internal/app/secretless/listeners/pg/listener.go
@@ -29,8 +29,8 @@ func (hhc handlerHasCredentials) Validate(value interface{}) error {
 	hs := value.([]config_v1.Handler)
 	errors := validation.Errors{}
 	for i, h := range hs {
-		if !h.HasCredential("host") {
-			errors[strconv.Itoa(i)] = fmt.Errorf("must have credential 'host'")
+		if !h.HasCredential("host") && !h.HasCredential("address") {
+			errors[strconv.Itoa(i)] = fmt.Errorf("must have credential 'host' or (deprecated) 'address'")
 		}
 		if !h.HasCredential("username") {
 			errors[strconv.Itoa(i)] = fmt.Errorf("must have credential 'username'")


### PR DESCRIPTION
Returns ability to define PG connector with an address

#### What ticket does this PR close?
Connected to #807

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/807-add-back-pg-address-support/)

#### What is the status of the manual tests?

Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [x] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
