### PR TITLE
Add AvailablePlugins module

### DIFF
--- a/internal/plugin/available_plugins.go
+++ b/internal/plugin/available_plugins.go
@@ -1,13 +1,103 @@
 package plugin
 
 import (
+	"github.com/cyberark/secretless-broker/pkg/secretless/log"
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
 )
+
+// CompatiblePluginAPIVersion indicates what matching API version an external plugin
+// must have so that we are capable of loading it.
+var CompatiblePluginAPIVersion = "0.1.0"
 
 // AvailablePlugins is an interface that provides a list of all the available
 // plugins for each type that the broker supports.
 type AvailablePlugins interface {
 	HTTPPlugins() map[string]http.Plugin
 	TCPPlugins() map[string]tcp.Plugin
+}
+
+// Plugins represent a holding object for a bundle of plugins of different types.
+type Plugins struct {
+	HTTPPluginsByID map[string]http.Plugin
+	TCPPluginsByID  map[string]tcp.Plugin
+}
+
+// HTTPPlugins returns only the HTTP plugins in the Plugins struct.
+func (plugins *Plugins) HTTPPlugins() map[string]http.Plugin {
+	return plugins.HTTPPluginsByID
+}
+
+// TCPPlugins returns only the TCP plugins in the Plugins struct.
+func (plugins *Plugins) TCPPlugins() map[string]tcp.Plugin {
+	return plugins.TCPPluginsByID
+}
+
+// AllAvailablePlugins returns the full list of internal and external plugins
+// available to the broker.
+func AllAvailablePlugins(
+	pluginDir string,
+	checksumsFile string,
+	logger log.Logger,
+) (AvailablePlugins, error) {
+
+	return AllAvailablePluginsWithOptions(
+		pluginDir,
+		checksumsFile,
+		GetInternalPluginsFunc,
+		LoadPluginsFromDir,
+		logger,
+	)
+}
+
+// AllAvailablePluginsWithOptions returns the full list of internal and external plugins
+// available to the broker using explicitly-defined lookup functions.
+// TODO: Test this
+func AllAvailablePluginsWithOptions(
+	pluginDir string,
+	checksumsFile string,
+	internalLookupFunc InternalPluginLookupFunc,
+	externalLookupfunc ExternalPluginLookupFunc,
+	logger log.Logger,
+) (AvailablePlugins, error) {
+
+	internalPlugins, err := InternalPlugins(internalLookupFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	externalPlugins, err := ExternalPlugins(
+		pluginDir,
+		externalLookupfunc,
+		logger,
+		checksumsFile,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	httpPlugins := internalPlugins.HTTPPlugins()
+	for name, httpPlugin := range externalPlugins.HTTPPlugins() {
+		if _, ok := httpPlugins[name]; ok {
+			logger.Warnf("Internal plugin '%s' is replaced by an externally-provided plugin",
+				name)
+		}
+
+		httpPlugins[name] = httpPlugin
+	}
+
+	tcpPlugins := internalPlugins.TCPPlugins()
+	for name, tcpPlugin := range externalPlugins.TCPPlugins() {
+		if _, ok := tcpPlugins[name]; ok {
+			logger.Warnf("Internal plugin '%s' is replaced by an externally-provided plugin",
+				name)
+		}
+
+		tcpPlugins[name] = tcpPlugin
+	}
+
+	return &Plugins{
+		HTTPPluginsByID: httpPlugins,
+		TCPPluginsByID:  tcpPlugins,
+	}, nil
 }

--- a/internal/plugin/available_plugins_test.go
+++ b/internal/plugin/available_plugins_test.go
@@ -1,0 +1,57 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
+)
+
+type mockHTTPPlugin struct{ http.Plugin }
+type mockTCPPlugin struct{ tcp.Plugin }
+
+// These need to sit outside of the func since we are comparing them in the
+// tests
+var mockHTTPPlugins = map[string]http.Plugin{
+	"one": mockHTTPPlugin{},
+	"two": mockHTTPPlugin{},
+}
+
+var mockTCPPlugins = map[string]tcp.Plugin{
+	"one":   mockTCPPlugin{},
+	"two":   mockTCPPlugin{},
+	"three": mockTCPPlugin{},
+}
+
+func getMockPlugins() AvailablePlugins {
+	return &Plugins{
+		HTTPPluginsByID: mockHTTPPlugins,
+		TCPPluginsByID:  mockTCPPlugins,
+	}
+}
+
+func TestPlugins(t *testing.T) {
+	t.Run("HTTPPlugins", func(t *testing.T) {
+		httpPlugins := getMockPlugins().HTTPPlugins()
+
+		assert.NotNil(t, httpPlugins)
+		if httpPlugins == nil {
+			t.Fail()
+		}
+
+		assert.Equal(t, httpPlugins, mockHTTPPlugins)
+	})
+
+	t.Run("TCPPlugins", func(t *testing.T) {
+		tcpPlugins := getMockPlugins().TCPPlugins()
+
+		assert.NotNil(t, tcpPlugins)
+		if tcpPlugins == nil {
+			t.Fail()
+		}
+
+		assert.Equal(t, tcpPlugins, mockTCPPlugins)
+	})
+}

--- a/internal/plugin/external_plugins.go
+++ b/internal/plugin/external_plugins.go
@@ -1,0 +1,242 @@
+package plugin
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	go_plugin "plugin"
+	"strings"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/log"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
+)
+
+// ExternalPluginLookupFunc returns all available external plugins.
+type ExternalPluginLookupFunc func(
+	pluginDir string,
+	checksumfile string,
+	logger log.Logger,
+) (map[string]*go_plugin.Plugin, error)
+
+// LoadPluginsFromDir loads all plugins from a specified directory and returns
+// Plugins struct with tcp and http connectors.
+func LoadPluginsFromDir(
+	pluginDir string,
+	checksumsFile string,
+	logger log.Logger,
+) (map[string]*go_plugin.Plugin, error) {
+
+	filePaths, err := checkedPlugins(pluginDir, checksumsFile, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	return loadPluginFiles(filePaths, logger)
+}
+
+func checkedPlugins(
+	pluginDir string,
+	checksumsFile string,
+	logger log.Logger,
+) ([]string, error) {
+
+	files, err := ioutil.ReadDir(pluginDir)
+	if err != nil {
+		return nil, err
+	}
+
+	if checksumsFile == "" {
+		logger.Warnln("Plugin hashes were not provided - tampering will not be detectable!")
+		return filePaths(pluginDir, files), nil
+	}
+
+	// We override file listing if we did a verification to prevent additions
+	// to plugins between verification and loading the plugins.
+	if files, err = VerifyPluginChecksums(pluginDir, checksumsFile); err != nil {
+		logger.Errorln(err)
+		return nil, err
+	}
+
+	return filePaths(pluginDir, files), nil
+}
+
+func filePaths(pluginDir string, files []os.FileInfo) []string {
+	filePaths := []string{}
+	for _, file := range files {
+		filePaths = append(filePaths, path.Join(pluginDir, file.Name()))
+	}
+
+	return filePaths
+}
+
+func loadPluginFiles(
+	filePaths []string,
+	logger log.Logger,
+) (map[string]*go_plugin.Plugin, error) {
+
+	goPlugins := map[string]*go_plugin.Plugin{}
+	for _, filePath := range filePaths {
+		fileName := path.Base(filePath)
+		if !strings.HasSuffix(fileName, ".so") {
+			logger.Warnf("File '%s' ignored as a plugin - missing appropriate extension",
+				fileName)
+			continue
+		}
+
+		// Load shared library object
+		pluginObj, err := go_plugin.Open(filePath)
+		if err != nil {
+			logger.Errorln(err)
+			continue
+		}
+
+		logger.Infof("Adding '%s' as a plugin...", fileName)
+
+		goPlugins[fileName[:len(fileName)-3]] = pluginObj
+	}
+
+	return goPlugins, nil
+}
+
+// ExternalPlugins is used to enumerate all externally-available plugins in a sepcified
+// directory to the clients of this method.
+//TODO: Test this
+func ExternalPlugins(
+	pluginDir string,
+	getRawPlugins ExternalPluginLookupFunc,
+	logger log.Logger,
+	checksumsFile string,
+) (AvailablePlugins, error) {
+
+	rawPlugins, err := getRawPlugins(pluginDir, checksumsFile, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	plugins := Plugins{
+		HTTPPluginsByID: map[string]http.Plugin{},
+		TCPPluginsByID:  map[string]tcp.Plugin{},
+	}
+
+	for rawPluginName, rawPlugin := range rawPlugins {
+		logger.Infof("Loading plugin '%s'...", rawPluginName)
+
+		pluginType, pluginID, err := parsePluginMetadata(rawPlugin, rawPluginName)
+		if err != nil {
+			logger.Errorln(err)
+			continue
+		}
+
+		switch pluginType {
+		case "connector.http":
+			httpPluginSym, err := symbolFromName(rawPlugin, "GetHTTPPlugin")
+			if err != nil {
+				logger.Errorln(err)
+				continue
+			}
+
+			httpPluginFunc, ok := httpPluginSym.(func() http.Plugin)
+			if !ok {
+				logger.Errorln(errors.New("GetHTTPPlugin could not be cast to the expected type"))
+				continue
+			}
+
+			plugins.HTTPPluginsByID[pluginID] = httpPluginFunc()
+		case "connector.tcp":
+			tcpPluginSym, err := symbolFromName(rawPlugin, "GetTCPPlugin")
+			if err != nil {
+				logger.Errorln(err)
+				continue
+			}
+
+			tcpPluginFunc, ok := tcpPluginSym.(func() tcp.Plugin)
+			if !ok {
+				logger.Errorln(errors.New("GetTCPPlugin could not be cast to the expected type"))
+				continue
+			}
+
+			plugins.TCPPluginsByID[pluginID] = tcpPluginFunc()
+		default:
+			logger.Errorln(fmt.Errorf("PluginInfo['type'] of '%s' is not supported", pluginType))
+			continue
+		}
+
+		logger.Warnf("Plugin %s/%s loaded", pluginType, pluginID)
+	}
+
+	return &plugins, nil
+}
+
+func symbolFromName(
+	rawPlugin *go_plugin.Plugin,
+	symbolName string,
+) (go_plugin.Symbol, error) {
+
+	symbol, err := (*rawPlugin).Lookup(symbolName)
+	if err != nil {
+		return nil, err
+	}
+
+	return symbol, nil
+}
+
+func infoField(info map[string]string, fieldName string) (string, error) {
+	fieldValue, ok := info[fieldName]
+	if !ok {
+		err := fmt.Errorf("PluginInfo does not contain '%s' field", fieldName)
+		return "", err
+	}
+
+	if fieldValue == "" {
+		err := fmt.Errorf("PluginInfo['%s'] is blank", fieldName)
+		return "", err
+	}
+
+	return fieldValue, nil
+}
+
+func parsePluginMetadata(
+	rawPlugin *go_plugin.Plugin,
+	rawPluginName string,
+) (pluginType string, pluginID string, err error) {
+
+	pluginInfoSym, err := symbolFromName(rawPlugin, "PluginInfo")
+	if err != nil {
+		return pluginType, pluginID, err
+	}
+
+	pluginInfoFunc, ok := pluginInfoSym.(func() map[string]string)
+	if !ok {
+		err = errors.New("could not cast PluginInfo to proper type")
+		return pluginType, pluginID, err
+	}
+	pluginInfo := pluginInfoFunc()
+
+	pluginAPIVersion, err := infoField(pluginInfo, "pluginAPIVersion")
+	if err != nil {
+		return pluginType, pluginID, err
+	}
+
+	if pluginAPIVersion != CompatiblePluginAPIVersion {
+		err = fmt.Errorf("plugin '%s' (API v%s) is not a supported API version (v%s)",
+			rawPluginName, pluginAPIVersion, CompatiblePluginAPIVersion)
+		return pluginType, pluginID, err
+	}
+
+	pluginType, err = infoField(pluginInfo, "type")
+	if err != nil {
+		return pluginType, pluginID, err
+	}
+
+	pluginID, err = infoField(pluginInfo, "id")
+	if err != nil {
+		return pluginType, pluginID, err
+	}
+
+	// TODO: Verify PluginID charset
+
+	return pluginType, pluginID, nil
+}

--- a/internal/plugin/internal_plugins.go
+++ b/internal/plugin/internal_plugins.go
@@ -1,0 +1,36 @@
+package plugin
+
+import (
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
+)
+
+// InternalPluginLookupFunc returns all available internal plugins.
+type InternalPluginLookupFunc func() (AvailablePlugins, error)
+
+// GetInternalPluginsFunc returns currently available internal plugins
+// but for now, this list is empty since we have none implemented.
+func GetInternalPluginsFunc() (AvailablePlugins, error) {
+	return &Plugins{
+		HTTPPluginsByID: map[string]http.Plugin{},
+		TCPPluginsByID:  map[string]tcp.Plugin{},
+	}, nil
+}
+
+// InternalPlugins is used to enumerate internally-available plugins to the clients
+// of this method.
+func InternalPlugins(lookupFunc InternalPluginLookupFunc) (AvailablePlugins, error) {
+	plugins, err := lookupFunc()
+	if err != nil {
+		return nil, err
+	}
+
+	if plugins == nil {
+		plugins = &Plugins{
+			HTTPPluginsByID: nil,
+			TCPPluginsByID:  nil,
+		}
+	}
+
+	return plugins, nil
+}

--- a/internal/plugin/internal_plugins_test.go
+++ b/internal/plugin/internal_plugins_test.go
@@ -1,0 +1,70 @@
+package plugin
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
+)
+
+func getMockHTTPPlugins() AvailablePlugins {
+	var mockInternalHTTPPlugins = map[string]http.Plugin{
+		"one": mockHTTPPlugin{},
+		"two": mockHTTPPlugin{},
+	}
+
+	var mockInternalTCPPlugins = map[string]tcp.Plugin{
+		"one":   mockTCPPlugin{},
+		"two":   mockTCPPlugin{},
+		"three": mockTCPPlugin{},
+	}
+
+	return &Plugins{
+		HTTPPluginsByID: mockInternalHTTPPlugins,
+		TCPPluginsByID:  mockInternalTCPPlugins,
+	}
+}
+
+func TestInternalPlugins(t *testing.T) {
+	t.Run("InternalPluginFunc plugins are passed through", func(t *testing.T) {
+		plugins, _ := InternalPlugins(func() (AvailablePlugins, error) {
+			return getMockHTTPPlugins(), nil
+		})
+
+		assert.NotNil(t, plugins)
+		if plugins == nil {
+			t.Fail()
+		}
+
+		assert.Equal(t, plugins.HTTPPlugins(), getMockHTTPPlugins().HTTPPlugins())
+		assert.Equal(t, plugins.TCPPlugins(), getMockHTTPPlugins().TCPPlugins())
+	})
+
+	t.Run("InternalPluginFunc does not pass nil plugins", func(t *testing.T) {
+		plugins, _ := InternalPlugins(func() (AvailablePlugins, error) {
+			return nil, nil
+		})
+
+		assert.NotNil(t, plugins)
+		if plugins == nil {
+			t.Fail()
+		}
+
+		assert.Equal(t, len(plugins.HTTPPlugins()), 0)
+		assert.Equal(t, len(plugins.TCPPlugins()), 0)
+	})
+
+	t.Run("InternalPluginFunc errors are passed through", func(t *testing.T) {
+		mockError := errors.New("Some error")
+		plugins, err := InternalPlugins(func() (AvailablePlugins, error) {
+			return nil, mockError
+		})
+
+		assert.Nil(t, plugins)
+		assert.Error(t, err)
+		assert.Equal(t, mockError, err)
+	})
+}

--- a/internal/plugin/internal_plugins_test.go
+++ b/internal/plugin/internal_plugins_test.go
@@ -68,3 +68,30 @@ func TestInternalPlugins(t *testing.T) {
 		assert.Equal(t, mockError, err)
 	})
 }
