### PR TITLE
update docs to connector vs protocol

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -271,7 +271,7 @@ replace `<GOOS>/<GOARCH>` with your particular operating system and compilation 
    version: "2"
    services:
      pg_tcp:
-       protocol: pg
+       connector: pg
        listenOn: tcp://0.0.0.0:15432
        credentials:
          host:

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ Write a `secretless.yml` file that includes:
 version: "2"
 services:
   pg-db:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:4321
     credentials:
       host: localhost

--- a/bin/juxtaposer/README.md
+++ b/bin/juxtaposer/README.md
@@ -95,7 +95,7 @@ performance._
 version: 2
 services:
   mysql-socket:
-    protocol: mysql
+    connector: mysql
     listenOn: unix:///tmp/mysql
     credentials:
       username: myuser
@@ -105,7 +105,7 @@ services:
       sslmode: disable
 
   pg-socket:
-    protocol: pg
+    connector: pg
     listenOn: unix:///tmp/.s.PGSQL.5432
     credentials:
       username: myuser

--- a/bin/juxtaposer/deploy/secretless.yml
+++ b/bin/juxtaposer/deploy/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   mysql-tcp:
-    protocol: mysql
+    connector: mysql
     listenOn: tcp://0.0.0.0:13306
     credentials:
       username:
@@ -19,7 +19,7 @@ services:
         get: secretless-xa-db/mysql/port
 
   mysql-sock:
-    protocol: mysql
+    connector: mysql
     listenOn: unix:///sock/mysql
     credentials:
       username:
@@ -36,7 +36,7 @@ services:
         get: secretless-xa-db/mysql/port
 
   pg-tcp:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:15432
     credentials:
       username:
@@ -50,7 +50,7 @@ services:
         get: secretless-xa-db/postgresql/hostname
 
   pg-sock:
-    protocol: pg
+    connector: pg
     listenOn: unix:///sock/.s.PGSQL.5432
     credentials:
       username:

--- a/demos/k8s-demo/etc/secretless.yml
+++ b/demos/k8s-demo/etc/secretless.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   quick-start-postgres:
-    protocol: pg
+    connector: pg
     listenOn: tcp://localhost:5432
     credentials:
       address:

--- a/demos/quick-start/docker/etc/secretless.yml
+++ b/demos/quick-start/docker/etc/secretless.yml
@@ -1,7 +1,7 @@
 version: "2"
 services:
   quick-start-postgres:
-    protocol: pg
+    connector: pg
     debug: true
     listenOn: tcp://0.0.0.0:5454
     credentials:
@@ -14,7 +14,7 @@ services:
         get: QUICKSTART_PASSWORD
 
   quick-start-ssh:
-    protocol: ssh
+    connector: ssh
     listenOn: tcp://0.0.0.0:2222
     credentials:
       address: localhost
@@ -24,7 +24,7 @@ services:
         get: SSH_PRIVATE_KEY
 
   quick-start-basic-auth:
-    protocol: http
+    connector: basic_auth
     listenOn: tcp://0.0.0.0:8081
     credentials:
       username:
@@ -34,7 +34,6 @@ services:
         from: env
         get: BASIC_AUTH_PASSWORD
     config:
-      authenticationStrategy: basic_auth
       authenticateURLsMatching:
         - ^http\:\/\/quickstart\/
         - ^http\:\/\/localhost.*

--- a/design/simpler-configuration.md
+++ b/design/simpler-configuration.md
@@ -137,7 +137,7 @@ services:
   ###
 
   postgres-db:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:5432 # can be a socket as well (same name for both)
     credentials:
       host: postgres.my-service.internal
@@ -154,12 +154,11 @@ services:
   # http handler example
   ###
       
-  # the config for the http protocol has two required values:
-  #   `authenticationStrategy` which indicates which specific http protocol implementation to use (eg `type`)
+  # the config for the http protocol has one required value:
   #   `authenticateURLsMatching` which gives a regex pattern for request URIs that use Secretless for auth (eg `match`)
   
   aws-client:
-    protocol: http
+    connector: http
     listenOn: unix:///var/docker/docker.sock
     credentials:
       accessKeyID:
