### PR TITLE
Fixed a fatal crash when external plugin folder did not exist

### DIFF
--- a/internal/plugin/external_plugins.go
+++ b/internal/plugin/external_plugins.go
@@ -29,6 +29,16 @@ func LoadPluginsFromDir(
 	logger log.Logger,
 ) (map[string]*go_plugin.Plugin, error) {
 
+	// Missing external plugin folder is a warning not a fatal error
+	_, err := os.Stat(pluginDir)
+	if os.IsNotExist(err) {
+		logger.Warnf(
+			"Plugin directory '%s' not found. Ignoring external plugins...",
+			pluginDir,
+		)
+		return nil, nil
+	}
+
 	filePaths, err := checkedPlugins(pluginDir, checksumsFile, logger)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We assumed that the external plugin folder was always present on the
target system but that might not be the case which is a warning and not
a fatal exit condition. We now just show a warning and return no
external plugins if we are running in such an environment.

#### What ticket does this PR close?
Connected to #913 

#### Where should the reviewer start?
Code diff

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
