### PR TITLE
Use secretless.yml as configuration file by default

### DIFF
--- a/cmd/secretless-broker/main.go
+++ b/cmd/secretless-broker/main.go
@@ -19,7 +19,7 @@ func CmdLineParams() *entrypoint.SecretlessOptions {
 
 	params := entrypoint.SecretlessOptions{}
 
-	flag.StringVar(&params.ConfigFile, "f", "", "Location of the configuration file.")
+	flag.StringVar(&params.ConfigFile, "f", "secretless.yml", "Location of the configuration file.")
 
 	// for CPU and Memory profiling
 	// Acceptable values to input: cpu or memory


### PR DESCRIPTION
New changes made the broker not use any configuration files so the
loading failed without one explicitly specified. This change ensures
that we at least check if `secretless.yml` is available before failing.

#### What ticket does this PR close?
Connected to #915 

#### Where should the reviewer start?
Code diff

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
