### PR TITLE
Clarify logger for oren

### DIFF
--- a/internal/pkg/log/log_test.go
+++ b/internal/pkg/log/log_test.go
@@ -60,11 +60,6 @@ func isDebugOnlyMethod(methodName string) bool {
 		strings.HasPrefix(methodName, "Info")
 }
 
-// Format strings and sample arguments used in the test cases
-
-const testCaseFormatStr = "aaa %s bbb %d ccc %2.1f ddd \t eee"
-var testCaseArgs = []interface{}{ "stringval", 123, 1.234 }
-
 // LogTest represents a full test of all output-generating methods on a Logger.
 type LogTest struct {
 	logger logapi.Logger
@@ -82,6 +77,10 @@ func NewLogTest(isDebug bool, prefix string) *LogTest {
 }
 
 func (lt *LogTest) RunAllTests(t *testing.T) {
+
+	// Format strings and sample arguments used in the test cases
+	const testCaseFormatStr = "aaa %s bbb %d ccc %2.1f ddd \t eee"
+	testCaseArgs := []interface{}{ "stringval", 123, 1.234 }
 
 	// Formatted methods
 	for methodName, method := range map[string]logMethodF{

--- a/internal/pkg/log/log_test.go
+++ b/internal/pkg/log/log_test.go
@@ -37,33 +37,6 @@ func TestAllOutputMethods(t *testing.T) {
 	test.RunAllTests(t)
 }
 
-// Methods and types for describing and classifying the methods of a Logger
-
-// Logger methods have two possible signatures: one for "formatted" methods
-// that end in "f" and use "Printf" style format strings, and for normal methods
-// that just print their arguments
-type logMethod func(...interface{})
-type logMethodF func(string, ...interface{})
-
-// methodName elevates the string name of log methods to a proper type. This
-// is good because the behavior of the various log methods can be inferred from
-// their names.
-type methodName string
-
-// Names ending in "f" require a format string
-func (name methodName) requiresFormatString()  bool {
-	// Only formatted methods end in the letter f
-	formattedRe := regexp.MustCompile("f$")
-	return formattedRe.MatchString(string(name))
-}
-
-// debugOnly identifies methods that produce output only when the Logger is in
-// debug mode.
-func (name methodName) debugOnly()  bool {
-	return strings.HasPrefix(string(name), "Debug") ||
-		strings.HasPrefix(string(name), "Info")
-}
-
 // LogTest represents a full test of all output-generating methods on a Logger.
 type LogTest struct {
 	logger logapi.Logger
@@ -170,3 +143,31 @@ func (lt *LogTest) ResetBuffer() {
 func (lt *LogTest) CurrentOutput() string {
 	return lt.backingBuffer.String()
 }
+
+// Methods and types for describing and classifying the methods of a Logger
+
+// Logger methods have two possible signatures: one for "formatted" methods
+// that end in "f" and use "Printf" style format strings, and for normal methods
+// that just print their arguments
+type logMethod func(...interface{})
+type logMethodF func(string, ...interface{})
+
+// methodName elevates the string name of log methods to a proper type. This
+// is good because the behavior of the various log methods can be inferred from
+// their names.
+type methodName string
+
+// Names ending in "f" require a format string
+func (name methodName) requiresFormatString()  bool {
+	// Only formatted methods end in the letter f
+	formattedRe := regexp.MustCompile("f$")
+	return formattedRe.MatchString(string(name))
+}
+
+// debugOnly identifies methods that produce output only when the Logger is in
+// debug mode.
+func (name methodName) debugOnly()  bool {
+	return strings.HasPrefix(string(name), "Debug") ||
+		strings.HasPrefix(string(name), "Info")
+}
+

--- a/internal/pkg/log/log_test.go
+++ b/internal/pkg/log/log_test.go
@@ -96,7 +96,7 @@ func (lt *LogTest) RunAllTests(t *testing.T) {
 	} {
 		lt.ResetBuffer()
 		t.Run(
-			lt.testDescription(methodName),
+			lt.descriptionForTest(methodName),
 			func(t *testing.T) {
 				method(testCaseFormatStr, testCaseArgs...)
 				assert.Regexp(t, lt.expectedOutput(methodName), lt.CurrentOutput())
@@ -119,7 +119,7 @@ func (lt *LogTest) RunAllTests(t *testing.T) {
 	} {
 		lt.ResetBuffer()
 		t.Run(
-			lt.testDescription(methodName),
+			lt.descriptionForTest(methodName),
 			func(t *testing.T) {
 				method(testCaseArgs...)
 				assert.Regexp(t, lt.expectedOutput(methodName), lt.CurrentOutput())
@@ -154,7 +154,7 @@ func (lt *LogTest) expectedOutput(methNameStr string) *regexp.Regexp {
 	return regexp.MustCompile(fullLineRe)
 }
 
-func (lt *LogTest) testDescription(methodName string) string {
+func (lt *LogTest) descriptionForTest(methodName string) string {
 	return fmt.Sprintf(
 		"%s/prefix='%s'/isDebug=%t",
 		methodName,


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?

Improves the clarity of logger tests based on Oren's feedback.

#### Where should the reviewer start?

Be sure to use the "Commits" tag while reviewing, which breaks down the PR and gives specific reasons for each change.