### PR TITLE
Update tests to do a better job of cleaning up after exit

### DIFF
--- a/bin/run_integration
+++ b/bin/run_integration
@@ -41,6 +41,11 @@ if [[ ${#non_flag_args[@]} != 1 ]]; then
   exit 1
 fi
 
+# set the COMPOSE_PROJECT_NAME for the tests you'll be running
+COMPOSE_PROJECT_NAME="$(openssl rand -hex 3)"
+
+export COMPOSE_PROJECT_NAME
+
 # Validate the required scripts exists in the TEST_SUBDIR
 
 project_dir=$PWD

--- a/bin/test_demo
+++ b/bin/test_demo
@@ -5,6 +5,9 @@ set -eo pipefail
 CURRENT_DIR=$("$(dirname "$0")"/abspath)
 TOPLEVEL_DIR="$CURRENT_DIR/.."
 QUICK_START_DIR="${TOPLEVEL_DIR}/demos/quick-start"
+COMPOSE_PROJECT_NAME="$(openssl rand -hex 3)"
+
+export COMPOSE_PROJECT_NAME
 
 pushd "$QUICK_START_DIR" >/dev/null
 

--- a/demos/k8s-demo/02_app_developer_steps
+++ b/demos/k8s-demo/02_app_developer_steps
@@ -16,8 +16,8 @@ step "Start application"
 kubectl --namespace "${APP_NAMESPACE}" \
   apply --filename "etc/quick-start-application.yml"
 
-if [ ! "${SECRETLESS_IMAGE_NAME:-}" == "" ]; then
-  image_name="${SECRETLESS_IMAGE_NAME}:${SECRETLESS_IMAGE_TAG}"
+if [ ! "${SECRETLESS_IMAGE:-}" == "" ]; then
+  image_name="${SECRETLESS_IMAGE}"
 
   step "Patching deployment with ${image_name}"
 

--- a/demos/k8s-demo/stop
+++ b/demos/k8s-demo/stop
@@ -8,19 +8,7 @@
 # https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#wait
 delete_ns() {
   echo "Deleting namespace '$1'..."
-  # We don't care about the output of this command, only its return return code:
-  # success means there was something to delete, and that we must wait for
-  # deletion to fully process.  Failure means there was nothing to delete and
-  # we can return early.
-  if ! kubectl delete namespace "$1" > /dev/null 2>&1; then
-    return 0
-  fi
-
-  # As long as we can still "get" the namespace, the deletion isn't done.
-  while kubectl get namespace "$1" > /dev/null 2>&1; do 
-    printf "."
-    sleep 2
-  done
+  kubectl delete --wait=true --ignore-not-found=true namespace "$1"
 }
 
 delete_ns "$BACKEND_NAMESPACE"

--- a/demos/k8s-demo/test
+++ b/demos/k8s-demo/test
@@ -4,6 +4,9 @@ set -e
 set -o pipefail
 
 # setup environment variables
+export BACKEND_NAMESPACE="${TEST_NAMESPACE}-backend"
+export APP_NAMESPACE="${TEST_NAMESPACE}-app"
+
 log=log.txt
 rm -rf ${log}
 
@@ -15,9 +18,6 @@ trap cleanup EXIT INT QUIT
 
 function main() {
   cleanup
-
-  export BACKEND_NAMESPACE="${TEST_NAMESPACE}-backend"
-  export APP_NAMESPACE="${TEST_NAMESPACE}-app"
 
   # Deploy and test the results
   ./01_security_admin_steps

--- a/k8s-ci/k8s_crds/deployment.yaml.sh
+++ b/k8s-ci/k8s_crds/deployment.yaml.sh
@@ -91,7 +91,7 @@ spec:
         env:
         - name: SECRETLESS_CRD_SUFFIX
           value: "${SECRETLESS_CRD_SUFFIX}"
-        image: "${SECRETLESS_IMAGE_NAME}:${SECRETLESS_IMAGE_TAG}"
+        image: "${SECRETLESS_IMAGE}"
         readinessProbe:
           tcpSocket:
             port: 8080

--- a/k8s-ci/k8s_crds/test
+++ b/k8s-ci/k8s_crds/test
@@ -6,7 +6,7 @@ set -o pipefail
 # setup environment variables
 log=log.txt
 rm -rf ${log}
-export SECRETLESS_CRD_SUFFIX=${SECRETLESS_CRD_SUFFIX-}
+export SECRETLESS_CRD_SUFFIX=${TEST_ID-}
 
 exit_err() {
    printf '\n--------------------- \n\n'
@@ -149,7 +149,6 @@ function run_test_case() {
 }
 
 function main() {
-  echo "using SECRETLESS_CRD_SUFFIX=${SECRETLESS_CRD_SUFFIX}"
   cleanup
 
   # deploy secretless and echo-server

--- a/k8s-ci/test
+++ b/k8s-ci/test
@@ -20,12 +20,11 @@ docker inspect secretless-broker:latest > /dev/null 2>&1 || {
 }
 
 # Set environment variables
-export UNIQUE_TEST_ID
-UNIQUE_TEST_ID="k8s-test-$(uuidgen | tr "[:upper:]" "[:lower:]" | head -c 12 | tr -d -)"
+export TEST_ID="$(uuidgen | tr "[:upper:]" "[:lower:]" | head -c 12 | tr -d -)"
 export SECRETLESS_IMAGE_NAME="${DOCKER_REGISTRY_PATH}/secretless-broker"
-export SECRETLESS_IMAGE_TAG="${UNIQUE_TEST_ID}"
-
-export TEST_NAMESPACE="secretless-${UNIQUE_TEST_ID}"
+export SECRETLESS_IMAGE_TAG="${TEST_ID}"
+export SECRETLESS_IMAGE="${SECRETLESS_IMAGE_NAME}:${SECRETLESS_IMAGE_TAG}";
+export TEST_NAMESPACE="test-secretless-${TEST_ID}"
 
 # Clean up when script completes
 function finish {
@@ -45,12 +44,14 @@ function runTest() {
   local test_path="$1"
 
   runDockerCommand "
-# push the local secretless-broker image to the remote DOCKER_REGISTRY_PATH
-docker tag 'secretless-broker:latest' '${SECRETLESS_IMAGE_NAME}:${SECRETLESS_IMAGE_TAG}'> /dev/null;
-docker push '${SECRETLESS_IMAGE_NAME}:${SECRETLESS_IMAGE_TAG}' > /dev/null;
+# ensure the container has the appropriate env
+export TEST_ID=${TEST_ID}
+export SECRETLESS_IMAGE=${SECRETLESS_IMAGE}
+export TEST_NAMESPACE=${TEST_NAMESPACE}
 
-export SECRETLESS_CRD_SUFFIX='${UNIQUE_TEST_ID}';
-export TEST_NAMESPACE='${TEST_NAMESPACE}';
+# push the local secretless-broker image to the remote DOCKER_REGISTRY_PATH
+docker tag 'secretless-broker:latest' '${SECRETLESS_IMAGE}'> /dev/null;
+docker push '${SECRETLESS_IMAGE}' > /dev/null;
 
 # create test namespace
 kubectl create namespace '${TEST_NAMESPACE}';
@@ -58,10 +59,8 @@ kubectl create namespace '${TEST_NAMESPACE}';
 # switch to test namespace
 kubens '${TEST_NAMESPACE}';
 
-# run CRD tests
-cd $test_path;
-export SECRETLESS_IMAGE_NAME='${SECRETLESS_IMAGE_NAME}';
-export SECRETLESS_IMAGE_TAG='${SECRETLESS_IMAGE_TAG}';
+# run tests
+cd "$test_path";
 ./test
 "
 }

--- a/test/conjur/docker-compose.yml
+++ b/test/conjur/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     image: postgres:9.4
 
   conjur:
-    image: cyberark/conjur:0.3.0-stable
+    image: cyberark/conjur:latest
     command: server -a dev -f /work/conjur.yml
     environment:
       DATABASE_URL: postgres://postgres@pg/postgres
@@ -16,6 +16,16 @@ services:
       - .:/work
     depends_on:
       - pg
+
+  client:
+    image: cyberark/conjur-cli:5
+    depends_on:
+      - conjur
+    environment:
+      CONJUR_APPLIANCE_URL: http://conjur
+      CONJUR_ACCOUNT: dev
+      CONJUR_AUTHN_LOGIN: admin
+      CONJUR_AUTHN_API_KEY:
 
   secretless:
     image: secretless-broker
@@ -46,13 +56,3 @@ services:
       CONJUR_ACCOUNT: dev
     volumes:
       - ../..:/secretless
-
-  conjur-cli:
-    image: cyberark/conjur-cli:5-latest
-    environment:
-      CONJUR_APPLIANCE_URL: http://conjur
-      CONJUR_ACCOUNT: dev
-      CONJUR_AUTHN_TOKEN: e30K # dummy value required by CLI before Secretless connection
-    depends_on:
-      - conjur
-      - secretless

--- a/test/conjur/start
+++ b/test/conjur/start
@@ -4,7 +4,7 @@
 
 docker-compose build
 docker-compose up -d conjur
-docker-compose exec -T conjur conjurctl wait
+docker-compose exec -T conjur conjurctl wait -r 120
 
 admin_api_key=$(docker-compose exec -T conjur conjurctl role retrieve-key dev:user:admin | tr -d '\r')
 export CONJUR_AUTHN_API_KEY=$admin_api_key
@@ -33,5 +33,5 @@ sleep 2
 docker-compose run \
   --rm \
   --no-deps \
-  -e http_proxy=http://secretless:8080 \
-  conjur-cli variable values add db/password secret
+  client \
+  variable values add db/password secret


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
We've noticed two problems with the tests:
- the tests running in GKE don't always delete the namespaces that are created on exit
- the integration tests are experiencing collisions where one test removes a container running for another test

This PR updates so that all GKE namespaces will be removed on test exit, and all tests will run in their own `COMPOSE_PROJECT_NAME` so they won't have mid-air collisions


ETA: I also updated the `conjur` integration tests because they were failing on the `latest` branch - it turns out that this had already been fixed by someone (yay!) which I noticed when I cherry-picked my changes from `test-branch` to here, but I left my changes bc I think they further simplify things

You can see these changes passing on top of the `latest` branch here: https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--secretless-broker/detail/test-branch/2/pipeline/36

The `test-branch` branch can be deleted once this is merged.