@@ -172,11 +171,10 @@ services:
         from: conjur
         get: id-of-secret-in-conjur
     config:
-      authenticationStrategy: aws
       authenticateURLsMatching: ^http.*
 
   conjur-client:
-    protocol: http
+    connector: http
     listenOn: http://127.0.0.1:8080
     credentials:
       accessToken:
@@ -184,7 +182,6 @@ services:
         get: /path/to/file
       forceSSL: true
     config:
-      authenticationStrategy: conjur
       authenticateURLsMatching: ^http://srdjan.com*
 
   ###
@@ -192,7 +189,7 @@ services:
   ###
 
   ssh-proxy:
-    protocol: ssh
+    connector: ssh
     listenOn: tcp://0.0.0.0:2222
     credentials:
       address: "localhost"

--- a/design/tls-support-plan.md
+++ b/design/tls-support-plan.md
@@ -254,7 +254,7 @@ depend on your use case.
 version: "2"
 services:
   pg_connector:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:5432
     credentials:
       host: postgres.my-service.internal
@@ -269,7 +269,7 @@ services:
 version: "2"
 services:
   pg_connector:
-    protocol: pg
+    connector: pg
     listenOn: tcp://0.0.0.0:5432
     credentials:
       host: postgres.my-service.internal
@@ -300,7 +300,7 @@ services:
 version: "2"
 services:
   pg_connector:
-    protocol: pg
+    connector: pg
     listenOn: unix:///sock/.s.PGSQL.5432
     credentials:
       host: postgres.my-service.internal

--- a/docs/_posts/2018-09-21-configuration-with-custom-resources.md
+++ b/docs/_posts/2018-09-21-configuration-with-custom-resources.md
@@ -23,7 +23,7 @@ Broker should be running. Your `secretless.yml` might look something like:
 version: "2"
 services:
   my_webapp_connector:
-    protocol: http
+    connector: basic_auth
     listenOn: tcp://0.0.0.0:8080
     credentials:
       username:
@@ -33,7 +33,6 @@ services:
         from: env
         get: WEBAPP_PASSWORD
     config:
