### PR TITLE
Add support for listening on unix socket files

### DIFF
--- a/internal/proxyservice/proxy_service.go
+++ b/internal/proxyservice/proxy_service.go
@@ -96,8 +96,15 @@ func (s *proxyServices) createTCPService(
 	plugin tcp.Plugin,
 ) (internal.Service, error) {
 
+	// XXX/TBD: We mght also consider `tcp://` to be the default socket type
+	addressParts := strings.SplitN(svc.ListenOn, "://", 2)
+	if len(addressParts) != 2 {
+		return nil, fmt.Errorf("listenOn requires a socket type schema prefix (e.g. 'tcp://' or 'unix://')")
+	}
+
+	//TODO: Add validation to only support expected socket types
 	//TODO: Add validation somewhere about overlapping listenOns
-	listener, err := net.Listen("tcp", strings.TrimLeft(svc.ListenOn, "tcp://"))
+	listener, err := net.Listen(addressParts[0], addressParts[1])
 	if err != nil {
 		s.logger.Errorf("could not create listener on: %s", svc.ListenOn)
 		return nil, err


### PR DESCRIPTION
Old code forced listening on tcp connections so this change enables
listening to unix socket files too to recover some of the old
functionality we had previously.

#### What ticket does this PR close?
Connected to #918

#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
