### PR TITLE
Configuration adds support for universal connector spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ replace `<GOOS>/<GOARCH>` with your particular operating system and compilation 
    version: "2"
    services:
      pg_tcp:
-       protocol: pg
+       connector: pg
        listenOn: tcp://0.0.0.0:15432
        credentials:
          host:

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Write a `secretless.yml` file that includes:
 version: "2"
 services:
   pg-db:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:4321
     credentials:
       host: localhost

--- a/bin/juxtaposer/README.md
+++ b/bin/juxtaposer/README.md
@@ -95,7 +95,7 @@ performance._
 version: 2
 services:
   mysql-socket:
-    protocol: mysql
+    connector: mysql
     listenOn: unix:///tmp/mysql
     credentials:
       username: myuser
@@ -105,7 +105,7 @@ services:
       sslmode: disable
 
   pg-socket:
-    protocol: pg
+    connector: pg
     listenOn: unix:///tmp/.s.PGSQL.5432
     credentials:
       username: myuser

--- a/bin/juxtaposer/deploy/secretless.yml
+++ b/bin/juxtaposer/deploy/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   mysql-tcp:
-    protocol: mysql
+    connector: mysql
     listenOn: tcp://0.0.0.0:13306
     credentials:
       username:
@@ -19,7 +19,7 @@ services:
         get: secretless-xa-db/mysql/port
 
   mysql-sock:
-    protocol: mysql
+    connector: mysql
     listenOn: unix:///sock/mysql
     credentials:
       username:
@@ -36,7 +36,7 @@ services:
         get: secretless-xa-db/mysql/port
 
   pg-tcp:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:15432
     credentials:
       username:
@@ -50,7 +50,7 @@ services:
         get: secretless-xa-db/postgresql/hostname
 
   pg-sock:
-    protocol: pg
+    connector: pg
     listenOn: unix:///sock/.s.PGSQL.5432
     credentials:
       username:

--- a/demos/k8s-demo/etc/secretless.yml
+++ b/demos/k8s-demo/etc/secretless.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   quick-start-postgres:
-    protocol: pg
+    connector: pg
     listenOn: tcp://localhost:5432
     credentials:
       address:

--- a/demos/quick-start/docker/etc/secretless.yml
+++ b/demos/quick-start/docker/etc/secretless.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   quick-start-postgres:
-    protocol: pg
+    connector: pg
     debug: true
     listenOn: tcp://0.0.0.0:5454
     credentials:
@@ -14,7 +14,7 @@ services:
         get: QUICKSTART_PASSWORD
 
   quick-start-ssh:
-    protocol: ssh
+    connector: ssh
     listenOn: tcp://0.0.0.0:2222
     credentials:
       address: localhost
@@ -24,7 +24,7 @@ services:
         get: SSH_PRIVATE_KEY
 
   quick-start-basic-auth:
-    protocol: http
+    connector: basic_auth
     listenOn: tcp://0.0.0.0:8081
     credentials:
       username:
@@ -34,7 +34,6 @@ services:
         from: env
         get: BASIC_AUTH_PASSWORD
     config:
-      authenticationStrategy: basic_auth
       authenticateURLsMatching:
         - ^http\:\/\/quickstart\/
         - ^http\:\/\/localhost.*

--- a/design/simpler-configuration.md
+++ b/design/simpler-configuration.md
@@ -137,7 +137,7 @@ services:
   ###
 
   postgres-db:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:5432 # can be a socket as well (same name for both)
     credentials:
       host: postgres.my-service.internal
@@ -154,12 +154,11 @@ services:
   # http handler example
   ###
       
-  # the config for the http protocol has two required values:
-  #   `authenticationStrategy` which indicates which specific http protocol implementation to use (eg `type`)
+  # the config for the http protocol has one required value:
   #   `authenticateURLsMatching` which gives a regex pattern for request URIs that use Secretless for auth (eg `match`)
   
   aws-client:
-    protocol: http
+    connector: http
     listenOn: unix:///var/docker/docker.sock
     credentials:
       accessKeyID:
@@ -172,11 +171,10 @@ services:
         from: conjur
         get: id-of-secret-in-conjur
     config:
-      authenticationStrategy: aws
       authenticateURLsMatching: ^http.*
 
   conjur-client:
-    protocol: http
+    connector: http
     listenOn: http://127.0.0.1:8080
     credentials:
       accessToken:
@@ -184,7 +182,6 @@ services:
         get: /path/to/file
       forceSSL: true
     config:
-      authenticationStrategy: conjur
       authenticateURLsMatching: ^http://srdjan.com*
 
   ###