-      authenticationStrategy: basic_auth
       authenticateURLsMatching:
         - ^http.*
 ```

--- a/docs/tutorials/kubernetes/sec-admin.md
+++ b/docs/tutorials/kubernetes/sec-admin.md
@@ -373,7 +373,7 @@ cat << EOF > secretless.yml
 version: "2"
 services:
   pets-pg:
-    protocol: pg
+    connector: pg
     listenOn: tcp://localhost:5432
     credentials:
       host:

--- a/pkg/secretless/config/v2/config.go
+++ b/pkg/secretless/config/v2/config.go
@@ -2,6 +2,7 @@ package v2
 
 import (
 	"fmt"
+	"log"
 	"sort"
 
 	validation "github.com/go-ozzo/ozzo-validation"
@@ -157,15 +158,15 @@ func NewService(svcName string, svcYAML *serviceYAML) (*Service, error) {
 				return nil, fmt.Errorf("error on http config for service '%s': %s", svcName, err)
 			}
 		}
+	} else if svcYAML.Protocol != "" {
+		log.Printf("WARN: 'connector' and 'protocol' keys found on service '%s'. 'connector' key takes precendence, 'protocol' is deprecated.", svcName)
 	}
 
-	svc := &Service{
+	return &Service{
 		Credentials:     credentials,
 		ListenOn:        svcYAML.ListenOn,
 		Name:            svcName,
 		Connector:       connector,
 		ConnectorConfig: connectorConfigBytes,
-	}
-
-	return svc, nil
+	}, nil
 }

--- a/pkg/secretless/config/v2/config_http.go
+++ b/pkg/secretless/config/v2/config_http.go
@@ -2,22 +2,29 @@ package v2
 
 import (
 	"errors"
-
 	"github.com/go-ozzo/ozzo-validation"
 	"gopkg.in/yaml.v2"
 )
 
 type httpConfig struct {
-	AuthenticationStrategy   string   `yaml:"authenticationStrategy"`
 	AuthenticateURLsMatching []string `yaml:"authenticateURLsMatching"`
 }
 
 // HTTPAuthenticationStrategies are the different ways an http service
 // can authenticate.
-var HTTPAuthenticationStrategies = []string{
+var HTTPAuthenticationStrategies = []interface{}{
 	"aws",
 	"basic_auth",
 	"conjur",
+}
+
+func isHTTPConnector(connector string) bool {
+	for _, strategy := range HTTPAuthenticationStrategies {
+		if strategy == connector {
+			return true
+		}
+	}
+	return false
 }
 
 func newHTTPConfig(cfgBytes []byte) (*httpConfig, error) {
@@ -36,49 +43,44 @@ func newHTTPConfig(cfgBytes []byte) (*httpConfig, error) {
 }
 
 func (cfg *httpConfig) UnmarshalYAML(bytes []byte) error {
-	err := yaml.Unmarshal(bytes, cfg)
-
-	// A string type is converted into [] by default, so we must verify length.
-	// If this passes, all is good and we can return.
-	if ok := err == nil && len(cfg.AuthenticateURLsMatching) > 0; ok {
-		return nil
-	}
-
-	// Unmarshall into a temp struct that expects a string
+	// Unmarshall into a temp struct
+	//
+	// This temp struct makes it possible to parse 'authenticateURLsMatching' as
+	// string or []string
 	tempCfg := &struct {
-		AuthenticationStrategy   string `yaml:"authenticationStrategy"`
-		AuthenticateURLsMatching string `yaml:"authenticateURLsMatching"`
+		AuthenticateURLsMatching interface{} `yaml:"authenticateURLsMatching"`
 	}{}
-	err = yaml.Unmarshal(bytes, tempCfg)
-
-	// It must succeed with a non-empty string
-	if ok := err == nil && len(tempCfg.AuthenticateURLsMatching) > 0; !ok {
-		return errors.New("http ProtocolConfig could not be parsed")
+	err := yaml.Unmarshal(bytes, tempCfg)
+	if err != nil {
+		return errors.New("http ConnectorConfig could not be parsed")
 	}
 
-	// It's a string, let's convert it to a []string
-	cfg.AuthenticationStrategy = tempCfg.AuthenticationStrategy
-	cfg.AuthenticateURLsMatching = []string{ tempCfg.AuthenticateURLsMatching }
+	// Populate actual http config from tempCfg
+	switch v := tempCfg.AuthenticateURLsMatching.(type) {
+	case string:
+		cfg.AuthenticateURLsMatching = []string{ v }
+	case []interface{}:
+		urlMatchStrings := make([]string, len(v))
+		for urlMatchIndex, urlMatch := range v {
+			urlMatchString, ok := urlMatch.(string)
+			if !ok {
+				return errors.New("'authenticateURLsMatching' key has incorrect type, must be a string or list of strings")
+			}
+			urlMatchStrings[urlMatchIndex] = urlMatchString
+		}
+
+		cfg.AuthenticateURLsMatching = urlMatchStrings
+	default:
+		return errors.New("'authenticateURLsMatching' key has incorrect type, must be a string or list of strings")
+	}
 
 	return nil
 }
 
-// validate ensures AuthenticationStrategy neither field is empty, and that
-// AuthentcationStrategy is a valid value
+// validate ensures AuthenticationStrategy neither field is empty
 func (cfg *httpConfig) validate() error {
-	// convert strategies from []string to []interface{} for validation.In
-	var availStrategies []interface{}
-	for _, s := range HTTPAuthenticationStrategies {
-		availStrategies = append(availStrategies, s)
-	}
-
 	return validation.ValidateStruct(
 		cfg,
-		validation.Field(
-			&cfg.AuthenticationStrategy,
-			validation.Required,
-			validation.In(availStrategies...),
-		),
 		// AuthenticateURLsMatching cannot be empty
 		validation.Field(&cfg.AuthenticateURLsMatching, validation.Required),
 	)

--- a/pkg/secretless/config/v2/config_http.go
+++ b/pkg/secretless/config/v2/config_http.go
@@ -77,7 +77,8 @@ func (cfg *httpConfig) UnmarshalYAML(bytes []byte) error {
 	return nil
 }
 
-// validate ensures AuthenticationStrategy neither field is empty
+// validate carries out validation of httpConfig
+// ensuring that the validation rules of fields are met
 func (cfg *httpConfig) validate() error {
 	return validation.ValidateStruct(
 		cfg,

--- a/pkg/secretless/config/v2/config_http_test.go
+++ b/pkg/secretless/config/v2/config_http_test.go
@@ -10,7 +10,6 @@ func TestNewHTTPConfig(t *testing.T) {
 	t.Run("http config hydration with 'authenticateURLsMatching' string", func(t *testing.T) {
 		configFileContents := []byte(
 			`
