### PR TITLE
Push code coverage data to Jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
-c.out
 bench.*
 debug
 debug.*
@@ -39,3 +38,7 @@ github.com/cyberark/
 
 # Ignore any JSON results files
 results.json
+
+# Ignore test coverage files
+c.out
+coverage.xml

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,9 +30,13 @@ RUN groupadd -r secretless \
 # go-junit-report => Convert go test output to junit xml
 # goconvey => Go testing tool
 # reflex => Utility for watching files and executing process in response to changes
+# gocov => converts native coverage output to gocov's JSON interchange format
+# gocov-xml => converts gocov format to XML for use with Jenkins/Cobertura
 RUN go get -u github.com/jstemmer/go-junit-report && \
     go get github.com/smartystreets/goconvey && \
-    go get github.com/cespare/reflex
+    go get github.com/cespare/reflex && \
+    go get github.com/axw/gocov/gocov && \
+    go get github.com/AlekSi/gocov-xml
 
 # go mod dependency management for the secretless project
 COPY go.mod go.sum /secretless/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,7 @@ pipeline {
             sh './bin/test_unit'
 
             junit 'test/unit-test-output/junit.xml'
+            cobertura autoUpdateHealth: true, autoUpdateStability: true, coberturaReportFile: 'coverage.xml', conditionalCoverageTargets: '30, 0, 0', failUnhealthy: true, failUnstable: false, lineCoverageTargets: '30, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '30, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
             ccCoverage("gocov", "--prefix github.com/cyberark/secretless-broker")
           }
         }

--- a/bin/test_unit
+++ b/bin/test_unit
@@ -42,9 +42,18 @@ set -e
 
 rm -f "$junit_output_dir"/junit.xml
 
+# format test output XML
 docker run --rm \
   --volume "$junit_output_dir"/:/secretless/test/output/ \
   secretless-dev \
   bash -exc "
     cat ./test/output/junit.output | go-junit-report > ./test/output/junit.xml
+  "
+
+# format coverage output XML
+docker run --rm \
+  --volume "$toplevel_dir"/:/secretless/test/output/ \
+  secretless-dev \
+  bash -exc "
+    gocov convert ./test/output/c.out | gocov-xml > ./test/output/coverage.xml
   "


### PR DESCRIPTION
Reformat the default coverage output to Cobertura-compatible XML and publish
to Jenkins

Preview the code coverage report [here](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/add-jenkins-cov-report/)