### PR TITLE
cross-compile linux and darwin using cross-compile goreleaser image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,9 +1,12 @@
 project_name: secretless-broker
 
 builds:
-- binary: summon2
+- &summon-2-build
+  id: summon2-linux
+  main: ./cmd/summon2/main.go
+  binary: summon2
   env:
-  - CGO_ENABLED=0
+  - CGO_ENABLED=1
   # Tag 'netgo' is a Go build tag that ensures a pure Go networking stack
   # in the resulting binary instead of using the default host's stack to
   # ensure a fully statically-linked artifact that has no lib dependencies.
@@ -13,13 +16,32 @@ builds:
   - linux
   goarch:
   - amd64
-  id: summon2
   # These flags generate a statically-linked artifact that allows the binary
   # to run on any linux-based OS.
   ldflags: -s -w -linkmode external -extldflags "-static"
-  main: ./cmd/summon2/main.go
 
-- binary: secretless-broker
+- <<: *summon-2-build
+  id: summon2-osx
+  env:
+  - CGO_ENABLED=1
+  - CC=o64-clang
+  - CXX=o64-clang++
+  goos:
+  - darwin
+  goarch:
+  - amd64
+  # Building for OSX with -extldflags "-static" results in the error:
+  # ld: library not found for -lcrt0.o
+  # This is because static builds are only possible if all libraries
+  # (including libgcc.a) have also been compiled with -static.
+  # A static version of crt0.o is not provided
+  # with the OSX SDK
+  ldflags: -s -w -linkmode external
+
+- &secretless-broker-build
+  id: secretless-broker-linux
+  main: ./cmd/secretless-broker/main.go
+  binary: secretless-broker
   env:
   - CGO_ENABLED=1
   # Tag 'netgo' is a Go build tag that ensures a pure Go networking stack
@@ -31,12 +53,28 @@ builds:
   - linux
   goarch:
   - amd64
-  id: secretless-broker
   # The `Tag` override is there to provide the git commit information in the
   # final binary. See `Static long version tags` in the `Building` section
   # of `CONTRIBUTING.md` for more information.
   ldflags: -s -w -linkmode external -X "github.com/cyberark/secretless-broker/pkg/secretless.Tag={{ .ShortCommit }}" -extldflags "-static"
-  main: ./cmd/secretless-broker/main.go
+
+- <<: *secretless-broker-build
+  id: secretless-broker-osx
+  env:
+  - CGO_ENABLED=1
+  - CC=o64-clang
+  - CXX=o64-clang++
+  goos:
+  - darwin
+  goarch:
+  - amd64
+  # Building for OSX with -extldflags "-static" results in the error:
+  # ld: library not found for -lcrt0.o
+  # This is because static builds are only possible if all libraries
+  # (including libgcc.a) have also been compiled with -static.
+  # A static version of crt0.o is not provided
+  # with the OSX SDK
+  ldflags: -s -w -linkmode external -X "github.com/cyberark/secretless-broker/pkg/secretless.Tag={{ .ShortCommit }}"
 
 archives:
   - id: secretless-release-archive
@@ -55,6 +93,19 @@ checksum:
   name_template: 'SHA256SUMS.txt'
 
 dist: ./dist/goreleaser
+
+brews:
+  - description: Secures your apps by making them Secretless
+    homepage: https://secretless.io
+    url_template: https://github.com/cyberark/secretless-broker/releases/download/v{{.Version}}/secretless-broker_{{.Version}}_darwin_amd64.tar.gz
+    install: |
+      bin.install "secretless-broker"
+    test: |
+      system "#{bin}/secretless-broker", "-version"
+    github:
+      owner: cyberark
+      name: homebrew-tools
+    skip_upload: true
 
 nfpms:
   - bindir: /usr/bin

--- a/bin/Dockerfile.releaser
+++ b/bin/Dockerfile.releaser
@@ -1,0 +1,23 @@
+FROM dockercore/golang-cross
+
+RUN apt-get update && \
+    apt-get install -y bash \
+                       build-essential \
+                       curl \
+                       docker \
+                       git \
+                       mercurial \
+                       rpm
+
+ENV GORELEASER_VERSION=0.116.0 \
+    GORELEASER_SHA=34b7e3b843158bd0714d1be996951685496491adab4524fb1198ae144ab06ba3 \
+    GORELEASER_DOWNLOAD_FILE=goreleaser_Linux_x86_64.tar.gz
+
+ENV GORELEASER_DOWNLOAD_URL=https://github.com/goreleaser/goreleaser/releases/download/v${GORELEASER_VERSION}/${GORELEASER_DOWNLOAD_FILE}
+
+RUN wget "${GORELEASER_DOWNLOAD_URL}" && \
+    echo "$GORELEASER_SHA $GORELEASER_DOWNLOAD_FILE" | sha256sum -c - && \
+    tar -xzf "$GORELEASER_DOWNLOAD_FILE" -C /usr/bin/ goreleaser && \
+    rm "$GORELEASER_DOWNLOAD_FILE"
+
+ENTRYPOINT ["goreleaser"]

--- a/bin/build_release
+++ b/bin/build_release
@@ -2,20 +2,25 @@
 
 CURRENT_DIR=$("$(dirname "$0")/abspath")
 
-GORELEASER_IMAGE="goreleaser/goreleaser:latest-cgo"
+# xgo because it allows cross-compilation
+GORELEASER_IMAGE="cyberark/goreleaser:latest-xgo"
 
-GORELEASER_ARGS="--rm-dist"
+GORELEASER_ARGS=("--rm-dist")
 if [[ "${SNAPSHOT}" == "true" ]]; then
-  GORELEASER_ARGS+=" --snapshot"
+  GORELEASER_ARGS+=("--snapshot")
 fi
 
 echo "Current dir: $CURRENT_DIR"
 
-docker pull "${GORELEASER_IMAGE}"
+# TODO: the image cyberark/goreleaser:latest-xgo will need to be pushed
+# TODO: to Dockerhub, and the command below should become
+# TODO: docker pull cyberark/goreleaser:latest-xgo
+# NOTE: Piping the Dockerfile sends an empty context to docker build
+docker build -t "${GORELEASER_IMAGE}" - < "$CURRENT_DIR/Dockerfile.releaser"
 
 docker run --rm -it \
   --volume "$CURRENT_DIR/..:/secretless-broker" \
   --workdir /secretless-broker \
-  "${GORELEASER_IMAGE}" "${GORELEASER_ARGS}"
+  "${GORELEASER_IMAGE}" "${GORELEASER_ARGS[@]}"
 
 echo "Releases built. Archives can be found in dist/goreleaser"


### PR DESCRIPTION
An image of goreleaser build on top of dockercore/golang-cross allows us to cross-compile binaries, that use CGO, to both linux and darwin.
