### PR TITLE
Added http and tcp plugin interfaces

### DIFF
--- a/pkg/secretless/plugin/connector/connector_resources.go
+++ b/pkg/secretless/plugin/connector/connector_resources.go
@@ -1,0 +1,17 @@
+package connector
+
+import (
+	"github.com/cyberark/secretless-broker/pkg/secretless/log"
+)
+
+// Resources is an interface that defines what things will
+// be needed by a plugin at runtime.
+type Resources interface {
+	// Config returns the content of addition configuration
+	// parameters passed to the connector.
+	Config() []byte
+
+	// Logger returns an instance of a Logger that can be used
+	// to record logging messages from the plugin.
+	Logger() log.Logger
+}

--- a/pkg/secretless/plugin/connector/http/http.go
+++ b/pkg/secretless/plugin/connector/http/http.go
@@ -1,0 +1,25 @@
+package http
+
+import (
+	"net/http"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
+)
+
+// Plugin is the main interface that HTTP plugins need to implement
+// to be loaded by our codebase.
+type Plugin interface {
+	// PluginInfo contains a key-value map of informational fields
+	// about the plugin.
+	PluginInfo() map[string]string
+
+	// NewConnector creates a new Connector based on the ConnectorResources
+	// passed into it.
+	NewConnector(connector.Resources) Connector
+}
+
+// Connector is the function that will be invoked when a matching
+// request comes in. It uses both the request object and the secrets
+// map to authenticate the client.
+type Connector func(request *http.Request, secrets plugin.SecretsByID) error

--- a/pkg/secretless/plugin/connector/tcp/tcp.go
+++ b/pkg/secretless/plugin/connector/tcp/tcp.go
@@ -1,0 +1,29 @@
+package tcp
+
+import (
+	"net"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
+)
+
+// Plugin is the main interface that TCP plugins need to implement
+// to be loaded by our codebase.
+type Plugin interface {
+	// PluginInfo contains a key-value map of informational fields
+	// about the plugin.
+	PluginInfo() map[string]string
+
+	// NewConnector creates a new Connector based on the ConnectorResources
+	// passed into it.
+	NewConnector(connector.Resources) Connector
+}
+
+// Connector is the function that will be invoked when a matching
+// TCP request comes in. It uses both the initiating connection and the
+// secrets map to authenticate the client, returning the backend
+// network connection.
+type Connector func(
+	clientConn net.Conn,
+	secrets plugin.SecretsByID,
+) (backendConn net.Conn, err error)

--- a/pkg/secretless/plugin/plugin.go
+++ b/pkg/secretless/plugin/plugin.go
@@ -1,0 +1,4 @@
+package plugin
+
+// SecretsByID is a type mapping variable IDs to their values
+type SecretsByID map[string][]byte


### PR DESCRIPTION
Since we have a new way to interact with our plugins, the
interface is the first needed step to initiate the conversion
so this commits adds those for both http and tcp.

#### What ticket does this PR close?
Connected to #852 

#### Where should the reviewer start?
Diff page

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