@@ -192,7 +189,7 @@ services:
   ###
 
   ssh-proxy:
-    protocol: ssh
+    connector: ssh
     listenOn: tcp://0.0.0.0:2222
     credentials:
       address: "localhost"

--- a/design/tls-support-plan.md
+++ b/design/tls-support-plan.md
@@ -254,7 +254,7 @@ depend on your use case.
 version: "2"
 services:
   pg_connector:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:5432
     credentials:
       host: postgres.my-service.internal
@@ -269,7 +269,7 @@ services:
 version: "2"
 services:
   pg_connector:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:5432
     credentials:
       host: postgres.my-service.internal
@@ -300,7 +300,7 @@ services:
 version: "2"
 services:
   pg_connector:
-    protocol: pg
+    connector: pg
     listenOn: unix:///sock/.s.PGSQL.5432
     credentials:
       host: postgres.my-service.internal

--- a/docs/_posts/2018-09-21-configuration-with-custom-resources.md
+++ b/docs/_posts/2018-09-21-configuration-with-custom-resources.md
@@ -23,7 +23,7 @@ Broker should be running. Your `secretless.yml` might look something like:
 version: "2"
 services:
   my_webapp_connector:
-    protocol: http
+    connector: basic_auth
     listenOn: tcp://0.0.0.0:8080
     credentials:
       username:
@@ -33,7 +33,6 @@ services:
         from: env
         get: WEBAPP_PASSWORD
     config:
