### PR TITLE
Added AvailablePlugins interface

### DIFF
--- a/internal/pkg/plugin/available_plugins.go
+++ b/internal/pkg/plugin/available_plugins.go
@@ -1,0 +1,13 @@
+package plugin
+
+import (
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
+)
+
+// AvailablePlugins is an interface that provides a list of all the available
+// plugins for each type that the broker supports.
+type AvailablePlugins interface {
+	HTTPPlugins() map[string]http.Plugin
+	TCPPlugins() map[string]tcp.Plugin
+}


### PR DESCRIPTION
This interface is used by objects that enumerate the plugins that will
be used during the runtime of the broker. Currently there are no users
of this interface.

#### What ticket does this PR close?
Connected to #883 

#### Where should the reviewer start?

Code diff

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