+
+func TestGetInternalPlugins(t *testing.T) {
+	t.Run("GetInternalPluginsFunc does not error out", func(t *testing.T) {
+		_, err := GetInternalPluginsFunc()
+		assert.Nil(t, err)
+	})
+
+	t.Run("GetInternalPluginsFunc returns the expected plugin list", func(t *testing.T) {
+		internalPlugins, err := GetInternalPluginsFunc()
+		assert.Nil(t, err)
+
+		if err != nil {
+			t.Fail()
+		}
+
+		assert.NotNil(t, internalPlugins.HTTPPlugins())
+		assert.NotNil(t, internalPlugins.TCPPlugins())
+
+		if internalPlugins.HTTPPlugins() != nil {
+			assert.Equal(t, 0, len(internalPlugins.HTTPPlugins()))
+		}
+
+		if internalPlugins.TCPPlugins() != nil {
+			assert.Equal(t, 0, len(internalPlugins.TCPPlugins()))
+		}
+	})
+}

--- a/internal/proxyservice/proxy_service.go
+++ b/internal/proxyservice/proxy_service.go
@@ -6,8 +6,6 @@ import (
 	"github.com/cyberark/secretless-broker/pkg/secretless"
 	v2 "github.com/cyberark/secretless-broker/pkg/secretless/config/v2"
 	"github.com/cyberark/secretless-broker/pkg/secretless/log"
-	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
-	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
 )
 
 // TODO: move to impl package