-      authenticationStrategy: basic_auth
       authenticateURLsMatching:
         - ^http.*
 ```

--- a/docs/tutorials/kubernetes/sec-admin.md
+++ b/docs/tutorials/kubernetes/sec-admin.md
@@ -373,7 +373,7 @@ cat << EOF > secretless.yml
 version: "2"
 services:
   pets-pg:
-    protocol: pg
+    connector: pg
     listenOn: tcp://localhost:5432
     credentials:
       host:

--- a/pkg/secretless/config/v2/config.go
+++ b/pkg/secretless/config/v2/config.go
@@ -1,8 +1,11 @@
 package v2
 
 import (
+	"fmt"
+	"log"
 	"sort"
 
+	validation "github.com/go-ozzo/ozzo-validation"
 	"gopkg.in/yaml.v2"
 
 	config_v1 "github.com/cyberark/secretless-broker/pkg/secretless/config/v1"
@@ -19,11 +22,11 @@ type Config struct {
 // location of its required credentials, and (optionally) any additional
 // protocol specific configuration.
 type Service struct {
-	Credentials    []*Credential
-	ListenOn       string
-	Name           string
-	Protocol       string
-	ProtocolConfig []byte
+	Connector       string
+	ConnectorConfig []byte
+	Credentials     []*Credential
+	ListenOn        string
+	Name            string
 }
 
 // NewV1Config converts the bytes of a v2 YAML file to a v1.Config.  As such,
@@ -88,9 +91,42 @@ func NewConfig(v2YAML []byte) (*Config, error) {
 		services = append(services, svc)
 	}
 
+	// sort Services
+	sort.Slice(services, func(i, j int) bool {
+		return services[i].Name < services[j].Name
+	})
+
 	return &Config{
 		Services: services,
 	}, nil
+}
+
+// connectorFromLegacyHTTPConfig extracts authenticationStrategy.
+// This function is useful when the deprecated 'protocol' field equals 'http'
+// and you want to determine the connector name
+func connectorFromLegacyHTTPConfig(connectorConfigBytes []byte) (string, error) {
+	tempCfg := &struct {
+		AuthenticationStrategy string `yaml:"authenticationStrategy"`
+	}{}
+	err := yaml.Unmarshal(connectorConfigBytes, tempCfg)
+	if err != nil {
+		return "", err
+	}
+
+	err = validation.ValidateStruct(
+		tempCfg,
+		validation.Field(
+			&tempCfg.AuthenticationStrategy,
+			validation.Required,
+			validation.In(HTTPAuthenticationStrategies...),
+		),
+	)
+
+	if err != nil {
+		return "", err
+	}
+
+	return tempCfg.AuthenticationStrategy, nil
 }
 
 // NewService creates a named v2.Service from yaml bytes
@@ -100,19 +136,51 @@ func NewService(svcName string, svcYAML *serviceYAML) (*Service, error) {
 		return nil, err
 	}
 
-	svc := &Service{
-		Credentials:    credentials,
-		ListenOn:       svcYAML.ListenOn,
-		Name:           svcName,
-		Protocol:       svcYAML.Protocol,
-		ProtocolConfig: nil,
-	}
-
-	configBytes, err := yaml.Marshal(svcYAML.Config)
+	connectorConfigBytes, err := yaml.Marshal(svcYAML.Config)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to parse 'config' key for service '%s': %s", svcName, err)
 	}
-	svc.ProtocolConfig = configBytes
 
-	return svc, nil
+	hasConnector := svcYAML.Connector != ""
+	hasProtocol := svcYAML.Protocol != ""
+
+	// Both connector and protocol given
+	if hasConnector && hasProtocol {
+		log.Printf("WARN: 'connector' and 'protocol' keys found on "+
+			"service '%s'. 'connector' key takes precendence, 'protocol' is "+
+			"deprecated.", svcName)
+	}
+
+	var connector string
+
+	// Connector given, always takes precedence
+	if hasConnector {
+		connector = svcYAML.Connector
+
+	// Only use protocol when connector not given
+	} else if hasProtocol {
+		connector = svcYAML.Protocol
+
+	// Neither given
+	} else {
+		return nil, fmt.Errorf("missing 'connector' key on service '%s'", svcName)
+	}
+
+	// When only the deprecated 'protocol' field
+	// is given and it equals 'http' the connector name
+	// must be extracted from the http config
+	if !hasConnector && hasProtocol && connector == "http" {
+		connector, err = connectorFromLegacyHTTPConfig(connectorConfigBytes)
+		if err != nil {
+			return nil, fmt.Errorf("error on http config for service '%s': %s", svcName, err)
+		}
+	}
+
+	return &Service{
+		Credentials:     credentials,
+		ListenOn:        svcYAML.ListenOn,
+		Name:            svcName,
+		Connector:       connector,
+		ConnectorConfig: connectorConfigBytes,
+	}, nil
 }

--- a/pkg/secretless/config/v2/config_http_test.go
+++ b/pkg/secretless/config/v2/config_http_test.go
@@ -1,0 +1,66 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHTTPConfig(t *testing.T) {
+	t.Run("http config hydration with 'authenticateURLsMatching' string", func(t *testing.T) {
+		configFileContents := []byte(
+			`
+authenticateURLsMatching: "*"
+`)
+		cfg, _ := newHTTPConfig(configFileContents)
+		assert.Equal(t, cfg.AuthenticateURLsMatching, []string{"*"})
+	})
+
+	t.Run("http config hydration with 'authenticateURLsMatching' string list", func(t *testing.T) {
+		configFileContents := []byte(
+			`
+authenticateURLsMatching: 
+ - "*"
+`)
+		cfg, _ := newHTTPConfig(configFileContents)
+		assert.Equal(t, cfg.AuthenticateURLsMatching, []string{"*"})
+	})
+
+	t.Run("error on bad type for 'authenticateURLsMatching' list", func(t *testing.T) {
+		configFileContents := []byte(
+			`
+authenticateURLsMatching: 
+ - true
+ - "meow"
+`)
+		_, err := newHTTPConfig(configFileContents)
+		assert.Error(t, err)
+	})
+
+	t.Run("error on bad type for 'authenticateURLsMatching' scalar", func(t *testing.T) {
+		configFileContents := []byte(
+			`
+authenticateURLsMatching: false
+`)
+		_, err := newHTTPConfig(configFileContents)
+		assert.Error(t, err)
+	})
+
+	t.Run("error on invalid file contents", func(t *testing.T) {
+		configFileContents := []byte(
+`
+{
+"x": false
+}
+`)
+		_, err := newHTTPConfig(configFileContents)
+		assert.Error(t, err)
+	})
+
+	t.Run("error on blank file contents", func(t *testing.T) {
+		configFileContents := []byte("")
+		_, err := NewConfig(configFileContents)
+		assert.Error(t, err)
+	})
+
+}

--- a/pkg/secretless/config/v2/config_test.go
+++ b/pkg/secretless/config/v2/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const sampleConfigStr = `
+const sampleConfigWithProtocolStr = `
 version: 2
 services:
   postgres-db:
@@ -22,10 +22,55 @@ services:
         get: USERNAME
     config:  # this section usually blank
       optionalStuff: blah
+  aws-proxy:
+    protocol: http
+    listenOn: tcp://0.0.0.0:8080
+    credentials:
+      accessKeyId:
+        from: env
+        get: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        from: env
+        get: AWS_SECRET_ACCESS_KEY
+    config:
+      authenticationStrategy: aws
+      authenticateURLsMatching:
+        - .*
 `
 
