### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,39 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Changed
+## [1.1.0] 2019-08-09
+
+### Added
+- Added version output to logs on startup
+- Added NOTICES.txt to the project
+- Added dependency tracking tools and info
 - Added ability to configure PG connector with `host`/`port` combination
+- Added gitleaks config to enable running gitleaks pre-push
+
+### Changed
 - Deprecated support for PG connector configurations with `address` field
+- Minor edits to website quick start instructions
+- Updated versioning method for the project to use version.go
+- Parallelized integration tests
+- Upgraded summon module dependency to 0.7.0
+- Cleaned up go.mod and go.sum with `go mod tidy`
+- Only pin to vault/api submodule rather than larger vault module
+- MySQL port defaults to 3306 if not specified
+- Updated health check test to wait longer for server to come up to prevent
+  test failures
+- Revised README for simplicity and to describe available releases
+
+### Removed
+- Removed custom script to check style in favor of code climate
+- Removed old benchmark proof of concepts
+- Removed GitLab pipeline
+- Removed ability to pass `dbname` in the `address` field of the PostgreSQL
+  config - the PostgreSQL `address` config now only accepts `host:[port]`
+
+### Fixed
+- Resolved shellcheck errors
+- Standardized spacing in `testutil` package
+- Fixed changelog prefill script
 
 ## [1.0.0] 2019-07-03
 
@@ -288,7 +318,7 @@ external plugins
 
 The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.1.0...HEAD
 [0.2.0]: https://github.com/cyberark/secretless-broker/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/cyberark/secretless-broker/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/cyberark/secretless-broker/compare/v0.3.0...v0.4.0
@@ -304,3 +334,4 @@ The first tagged version.
 [0.7.1]: https://github.com/cyberark/secretless-broker/compare/v0.7.0...v0.7.1 
 [0.8.0]: https://github.com/cyberark/secretless-broker/compare/v0.7.1...v0.8.0 
 [1.0.0]: https://github.com/cyberark/secretless-broker/compare/v0.8.0...v1.0.0 
+[1.1.0]: https://github.com/cyberark/secretless-broker/compare/v1.0.0...v1.1.0 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -368,6 +368,8 @@ _Please note: Plugin API interface signatures and supported plugin API version(s
    from your local machine).
 
 ### Build a release
+**Note:** Until the stable quality exercises have completed, the GitHub release
+should be officially marked as a `pre-release` (eg "non-production ready")
 1. From a **clean checkout of master** run `./bin/build_release` to generate
    the release artifacts.
 1. Create a GitHub release from the tag, add a description by copying the CHANGELOG entries

--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Post-1.0, GitHub releases are created for GitHub tagged versions that have under
 
 At any given time there is only one Docker image with the `stable` tag - that of the latest `stable` release. Older stable versions (v1.0+) can be found on the official [GitHub releases page](https://github.com/cyberark/secretless-broker/releases).
 
+**Note:** the [GitHub releases page](https://github.com/cyberark/secretless-broker/releases) will also show `pre-releases`, which have not yet been promoted to stable.
+
 ### GitHub repository
 The code on `master` in the project's GitHub repository represents the development work done since the previous GitHub tag. It is possible to build Secretless from source (see [our contributing guidelines](#development) for more info), but for regular use we recommend using the `stable` Docker image from DockerHub or an official GitHub release.
 

--- a/pkg/secretless/version.go
+++ b/pkg/secretless/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the broker
-var Version = "1.0.0"
+var Version = "1.1.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
Other things done in this PR:
- Add note to README about pre-releases
- Update contributor release instructions to include marking a release as a
  "pre-release" until the stable quality exercises have been completed

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [x] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [x] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [x] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch