### PR TITLE
Fix problems with prefil_changelog running

### DIFF
--- a/bin/prefill_changelog
+++ b/bin/prefill_changelog
@@ -2,7 +2,9 @@
 
 set -e
 
-if [[ $# -ge 1 ]] && [[ "$1" != "--dry-run" ]]; then
+. ./bin/build_utils
+
+if [[ $# -ge 1 ]] && [[ "${1:-}" != "--dry-run" ]]; then
   echo "Usage: $0 [--dry-run]"
   exit 1
 fi
@@ -12,7 +14,7 @@ most_recent_version() {
 }
 
 dry_run="false"
-if [[ "$1" == "--dry-run" ]]; then
+if [[ "${1:-}" == "--dry-run" ]]; then
   dry_run="true"
   shift
 fi


### PR DESCRIPTION
We were missing an import and we needed to account for unbound variable
$1 when running. This commit should fix both issues.