-func sampleConfig() (*Config, error) {
-	configFileContents := []byte(sampleConfigStr)
+const sampleConfigWithConnectorStr = `
+version: 2
+services:
+  postgres-db:
+    connector: pg
+    listenOn: tcp://0.0.0.0:5432 # can be a socket as well (same name for both)
+    credentials:
+      host: postgres.my-service.internal
+      password:
+        from: vault
+        get: name-in-vault
+      username:
+        from: env
+        get: USERNAME
+    config:  # this section usually blank
+      optionalStuff: blah
+  aws-proxy:
+    connector: aws
+    listenOn: tcp://0.0.0.0:8080
+    credentials:
+      accessKeyId:
+        from: env
+        get: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        from: env
+        get: AWS_SECRET_ACCESS_KEY
+    config:
+      authenticateURLsMatching:
+        - .*
+`
+
+func sampleConfig(contents string) (*Config, error) {
+	configFileContents := []byte(contents)
 	return NewConfig(configFileContents)
 }
 
@@ -42,37 +87,54 @@ func TestNewConfig(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("basic hydration", func(t *testing.T) {
-		cfg, err := sampleConfig()
+	RunNewConfigTestCases(t, "with-protocol", sampleConfigWithProtocolStr)
+	RunNewConfigTestCases(t, "with-connector", sampleConfigWithConnectorStr)
+}
+
+func RunNewConfigTestCases(t *testing.T, label string, sampleContents string) {
+	t.Run(label + ": basic hydration", func(t *testing.T) {
+		cfg, err := sampleConfig(sampleContents)
 		assert.NoError(t, err)
 		if err != nil {
 			return
 		}
 
-		assert.Equal(t, "postgres-db", cfg.Services[0].Name)
-		assert.Equal(t, "pg", cfg.Services[0].Protocol)
-		assert.Equal(t, "tcp://0.0.0.0:5432", cfg.Services[0].ListenOn)
+		assert.Equal(t, "postgres-db", cfg.Services[1].Name)
+		assert.Equal(t, "pg", cfg.Services[1].Connector)
+		assert.Equal(t, "tcp://0.0.0.0:5432", cfg.Services[1].ListenOn)
 	})
 
-	t.Run("config hydration", func(t *testing.T) {
-		cfg, err := sampleConfig()
+	t.Run(label + ": config hydration", func(t *testing.T) {
+		cfg, err := sampleConfig(sampleContents)
 		assert.NoError(t, err)
 		if err != nil {
 			return
 		}
 
 		expectedBytes := []byte("optionalStuff: blah\n")
-		assert.Equal(t, expectedBytes, cfg.Services[0].ProtocolConfig)
+		assert.Equal(t, expectedBytes, cfg.Services[1].ConnectorConfig)
 	})
 
-	t.Run("credential hydration", func(t *testing.T) {
-		cfg, err := sampleConfig()
+	t.Run(label + ": http hydration", func(t *testing.T) {
+		cfg, err := sampleConfig(sampleContents)
 		assert.NoError(t, err)
 		if err != nil {
 			return
 		}
 
-		actualCreds := cfg.Services[0].Credentials
+		assert.Equal(t, "aws-proxy", cfg.Services[0].Name)
+		assert.Equal(t, "aws", cfg.Services[0].Connector)
+		assert.Equal(t, "tcp://0.0.0.0:8080", cfg.Services[0].ListenOn)
+	})
+
+	t.Run(label + ": credential hydration", func(t *testing.T) {
+		cfg, err := sampleConfig(sampleContents)
+		assert.NoError(t, err)
+		if err != nil {
+			return
+		}
+
+		actualCreds := cfg.Services[1].Credentials
 		expectedCreds := []*Credential{
 			{
 				Name: "host",

--- a/pkg/secretless/config/v2/config_yaml.go
+++ b/pkg/secretless/config/v2/config_yaml.go
@@ -11,7 +11,14 @@ type configYAML struct {
 }
 
 type serviceYAML struct {
+	// Protocol specifies the service connector by protocol.
+	// It is an internal detail.
+	//
+	// Deprecated: Protocol exists for historical compatibility
+	// and should not be used. To specify the service connector,
+	// use the Connector field.
 	Protocol    string          `yaml:"protocol" json:"protocol"`
+	Connector   string          `yaml:"connector" json:"connector"`
 	ListenOn    string          `yaml:"listenOn" json:"listenOn"`
 	Credentials credentialsYAML `yaml:"credentials" json:"credentials"`
 	Config      interface{}     `yaml:"config" json:"config"`

--- a/pkg/secretless/config/v2/doc.go
+++ b/pkg/secretless/config/v2/doc.go
@@ -12,7 +12,7 @@ demonstrates all the features of a v2 yaml file:
     version: 2
     services:
       http_basic_auth:
-        protocol: http
+        connector: basic_auth
         listenOn: tcp://0.0.0.0:8080
         credentials:
           username: someuser
@@ -20,7 +20,6 @@ demonstrates all the features of a v2 yaml file:
             from: conjur
             get: testpassword
           config:
-            authenticationStrategy: basic_auth
             authenticateURLsMatching:
               - ^http.
 

--- a/test/aws_handler/secretless.yml
+++ b/test/aws_handler/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   http-aws:
-    protocol: http
+    connector: aws
     listenOn: tcp://0.0.0.0:80
     credentials:
       accessKeyId:
@@ -12,6 +12,5 @@ services:
         from: env
         get: AWS_SECRET_ACCESS_KEY
     config:
-      authenticationStrategy: aws
       authenticateURLsMatching:
         - ".*"

--- a/test/conjur/secretless.dev.yml
+++ b/test/conjur/secretless.dev.yml
@@ -2,13 +2,12 @@ version: 2
 
 services:
   conjur-http:
-    protocol: http
+    connector: conjur
     listenOn: tcp://0.0.0.0:1080
     credentials:
       accessToken:
         from: conjur
         get: accessToken
     config:
-      authenticationStrategy: conjur
       authenticateURLsMatching:
         - ".*"

--- a/test/conjur/secretless.yml
+++ b/test/conjur/secretless.yml
@@ -2,13 +2,12 @@ version: 2
 
 services:
   conjur-http:
-    protocol: http
+    connector: conjur
     listenOn: tcp://0.0.0.0:8080
     credentials:
       accessToken:
         from: conjur
         get: accessToken
     config:
-      authenticationStrategy: conjur
       authenticateURLsMatching:
         - ^http\:\/\/conjur\/

--- a/test/http_basic_auth/secretless.yml
+++ b/test/http_basic_auth/secretless.yml
@@ -2,23 +2,21 @@ version: 2
 
 services:
   http_good_basic_auth:
-    protocol: http
+    connector: basic_auth
     listenOn: tcp://0.0.0.0:8080
     credentials:
       username: someuser
       password: testpassword
     config:
-      authenticationStrategy: basic_auth
       authenticateURLsMatching:
         - ^http.
 
   http_bad_basic_auth:
-    protocol: http
+    connector: basic_auth
     listenOn: tcp://0.0.0.0:8081
     credentials:
       username: someuser
       password: notthecorrectpassword
     config:
-      authenticationStrategy: basic_auth
       authenticateURLsMatching:
        - ^http.

--- a/test/plugin/secretless.dev.yml
+++ b/test/plugin/secretless.dev.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   echo_tcp:
-    protocol: echo
+    connector: echo
     listenOn: tcp://0.0.0.0:6175
     credentials:
       host: localhost
@@ -12,7 +12,7 @@ services:
         get: exampleVariable
 
   echo_denied_tcp:
-    protocol: echo
+    connector: echo
     listenOn: tcp://0.0.0.0:6176
     credentials:
       host: localhost

--- a/test/plugin/secretless.yml
+++ b/test/plugin/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   echo_tcp:
-    protocol: echo
+    connector: echo
     listenOn: tcp://0.0.0.0:6175
     credentials:
       port: 6174
@@ -14,7 +14,7 @@ services:
         get: exampleVariable
 
   echo_denied_tcp:
-    protocol: echo
+    connector: echo
     listenOn: tcp://0.0.0.0:6176
     credentials:
       port: 6174

--- a/test/ssh_agent_handler/secretless.dev.yml
+++ b/test/ssh_agent_handler/secretless.dev.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   sshagent:
-    protocol: ssh-agent
+    connector: ssh-agent
     listenOn: unix:///sock/.agent
     credentials:
       rsa:

--- a/test/ssh_agent_handler/secretless.yml
+++ b/test/ssh_agent_handler/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   sshagent:
-    protocol: ssh-agent
+    connector: ssh-agent
     listenOn: unix:///sock/.agent
     credentials:
       rsa:

--- a/test/ssh_handler/secretless.yml
+++ b/test/ssh_handler/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   ssh:
-    protocol: ssh
+    connector: ssh
     listenOn: tcp://0.0.0.0:2222
     credentials:
       privateKey:


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
1. Configuration adds support for universal `connector` spec.
1. Maintains backwards compatibility with `protocol` spec and http `authenticationStrategy`.
1. Adds unit test cases for `connector` spec.
1. References to protocol and/or authenticationStrategy in tests and sample configuration files in the main project repo are updated to use the single connector reference instead

#### What ticket does this PR close?
Connected to https://github.com/cyberark/secretless-broker/issues/826
#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