@@ -16,17 +14,6 @@ type proxyServices struct {
 	logger        log.Logger
 	eventNotifier v1.EventNotifier
 	availPlugins  plugin.AvailablePlugins
-}
-
-// AvailPluginStub is a temporary placeholder for AvailablePlugins
-type AvailPluginStub struct {}
-// HTTPPlugins returns the available HTTP plugins.
-func (ap *AvailPluginStub) HTTPPlugins() map[string]http.Plugin {
-	return nil
-}
-// TCPPlugins returns the available TCP plugins.
-func (ap *AvailPluginStub) TCPPlugins() map[string]tcp.Plugin {
-	return nil
 }
 
 // TODO: Rename to Call or Run and return a Stopper instead of having Stop()

--- a/pkg/secretless/plugin/connector/http/http.go
+++ b/pkg/secretless/plugin/connector/http/http.go
@@ -10,10 +10,6 @@ import (
 // Plugin is the main interface that HTTP plugins need to implement
 // to be loaded by our codebase.
 type Plugin interface {
-	// PluginInfo contains a key-value map of informational fields
-	// about the plugin.
-	PluginInfo() map[string]string
-
 	// NewConnector creates a new Connector based on the ConnectorResources
 	// passed into it.
 	NewConnector(connector.Resources) Connector

--- a/pkg/secretless/plugin/connector/tcp/tcp.go
+++ b/pkg/secretless/plugin/connector/tcp/tcp.go
@@ -10,10 +10,6 @@ import (
 // Plugin is the main interface that TCP plugins need to implement
 // to be loaded by our codebase.
 type Plugin interface {
-	// PluginInfo contains a key-value map of informational fields
-	// about the plugin.
-	PluginInfo() map[string]string
-
 	// NewConnector creates a new Connector based on the ConnectorResources
 	// passed into it.
 	NewConnector(connector.Resources) Connector


### PR DESCRIPTION
Adds plugin loading logic to our codebase

#### What ticket does this PR close?

Connected to #878
#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
