### PR TITLE
add deprecation warning for protocol key on v2 config

### DIFF
--- a/demos/k8s-demo/etc/pg.yml
+++ b/demos/k8s-demo/etc/pg.yml
@@ -53,5 +53,4 @@ spec:
   ports:
     - port: 5432
       targetPort: 5432
-      nodePort: 30001
-  type: NodePort
+  type: LoadBalancer

--- a/demos/k8s-demo/etc/quick-start-application.yml
+++ b/demos/k8s-demo/etc/quick-start-application.yml
@@ -54,5 +54,4 @@ spec:
   ports:
   - port: 8080
     targetPort: 8080
-    nodePort: 30002
-  type: NodePort
+  type: LoadBalancer

--- a/pkg/secretless/config/v2/service.go
+++ b/pkg/secretless/config/v2/service.go
@@ -113,6 +113,12 @@ func NewService(svcName string, svcYAML *serviceYAML) (*Service, error) {
 	hasConnector := svcYAML.Connector != ""
 	hasProtocol := svcYAML.Protocol != ""
 
+	// Protocol given
+	if hasProtocol {
+		log.Printf("WARN: 'protocol' key found on service '%s'. 'protocol' is now " +
+		"deprecated and will be removed in a future release.", svcName)
+	}
+
 	// Both connector and protocol given
 	if hasConnector && hasProtocol {
 		log.Printf("WARN: 'connector' and 'protocol' keys found on "+


### PR DESCRIPTION
1. add deprecation warning for protocol key on v2 config
2. use type LoadBalancer on Services in k8s-demo to avoid NodePort conflicts
