### PR TITLE
Added configurable logging subsystem

### DIFF
--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -15,7 +15,7 @@ var defaultOutputBuffer = os.Stdout
 type Logger struct {
 	BackingLogger *stdlib_log.Logger
 	IsDebug       bool
-	Prefix        string
+	prefix        string
 }
 
 // severity is an integer representation of the severity level associated with
@@ -63,7 +63,7 @@ func NewWithOptions(outputBuffer io.Writer, prefix string, isDebug bool) log_api
 	return &Logger{
 		BackingLogger: stdlib_log.New(outputBuffer, "", stdlib_log.LstdFlags),
 		IsDebug:       isDebug,
-		Prefix:        prefix,
+		prefix:        prefix,
 	}
 }
 
@@ -91,6 +91,11 @@ func (logger *Logger) DebugEnabled() bool {
 	return logger.IsDebug
 }
 
+// Prefix returns the prefix that will be prepended to all output messages
+func (logger *Logger) Prefix() string {
+	return logger.prefix
+}
+
 // ---------------------------
 // Main logging methods that funnel all the info here
 
@@ -99,9 +104,9 @@ func (logger *Logger) logf(severityLevel severity, format string, args ...interf
 		return
 	}
 
-	if logger.Prefix != "" {
+	if logger.prefix != "" {
 		format = "%s: " + format
-		args = prependString(logger.Prefix, args...)
+		args = prependString(logger.prefix, args...)
 	}
 
 	logger.BackingLogger.Printf(format, args...)
@@ -112,8 +117,8 @@ func (logger *Logger) logln(severityLevel severity, args ...interface{}) {
 		return
 	}
 
-	if logger.Prefix != "" {
-		args = prependString(logger.Prefix+":", args...)
+	if logger.prefix != "" {
+		args = prependString(logger.prefix+":", args...)
 	}
 
 	logger.BackingLogger.Println(args...)

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -85,6 +85,12 @@ func prependString(prependString string, args ...interface{}) []interface{} {
 	return newArgs
 }
 
+// DebugEnabled returns if the debug logging should be displayed for a particular
+// logger instance
+func (logger *Logger) DebugEnabled() bool {
+	return logger.IsDebug
+}
+
 // ---------------------------
 // Main logging methods that funnel all the info here
 

--- a/internal/pkg/log/log.go
+++ b/internal/pkg/log/log.go
@@ -1,0 +1,201 @@
+package log
+
+import (
+	"io"
+	stdlib_log "log"
+	"os"
+
+	log_api "github.com/cyberark/secretless-broker/pkg/secretless/log"
+)
+
+var defaultOutputBuffer = os.Stdout
+
+// Logger is the main logging object that can be used to log messages to stdout
+// or any other io.Writer. Delegates to `log.Logger` for writing to the buffer.
+type Logger struct {
+	BackingLogger *stdlib_log.Logger
+	IsDebug       bool
+	Prefix        string
+}
+
+// severity is an integer representation of the severity level associated with
+// a logging message.
+type severity uint8
+
+const (
+	// DebugSeverity indicates a debug logging message
+	DebugSeverity severity = iota
+	// InfoSeverity indicates an informational logging message
+	InfoSeverity
+	// WarnSeverity indicates a warning logging message
+	WarnSeverity
+	// ErrorSeverity indicates a critical severity logging message
+	ErrorSeverity
+	// PanicSeverity indicates a severity logging message that is unliekly to be
+	// recovered from
+	PanicSeverity
+)
+
+// severityLevels is a list of all available severity levels. This is a shorthand
+// to work around the fact that Golang cannot `range` over an enum.
+var severityLevels = []severity{
+	DebugSeverity,
+	InfoSeverity,
+	WarnSeverity,
+	ErrorSeverity,
+	PanicSeverity,
+}
+
+// New method instantiates a new logger that we can write things to.
+func New(isDebug bool) log_api.Logger {
+	return NewWithOptions(defaultOutputBuffer, "", isDebug)
+}
+
+// NewForService method instantiates a new logger that includes information about
+// the service itself.
+func NewForService(serviceName string, isDebug bool) log_api.Logger {
+	return NewWithOptions(defaultOutputBuffer, serviceName, isDebug)
+}
+
+// NewWithOptions method instantiates a new logger with all configurable options.
+// This specific constructor is not intended to be used directly by clients.
+func NewWithOptions(outputBuffer io.Writer, prefix string, isDebug bool) log_api.Logger {
+	return &Logger{
+		BackingLogger: stdlib_log.New(outputBuffer, "", stdlib_log.LstdFlags),
+		IsDebug:       isDebug,
+		Prefix:        prefix,
+	}
+}
+
+func (logger *Logger) shouldPrint(severityLevel severity) bool {
+	if !logger.IsDebug && (severityLevel == InfoSeverity || severityLevel == DebugSeverity) {
+		return false
+	}
+
+	return true
+}
+
+func prependString(prependString string, args ...interface{}) []interface{} {
+	newArgs := make([]interface{}, len(args)+1)
+	newArgs[0] = prependString
+	for idx, val := range args {
+		newArgs[idx+1] = val
+	}
+
+	return newArgs
+}
+
+// ---------------------------
+// Main logging methods that funnel all the info here
+
+func (logger *Logger) logf(severityLevel severity, format string, args ...interface{}) {
+	if !logger.shouldPrint(severityLevel) {
+		return
+	}
+
+	if logger.Prefix != "" {
+		format = "%s: " + format
+		args = prependString(logger.Prefix, args...)
+	}
+
+	logger.BackingLogger.Printf(format, args...)
+}
+
+func (logger *Logger) logln(severityLevel severity, args ...interface{}) {
+	if !logger.shouldPrint(severityLevel) {
+		return
+	}
+
+	if logger.Prefix != "" {
+		args = prependString(logger.Prefix+":", args...)
+	}
+
+	logger.BackingLogger.Println(args...)
+}
+
+func (logger *Logger) log(severityLevel severity, args ...interface{}) {
+	logger.logln(severityLevel, args...)
+}
+
+// ---------------------------
+// Specific API implementation
+
+// Debugf prints to stdout a formatted debug-level logging message
+func (logger *Logger) Debugf(format string, args ...interface{}) {
+	logger.logf(DebugSeverity, format, args...)
+}
+
+// Infof prints to stdout a formatted info-level logging message
+func (logger *Logger) Infof(format string, args ...interface{}) {
+	logger.logf(InfoSeverity, format, args...)
+}
+
+// Warnf prints to stdout a formatted warning-level logging message
+func (logger *Logger) Warnf(format string, args ...interface{}) {
+	logger.logf(WarnSeverity, format, args...)
+}
+
+// Errorf prints to stdout a formatted error-level logging message
+func (logger *Logger) Errorf(format string, args ...interface{}) {
+	logger.logf(ErrorSeverity, format, args...)
+}
+
+// Panicf prints to stdout a formatted panic-level logging message
+func (logger *Logger) Panicf(format string, args ...interface{}) {
+	logger.logf(PanicSeverity, format, args...)
+}
+
+// Debugln prints to stdout a debug-level logging message
+func (logger *Logger) Debugln(args ...interface{}) {
+	logger.logln(DebugSeverity, args...)
+}
+
+// Infoln prints to stdout a info-level logging message
+func (logger *Logger) Infoln(args ...interface{}) {
+	logger.logln(InfoSeverity, args...)
+}
+
+// Warnln prints to stdout a warning-level logging message
+func (logger *Logger) Warnln(args ...interface{}) {
+	logger.logln(WarnSeverity, args...)
+}
+
+// Errorln prints to stdout a error-level logging message
+func (logger *Logger) Errorln(args ...interface{}) {
+	logger.logln(ErrorSeverity, args...)
+}
+
+// Panicln prints to stdout a panic-level logging message
+func (logger *Logger) Panicln(args ...interface{}) {
+	logger.logln(PanicSeverity, args...)
+}
+
+// Debug prints to stdout a debug-level logging message. Alias of
+// Debugln method.
+func (logger *Logger) Debug(args ...interface{}) {
+	logger.log(DebugSeverity, args...)
+}
+
+// Info prints to stdout a info-level logging message. Alias of
+// Infoln method.
+func (logger *Logger) Info(args ...interface{}) {
+	logger.log(InfoSeverity, args...)
+}
+
+// Warn prints to stdout a warning-level logging message. Alias of
+// Warnln method.
+func (logger *Logger) Warn(args ...interface{}) {
+	logger.log(WarnSeverity, args...)
+}
+
+// Error prints to stdout a error-level logging message. Alias of
+// Errorn method.
+func (logger *Logger) Error(args ...interface{}) {
+	logger.log(ErrorSeverity, args...)
+}
+
+// Panic prints to stdout a panic-level logging message. Alias of
+// Panicln method.
+func (logger *Logger) Panic(args ...interface{}) {
+	logger.log(PanicSeverity, args...)
+}

--- a/internal/pkg/log/log_test.go
+++ b/internal/pkg/log/log_test.go
@@ -87,6 +87,16 @@ func newOutputTest(methodName string, isDebug bool, prefix string) OutputTest {
 	}
 }
 
+func TestDebugEnabled(t *testing.T) {
+	assert.True(t, New(true).DebugEnabled())
+	assert.True(t, NewForService("abc", true).DebugEnabled())
+	assert.True(t, NewWithOptions(&bytes.Buffer{}, "abc", true).DebugEnabled())
+
+	assert.False(t, New(false).DebugEnabled())
+	assert.False(t, NewForService("abc", false).DebugEnabled())
+	assert.False(t, NewWithOptions(&bytes.Buffer{}, "abc", false).DebugEnabled())
+}
+
 func TestFormattedLogging(t *testing.T) {
 	// Iterate over prefixes and their string representation of the
 	// corresponding regexes

--- a/internal/pkg/log/log_test.go
+++ b/internal/pkg/log/log_test.go
@@ -1,0 +1,188 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var formattedLoggingMethods = []string{
+	"Debugf",
+	"Infof",
+	"Warnf",
+	"Errorf",
+	"Panicf",
+}
+
+var unformattedLoggingMethods = []string{
+	"Debug",
+	"Debugln",
+	"Info",
+	"Infoln",
+	"Warn",
+	"Warnln",
+	"Error",
+	"Errorln",
+	"Panic",
+	"Panicln",
+}
+
+type OutputTest struct {
+	name         string
+	outputMethod reflect.Value
+	outputBuffer *bytes.Buffer
+}
+
+// Datetime string should look something like: `2019/01/01 13:14:15`
+var datetimeRegexString = `\d{4}\/\d{2}\/\d{2} \d{1,2}:\d{2}:\d{2}`
+
+// Formatted string should include a string, int, and a float working
+var formattedArgsResultsRegexString = `aaa stringval bbb 123 ccc 1\.2 ddd\s{1,8}eee`
+
+// Unformatted string should include a string, int, and a float working
+var unformattedArgsResultsRegexString = `stringval 123 1\.234 aaa`
+
+type ExpectedEntry struct {
+	prefix          string
+	expectedContent *regexp.Regexp
+}
+
+func NewExpectedEntry(prefix string, contentRegexString string) *ExpectedEntry {
+	return &ExpectedEntry{
+		prefix:          prefix,
+		expectedContent: regexp.MustCompile(contentRegexString),
+	}
+}
+
+var formattedPrefixMatchers = []*ExpectedEntry{
+	NewExpectedEntry("",
+		"^"+datetimeRegexString+" "+formattedArgsResultsRegexString+"\n"),
+	NewExpectedEntry("prefix",
+		"^"+datetimeRegexString+" prefix: "+formattedArgsResultsRegexString+"\n"),
+}
+
+var unformattedPrefixMatchers = []*ExpectedEntry{
+	NewExpectedEntry("",
+		"^"+datetimeRegexString+" "+unformattedArgsResultsRegexString+"\n"),
+	NewExpectedEntry("prefix",
+		"^"+datetimeRegexString+" prefix: "+unformattedArgsResultsRegexString+"\n"),
+}
+
+func newOutputTest(methodName string, isDebug bool, prefix string) OutputTest {
+	outputBuffer := &bytes.Buffer{}
+	logger := NewWithOptions(outputBuffer, prefix, isDebug)
+
+	loggerType := reflect.ValueOf(logger)
+	methodPointer := loggerType.MethodByName(methodName)
+
+	return OutputTest{
+		name:         methodName,
+		outputMethod: methodPointer,
+		outputBuffer: outputBuffer,
+	}
+}
+
+func TestFormattedLogging(t *testing.T) {
+	// Iterate over prefixes and their string representation of the
+	// corresponding regexes
+	for _, prefixMatcher := range formattedPrefixMatchers {
+		// Iterate over all the logging methods that accept formatting string
+		// as an argument
+		for _, methodName := range formattedLoggingMethods {
+
+			// Iterate over both true and false values of the debug flag
+			for _, isDebug := range []bool{true, false} {
+				// Use the specified prefix, flag, and method name to create a struct
+				// containing all the information needed to run the specific test for
+				// a combination of those parameters
+				testCase := newOutputTest(methodName, isDebug, prefixMatcher.prefix)
+
+				// Create a unique test case for this iteration
+				t.Run(fmt.Sprintf("%s/prefix='%s'/isDebug=%t", testCase.name,
+					prefixMatcher.prefix, isDebug), func(t *testing.T) {
+
+					// Create a list of arguments that we will send to the formatted
+					// logging method. We must use reflect.Value since that's what
+					// the method pointer will expect
+					args := []reflect.Value{
+						reflect.ValueOf("aaa %s bbb %d ccc %2.1f ddd \t eee"),
+						reflect.ValueOf("stringval"),
+						reflect.ValueOf(123),
+						reflect.ValueOf(1.234),
+					}
+
+					// Invoke the specified `logger.<methodName>` with the arguments
+					// defined above
+					testCase.outputMethod.Call(args)
+
+					if !isDebug &&
+						(strings.HasPrefix(methodName, "Debug") ||
+							strings.HasPrefix(methodName, "Info")) {
+						// If we have the debug flag on, expect that debug and
+						// info messages don't show up
+						assert.Empty(t, testCase.outputBuffer.String())
+					} else {
+						// Otherwise assert that the printed output matches
+						// the defined regex
+						assert.Regexp(t, prefixMatcher.expectedContent, testCase.outputBuffer.String())
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestUnformattedLogging(t *testing.T) {
+	// Iterate over prefixes and their string representation of the
+	// corresponding regexes
+	for _, prefixMatcher := range unformattedPrefixMatchers {
+		// Iterate over all the logging methods that accept unformatted list
+		// of arguments
+		for _, methodName := range unformattedLoggingMethods {
+
+			// Iterate over both true and false values of the debug flag
+			for _, isDebug := range []bool{true, false} {
+				// Use the specified prefix, flag, and method name to create a struct
+				// containing all the information needed to run the specific test for
+				// a combination of those parameters
+				testCase := newOutputTest(methodName, isDebug, prefixMatcher.prefix)
+
+				// Create a unique test case for this iteration
+				t.Run(fmt.Sprintf("%s/prefix='%s'/isDebug=%t", testCase.name,
+					prefixMatcher.prefix, isDebug), func(t *testing.T) {
+
+					// Create a list of arguments that we will send to the unformatted
+					// logging method. We must use reflect.Value since that's what
+					// the method pointer will expect
+					args := []reflect.Value{
+						reflect.ValueOf("stringval"),
+						reflect.ValueOf(123),
+						reflect.ValueOf(1.234),
+						reflect.ValueOf("aaa"),
+					}
+
+					// Invoke the specified `logger.<methodName>` with the arguments
+					// defined above
+					testCase.outputMethod.Call(args)
+
+					if !isDebug &&
+						(strings.HasPrefix(methodName, "Debug") ||
+							strings.HasPrefix(methodName, "Info")) {
+						// If we have the debug flag on, expect that debug and
+						// info messages don't show up
+						assert.Empty(t, testCase.outputBuffer.String())
+					} else {
+						// Otherwise assert that the printed output matches
+						// the defined regex
+						assert.Regexp(t, prefixMatcher.expectedContent, testCase.outputBuffer.String())
+					}
+				})
+			}
+		}
+	}
+}

--- a/pkg/secretless/log/log.go
+++ b/pkg/secretless/log/log.go
@@ -4,6 +4,7 @@ package log
 // broker to common output(s).
 type Logger interface {
 	DebugEnabled() bool
+	Prefix() string
 
 	Debug(...interface{})
 	Debugf(string, ...interface{})

--- a/pkg/secretless/log/log.go
+++ b/pkg/secretless/log/log.go
@@ -3,6 +3,8 @@ package log
 // Logger interface is used to emit logging information about the
 // broker to common output(s).
 type Logger interface {
+	DebugEnabled() bool
+
 	Debug(...interface{})
 	Debugf(string, ...interface{})
 	Debugln(...interface{})

--- a/pkg/secretless/log/log.go
+++ b/pkg/secretless/log/log.go
@@ -1,0 +1,25 @@
+package log
+
+// Logger interface is used to emit logging information about the
+// broker to common output(s).
+type Logger interface {
+	Debug(...interface{})
+	Debugf(string, ...interface{})
+	Debugln(...interface{})
+
+	Info(...interface{})
+	Infof(string, ...interface{})
+	Infoln(...interface{})
+
+	Warn(...interface{})
+	Warnf(string, ...interface{})
+	Warnln(...interface{})
+
+	Error(...interface{})
+	Errorf(string, ...interface{})
+	Errorln(...interface{})
+
+	Panic(...interface{})
+	Panicf(string, ...interface{})
+	Panicln(...interface{})
+}


### PR DESCRIPTION
This change adds a configurable logging object that can be used to
display log messages. Currently there are no consumers of this class but
it is intended to be used with the new plugin APIs.

#### What ticket does this PR close?
Connected to #832 

#### Where should the reviewer start?

[Jenkins Build](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/832-logging-subsystem/)

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
