### PR TITLE
Reverted gke-utils image build to not use any context

### DIFF
--- a/k8s-ci/utils.sh
+++ b/k8s-ci/utils.sh
@@ -7,7 +7,9 @@ set -euo pipefail
 
 # Prepare Docker images
 function prepareTestEnvironment() {
-  docker build --rm --tag "gke-utils:latest" -f Dockerfile .
+  # Pipe the Dockerfile into the command to avoid sending the whole
+  # context to Docker
+  docker build --rm --tag "gke-utils:latest" - < Dockerfile
 }
 
 # Delete an image from GCR, unless it is has multiple tags pointing to it


### PR DESCRIPTION
The recent change made the gke-utils image be built with included
context, making the build process slower than it needed to be. This
change reverts this and moves the image building back to a no-context
build.