### PR TITLE
Added a method to create a new connector Resources interface

### DIFF
--- a/pkg/secretless/plugin/connector/resources.go
+++ b/pkg/secretless/plugin/connector/resources.go
@@ -15,3 +15,28 @@ type Resources interface {
 	// to record logging messages from the plugin.
 	Logger() log.Logger
 }
+
+type _resources struct {
+	config []byte
+	logger log.Logger
+}
+
+func (res *_resources) Config() []byte {
+	return res.config
+}
+
+func (res *_resources) Logger() log.Logger {
+	return res.logger
+}
+
+// NewResources creates a new Resources interface from a backing object struct
+// to be used in invocation of a new Connector
+func NewResources(
+	config []byte,
+	logger log.Logger) Resources {
+
+	return &_resources{
+		config: config,
+		logger: logger,
+	}
+}

--- a/pkg/secretless/plugin/connector/resources_test.go
+++ b/pkg/secretless/plugin/connector/resources_test.go
@@ -1,0 +1,22 @@
+package connector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/internal/pkg/log"
+)
+
+func TestNewResources(t *testing.T) {
+	config := []byte("configvalue")
+	logger := log.New(false)
+
+	// Ensure that the return type is the exact type we expect
+	var resources Resources
+
+	resources = NewResources(config, logger)
+
+	assert.Equal(t, config, resources.Config())
+	assert.Equal(t, logger, resources.Logger())
+}


### PR DESCRIPTION
We now have a way to instantiate a connector Resources interface via a
backing object. This should allow us to easily invoke the NewConnector
methods on plugins.

#### What ticket does this PR close?
Connected to #840

#### Where should the reviewer start?

[Jenkins Build](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/840-connector-resources-int/)

#### What is the status of the manual tests?
N/A

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