-authenticationStrategy: aws
 authenticateURLsMatching: "*"
 `)
 		cfg, _ := newHTTPConfig(configFileContents)
@@ -20,7 +19,6 @@ authenticateURLsMatching: "*"
 	t.Run("http config hydration with 'authenticateURLsMatching' string list", func(t *testing.T) {
 		configFileContents := []byte(
 			`
-authenticationStrategy: aws
 authenticateURLsMatching: 
  - "*"
 `)
@@ -31,7 +29,6 @@ authenticateURLsMatching:
 	t.Run("error on bad type for 'authenticateURLsMatching' list", func(t *testing.T) {
 		configFileContents := []byte(
 			`
-authenticationStrategy: aws
 authenticateURLsMatching: 
  - true
  - "meow"
@@ -43,7 +40,6 @@ authenticateURLsMatching:
 	t.Run("error on bad type for 'authenticateURLsMatching' scalar", func(t *testing.T) {
 		configFileContents := []byte(
 			`
-authenticationStrategy: aws
 authenticateURLsMatching: false
 `)
 		_, err := newHTTPConfig(configFileContents)

--- a/pkg/secretless/config/v2/config_http_test.go
+++ b/pkg/secretless/config/v2/config_http_test.go
@@ -1,0 +1,70 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewHTTPConfig(t *testing.T) {
+	t.Run("http config hydration with 'authenticateURLsMatching' string", func(t *testing.T) {
+		configFileContents := []byte(
+			`
+authenticationStrategy: aws
+authenticateURLsMatching: "*"
+`)
+		cfg, _ := newHTTPConfig(configFileContents)
+		assert.Equal(t, cfg.AuthenticateURLsMatching, []string{"*"})
+	})
+
+	t.Run("http config hydration with 'authenticateURLsMatching' string list", func(t *testing.T) {
+		configFileContents := []byte(
+			`
+authenticationStrategy: aws
+authenticateURLsMatching: 
+ - "*"
+`)
+		cfg, _ := newHTTPConfig(configFileContents)
+		assert.Equal(t, cfg.AuthenticateURLsMatching, []string{"*"})
+	})
+
+	t.Run("error on bad type for 'authenticateURLsMatching' list", func(t *testing.T) {
+		configFileContents := []byte(
+			`
+authenticationStrategy: aws
+authenticateURLsMatching: 
+ - true
+ - "meow"
+`)
+		_, err := newHTTPConfig(configFileContents)
+		assert.Error(t, err)
+	})
+
+	t.Run("error on bad type for 'authenticateURLsMatching' scalar", func(t *testing.T) {
+		configFileContents := []byte(
+			`
+authenticationStrategy: aws
+authenticateURLsMatching: false
+`)
+		_, err := newHTTPConfig(configFileContents)
+		assert.Error(t, err)
+	})
+
+	t.Run("error on invalid file contents", func(t *testing.T) {
+		configFileContents := []byte(
+`
+{
+"x": false
+}
+`)
+		_, err := newHTTPConfig(configFileContents)
+		assert.Error(t, err)
+	})
+
+	t.Run("error on blank file contents", func(t *testing.T) {
+		configFileContents := []byte("")
+		_, err := NewConfig(configFileContents)
+		assert.Error(t, err)
+	})
+
+}

--- a/pkg/secretless/config/v2/config_test.go
+++ b/pkg/secretless/config/v2/config_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const sampleConfigStr = `
+const sampleConfigWithProtocolStr = `
 version: 2
 services:
   postgres-db:
@@ -22,10 +22,55 @@ services:
         get: USERNAME
     config:  # this section usually blank
       optionalStuff: blah
+  aws-proxy:
+    protocol: http
+    listenOn: tcp://0.0.0.0:8080
+    credentials:
+      accessKeyId:
+        from: env
+        get: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        from: env
+        get: AWS_SECRET_ACCESS_KEY
+    config:
+      authenticationStrategy: aws
+      authenticateURLsMatching:
+        - .*
 `
 
-func sampleConfig() (*Config, error) {
-	configFileContents := []byte(sampleConfigStr)
+const sampleConfigWithConnectorStr = `
+version: 2
+services:
+  postgres-db:
+    connector: pg
+    listenOn: tcp://0.0.0.0:5432 # can be a socket as well (same name for both)
+    credentials:
+      host: postgres.my-service.internal
+      password:
+        from: vault
+        get: name-in-vault
+      username:
+        from: env
+        get: USERNAME
+    config:  # this section usually blank
+      optionalStuff: blah
+  aws-proxy:
+    connector: aws
+    listenOn: tcp://0.0.0.0:8080
+    credentials:
+      accessKeyId:
+        from: env
+        get: AWS_ACCESS_KEY_ID
+      secretAccessKey:
+        from: env
+        get: AWS_SECRET_ACCESS_KEY
+    config:
+      authenticateURLsMatching:
+        - .*
+`
+
+func sampleConfig(contents string) (*Config, error) {
+	configFileContents := []byte(contents)
 	return NewConfig(configFileContents)
 }
 
@@ -42,37 +87,54 @@ func TestNewConfig(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("basic hydration", func(t *testing.T) {
-		cfg, err := sampleConfig()
+	RunNewConfigTestCases(t, "with-protocol", sampleConfigWithProtocolStr)
+	RunNewConfigTestCases(t, "with-connector", sampleConfigWithConnectorStr)
+}
+
+func RunNewConfigTestCases(t *testing.T, label string, sampleContents string) {
+	t.Run(label + ": basic hydration", func(t *testing.T) {
+		cfg, err := sampleConfig(sampleContents)
 		assert.NoError(t, err)
 		if err != nil {
 			return
 		}
 
-		assert.Equal(t, "postgres-db", cfg.Services[0].Name)
-		assert.Equal(t, "pg", cfg.Services[0].Protocol)
-		assert.Equal(t, "tcp://0.0.0.0:5432", cfg.Services[0].ListenOn)
+		assert.Equal(t, "postgres-db", cfg.Services[1].Name)
+		assert.Equal(t, "pg", cfg.Services[1].Connector)
+		assert.Equal(t, "tcp://0.0.0.0:5432", cfg.Services[1].ListenOn)
 	})
 
-	t.Run("config hydration", func(t *testing.T) {
-		cfg, err := sampleConfig()
+	t.Run(label + ": config hydration", func(t *testing.T) {
+		cfg, err := sampleConfig(sampleContents)
 		assert.NoError(t, err)
 		if err != nil {
 			return
 		}
 
 		expectedBytes := []byte("optionalStuff: blah\n")
-		assert.Equal(t, expectedBytes, cfg.Services[0].ProtocolConfig)
+		assert.Equal(t, expectedBytes, cfg.Services[1].ConnectorConfig)
 	})
 
-	t.Run("credential hydration", func(t *testing.T) {
-		cfg, err := sampleConfig()
+	t.Run(label + ": http hydration", func(t *testing.T) {
+		cfg, err := sampleConfig(sampleContents)
 		assert.NoError(t, err)
 		if err != nil {
 			return
 		}
 
-		actualCreds := cfg.Services[0].Credentials
+		assert.Equal(t, "aws-proxy", cfg.Services[0].Name)
+		assert.Equal(t, "aws", cfg.Services[0].Connector)
+		assert.Equal(t, "tcp://0.0.0.0:8080", cfg.Services[0].ListenOn)
+	})
+
+	t.Run(label + ": credential hydration", func(t *testing.T) {
+		cfg, err := sampleConfig(sampleContents)
+		assert.NoError(t, err)
+		if err != nil {
+			return
+		}
+
+		actualCreds := cfg.Services[1].Credentials
 		expectedCreds := []*Credential{
 			{
 				Name: "host",

--- a/pkg/secretless/config/v2/config_yaml.go
+++ b/pkg/secretless/config/v2/config_yaml.go
@@ -11,7 +11,14 @@ type configYAML struct {
 }
 
 type serviceYAML struct {
+	// Protocol specifies the service connector by protocol.
+	// It is an internal detail.
+	//
+	// Deprecated: Protocol exists for historical compatibility
+	// and should not be used. To specify the service connector,
+	// use the Connector field.
 	Protocol    string          `yaml:"protocol" json:"protocol"`
+	Connector   string          `yaml:"connector" json:"connector"`
 	ListenOn    string          `yaml:"listenOn" json:"listenOn"`
 	Credentials credentialsYAML `yaml:"credentials" json:"credentials"`
 	Config      interface{}     `yaml:"config" json:"config"`

--- a/pkg/secretless/config/v2/doc.go
+++ b/pkg/secretless/config/v2/doc.go
@@ -12,7 +12,7 @@ demonstrates all the features of a v2 yaml file:
     version: 2
     services:
       http_basic_auth:
-        protocol: http
+        connector: basic_auth
         listenOn: tcp://0.0.0.0:8080
         credentials:
           username: someuser
@@ -20,7 +20,6 @@ demonstrates all the features of a v2 yaml file:
             from: conjur
             get: testpassword
           config:
-            authenticationStrategy: basic_auth
             authenticateURLsMatching:
               - ^http.
 

--- a/pkg/secretless/config/v2/v1_service.go
+++ b/pkg/secretless/config/v2/v1_service.go
@@ -26,10 +26,15 @@ type v1Service struct {
 func newV1Service(v2Svc Service) (ret *v1Service, err error) {
 	// Create basic Service
 
+	protocol := v2Svc.Connector
+	if isHTTPConnector(protocol) {
+		protocol = "http"
+	}
+
 	ret = &v1Service{
 		Listener: &config_v1.Listener{
 			Name:     v2Svc.Name,
-			Protocol: v2Svc.Protocol,
+			Protocol: protocol,
 		},
 		Handler: &config_v1.Handler{
 			Name:         v2Svc.Name,
@@ -71,24 +76,25 @@ func newV1Service(v2Svc Service) (ret *v1Service, err error) {
 
 	// Apply protocol specific config
 
-	if err = ret.applyProtocolConfig(v2Svc.ProtocolConfig); err != nil {
+	if err = ret.applyProtocolConfig(v2Svc); err != nil {
 		return nil, err
 	}
 
 	return ret, nil
 }
 
-func (v1Svc *v1Service) applyProtocolConfig(cfgBytes []byte) error {
+func (v1Svc *v1Service) applyProtocolConfig(v2Svc Service) error {
+	cfgBytes := v2Svc.ConnectorConfig
 	switch v1Svc.Listener.Protocol {
 	case "http":
-		if err := v1Svc.configureHTTP(cfgBytes); err != nil {
+		if err := v1Svc.configureHTTP(v2Svc.Connector, cfgBytes); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (v1Svc *v1Service) configureHTTP(cfgBytes []byte) error {
+func (v1Svc *v1Service) configureHTTP(connectorName string, cfgBytes []byte) error {
 	if len(cfgBytes) == 0 {
 		return fmt.Errorf("empty http config")
 	}
@@ -99,7 +105,7 @@ func (v1Svc *v1Service) configureHTTP(cfgBytes []byte) error {
 	}
 
 	v1Svc.Handler.Match = httpCfg.AuthenticateURLsMatching
-	v1Svc.Handler.Type = httpCfg.AuthenticationStrategy
+	v1Svc.Handler.Type = connectorName
 
 	return nil
 }

--- a/test/aws_handler/secretless.yml
+++ b/test/aws_handler/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   http-aws:
-    protocol: http
+    connector: aws
     listenOn: tcp://0.0.0.0:80
     credentials:
       accessKeyId:
@@ -12,6 +12,5 @@ services:
         from: env
         get: AWS_SECRET_ACCESS_KEY
     config:
-      authenticationStrategy: aws
       authenticateURLsMatching:
         - ".*"

--- a/test/conjur/secretless.dev.yml
+++ b/test/conjur/secretless.dev.yml
@@ -2,13 +2,12 @@ version: 2
 
 services:
   conjur-http:
-    protocol: http
+    connector: conjur
     listenOn: tcp://0.0.0.0:1080
     credentials:
       accessToken:
         from: conjur
         get: accessToken
     config:
-      authenticationStrategy: conjur
       authenticateURLsMatching:
         - ".*"

--- a/test/conjur/secretless.yml
+++ b/test/conjur/secretless.yml
@@ -2,13 +2,12 @@ version: 2
 
 services:
   conjur-http:
-    protocol: http
+    connector: conjur
     listenOn: tcp://0.0.0.0:8080
     credentials:
       accessToken:
         from: conjur
         get: accessToken
     config:
-      authenticationStrategy: conjur
       authenticateURLsMatching:
         - ^http\:\/\/conjur\/

--- a/test/http_basic_auth/secretless.yml
+++ b/test/http_basic_auth/secretless.yml
@@ -2,23 +2,21 @@ version: 2
 
 services:
   http_good_basic_auth:
-    protocol: http
+    connector: basic_auth
     listenOn: tcp://0.0.0.0:8080
     credentials:
       username: someuser
       password: testpassword
     config:
-      authenticationStrategy: basic_auth
       authenticateURLsMatching:
         - ^http.
 
   http_bad_basic_auth:
-    protocol: http
+    connector: basic_auth
     listenOn: tcp://0.0.0.0:8081
     credentials:
       username: someuser
       password: notthecorrectpassword
     config:
-      authenticationStrategy: basic_auth
       authenticateURLsMatching:
        - ^http.

--- a/test/plugin/secretless.dev.yml
+++ b/test/plugin/secretless.dev.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   echo_tcp:
-    protocol: echo
+    connector: echo
     listenOn: tcp://0.0.0.0:6175
     credentials:
       host: localhost
@@ -12,7 +12,7 @@ services:
         get: exampleVariable
 
   echo_denied_tcp:
-    protocol: echo
+    connector: echo
     listenOn: tcp://0.0.0.0:6176
     credentials:
       host: localhost

--- a/test/plugin/secretless.yml
+++ b/test/plugin/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   echo_tcp:
-    protocol: echo
+    connector: echo
     listenOn: tcp://0.0.0.0:6175
     credentials:
       port: 6174
@@ -14,7 +14,7 @@ services:
         get: exampleVariable
 
   echo_denied_tcp:
-    protocol: echo
+    connector: echo
     listenOn: tcp://0.0.0.0:6176
     credentials:
       port: 6174

--- a/test/ssh_agent_handler/secretless.dev.yml
+++ b/test/ssh_agent_handler/secretless.dev.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   sshagent:
-    protocol: ssh-agent
+    connector: ssh-agent
     listenOn: unix:///sock/.agent
     credentials:
       rsa:

--- a/test/ssh_agent_handler/secretless.yml
+++ b/test/ssh_agent_handler/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   sshagent:
-    protocol: ssh-agent
+    connector: ssh-agent
     listenOn: unix:///sock/.agent
     credentials:
       rsa:

--- a/test/ssh_handler/secretless.yml
+++ b/test/ssh_handler/secretless.yml
@@ -2,7 +2,7 @@ version: 2
 
 services:
   ssh:
-    protocol: ssh
+    connector: ssh
     listenOn: tcp://0.0.0.0:2222
     credentials:
       privateKey:


### PR DESCRIPTION
References to protocol and/or authenticationStrategy in tests and sample configuration files in the main project repo are updated to use the single connector reference instead
