### PR TITLE
fix aws service connector

### DIFF
--- a/internal/app/secretless/handlers/http/aws.go
+++ b/internal/app/secretless/handlers/http/aws.go
@@ -58,11 +58,11 @@ func (h AWSHandler) Authenticate(values map[string][]byte, r *http.Request) erro
 		return err
 	}
 
-	var accessKeyId, secretAccessKey, accessToken []byte
+	var accessKeyID, secretAccessKey, accessToken []byte
 	var header string
 
-	accessKeyId = values["accessKeyId"]
-	if accessKeyId == nil {
+	accessKeyID = values["accessKeyId"]
+	if accessKeyID == nil {
 		return fmt.Errorf("AWS connection parameter 'accessKeyId' is not available")
 	}
 	secretAccessKey = values["secretAccessKey"]
@@ -71,7 +71,7 @@ func (h AWSHandler) Authenticate(values map[string][]byte, r *http.Request) erro
 	}
 	accessToken = values["accessToken"]
 
-	creds := credentials.NewStaticCredentials(string(accessKeyId), string(secretAccessKey), string(accessToken))
+	creds := credentials.NewStaticCredentials(string(accessKeyID), string(secretAccessKey), string(accessToken))
 
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/internal/app/secretless/handlers/http/aws.go
+++ b/internal/app/secretless/handlers/http/aws.go
@@ -56,11 +56,11 @@ func (h AWSHandler) Authenticate(values map[string][]byte, r *http.Request) erro
 		return err
 	}
 
-	var accessKeyID, secretAccessKey, accessToken []byte
+	var accessKeyId, secretAccessKey, accessToken []byte
 	var header string
 
-	accessKeyID = values["accessKeyID"]
-	if accessKeyID == nil {
+	accessKeyId = values["accessKeyId"]
+	if accessKeyId == nil {
 		return fmt.Errorf("AWS connection parameter 'accessKeyId' is not available")
 	}
 	secretAccessKey = values["secretAccessKey"]
@@ -69,7 +69,7 @@ func (h AWSHandler) Authenticate(values map[string][]byte, r *http.Request) erro
 	}
 	accessToken = values["accessToken"]
 
-	creds := credentials.NewStaticCredentials(string(accessKeyID), string(secretAccessKey), string(accessToken))
+	creds := credentials.NewStaticCredentials(string(accessKeyId), string(secretAccessKey), string(accessToken))
 
 	bodyBytes, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/internal/app/secretless/handlers/http/aws.go
+++ b/internal/app/secretless/handlers/http/aws.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/app/secretless/plugin/v1"
@@ -111,8 +113,20 @@ func (h AWSHandler) Authenticate(values map[string][]byte, r *http.Request) erro
 		return err
 	}
 
-	// TODO: don't always force SSL, some services such as S3 don't require it.
-	r.URL.Scheme = "https"
+	// When the endpoint URL is http://secretless.empty
+	// use default resolver to get service endpoint
+	if r.URL.Scheme == "http" && r.URL.Host == "secretless.empty" {
+		// The endpoint will use TLS if possible
+		endpoint, _ := endpoints.DefaultResolver().EndpointFor(
+			serviceName,
+			region)
+
+		endpointURL, _ := url.Parse(endpoint.URL)
+
+		r.URL.Scheme = endpointURL.Scheme
+		r.URL.Host = endpointURL.Host
+	}
+
 	r.Body = ioutil.NopCloser(bytes.NewReader(bodyBytes))
 
 	return nil


### PR DESCRIPTION
# PR

Resolves https://github.com/cyberark/secretless-broker/issues/816

This PR achieve 2 goals, covered in the sections below.

## Bug fix
The AWS service connector was altogether not working due to a naming mistake. `s/accessKeyID/accessKeyId/`.

## UX Improvement
The AWS service connector is an http proxy. It requires the client application to connect through Secretless to an HTTP endpoint. e.g. 
```
HTTP_PROXY=http://localhost:8080 aws --endpoint-url http://s3.us-east-1.amazonaws.com s3 list ...
```

This forces the client to fundamentally change how they interact with the AWS CLI (or SDK). The client must have knowledge of AWS endpoints because the client can only connect to an endpoint over HTTP when using Secretless.

Inside the AWS SDK and CLI the endpoints are determined dynamically. An improved experience with Secretless would be similar.  

The second commit of the PR introduces the dynamic discovery of endpoints that the AWS SDK offers. It also makes it possible to specify your own HTTP endpoint that the Secretless proxy will follow. The client must specify an endpoint URL of `http://secretless.empty` to take the dynamic endpoint route otherwise Secretless will use the provided endpoint. The example below illustrates the experience.

```
alias aws="HTTP_PROXY=http://localhost:8080 aws --endpoint-url http://secretless.empty"
aws s3 list
```

Note that the dynamic endpoint route means TLS between Secretless and the endpoint (if it makes sense.

TODO: Add a way to allow TLS between Secretless and Endpoint for non-dynamic endpoints. 