### PR TITLE
Connector api fix

### DIFF
--- a/internal/proxyservice/http/aws/plugin.go
+++ b/internal/proxyservice/http/aws/plugin.go
@@ -18,14 +18,10 @@ func PluginInfo() map[string]string {
 
 // NewConnector returns an http.Connector that decorates each incoming http
 // request with authorization data.
-//
-// It is a required method on the http.Plugin interface. The single argument
-// passed in is of type connector.Resources. It contains connector-specific
-// config and a logger.
 func NewConnector(conRes connector.Resources) http.Connector {
-	return (&Connector{
+	return &Connector{
 		logger:   conRes.Logger(),
-	}).Connect
+	}
 }
 
 // GetHTTPPlugin is required as part of the Secretless plugin spec for HTTP

--- a/internal/proxyservice/http/basicauth/plugin.go
+++ b/internal/proxyservice/http/basicauth/plugin.go
@@ -19,9 +19,9 @@ func PluginInfo() map[string]string {
 // NewConnector returns an http.Connector that decorates each incoming http
 // request with a basic auth header.
 func NewConnector(conRes connector.Resources) http.Connector {
-	return (&Connector{
+	return &Connector{
 		logger:   conRes.Logger(),
-	}).Connect
+	}
 }
 
 // GetHTTPPlugin is required as part of the Secretless plugin spec for HTTP

--- a/internal/proxyservice/http/proxy_service.go
+++ b/internal/proxyservice/http/proxy_service.go
@@ -9,11 +9,11 @@ import (
 	gohttp "net/http"
 	"regexp"
 
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
 	validation "github.com/go-ozzo/ozzo-validation"
 
 	"github.com/cyberark/secretless-broker/internal"
 	"github.com/cyberark/secretless-broker/pkg/secretless/log"
-	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
 )
 
 // Subservice handles specific traffic within an HTTP proxy service, using
@@ -27,8 +27,8 @@ type Subservice struct {
 	// having it are minimal so far. This is something we should keep an eye on
 	// and refactor if it comes up again.
 
+	Connector                http.Connector
 	ConnectorID              string
-	Authenticate             http.Connector
 	RetrieveCredentials      internal.CredentialsRetriever
 	AuthenticateURLsMatching []*regexp.Regexp
 }
@@ -182,7 +182,7 @@ func (proxy *proxyService) ServeHTTP(w gohttp.ResponseWriter, r *gohttp.Request)
 
 	// Authenticate request
 
-	err = subservice.Authenticate(r, creds)
+	err = subservice.Connector.Connect(r, creds)
 	if err != nil {
 		gohttp.Error(w, err.Error(), 500)
 		return

--- a/internal/proxyservice/proxy_service.go
+++ b/internal/proxyservice/proxy_service.go
@@ -135,7 +135,7 @@ func (s *proxyServices) createHTTPService(
 
 		subservices = append(subservices, httpproxy.Subservice{
 			ConnectorID:              subCfg.Connector, // TODO: Rename connectorID
-			Authenticate:             curConnector,
+			Connector:                curConnector,
 			RetrieveCredentials:      credsRetriever,
 			AuthenticateURLsMatching: httpCfg.AuthenticateURLsMatching,
 		})

--- a/internal/proxyservice/tcp/mysql/plugin.go
+++ b/internal/proxyservice/tcp/mysql/plugin.go
@@ -13,7 +13,7 @@ import (
 // The single argument passed in is of type connector.Resources. It contains
 // connector-specific config and a logger.
 func NewConnector(conRes connector.Resources) tcp.Connector {
-	return func(
+	connectorFunc := func(
 		clientConn net.Conn,
 		credentialValuesByID connector.CredentialValuesByID,
 	) (backendConn net.Conn, err error) {
@@ -25,6 +25,8 @@ func NewConnector(conRes connector.Resources) tcp.Connector {
 
 		return singleUseConnector.Connect(clientConn, credentialValuesByID)
 	}
+
+	return tcp.ConnectorFunc(connectorFunc)
 }
 
 // PluginInfo is required as part of the Secretless plugin spec. It provides

--- a/internal/proxyservice/tcp/pg/connector.go
+++ b/internal/proxyservice/tcp/pg/connector.go
@@ -35,7 +35,7 @@ func (s *SingleUseConnector) abort(err error) {
 	}
 }
 
-// Connect implements the tcp.Connector func signature
+// Connect implements the tcp.Connector func signature.
 //
 // It is the main method of the SingleUseConnector. It:
 //   1. Constructs connection details from the provided credentials map.

--- a/internal/proxyservice/tcp/pg/plugin.go
+++ b/internal/proxyservice/tcp/pg/plugin.go
@@ -11,7 +11,7 @@ import (
 // connection to a target service for each incoming client connection. It is a
 // required method on the tcp.Plugin interface.
 func NewConnector(conRes connector.Resources) tcp.Connector {
-	return func(
+	newConnectorFunc := func(
 		clientConn net.Conn,
 		credentialValuesByID connector.CredentialValuesByID,
 	) (backendConn net.Conn, err error) {
@@ -23,6 +23,8 @@ func NewConnector(conRes connector.Resources) tcp.Connector {
 
 		return singleUseConnector.Connect(clientConn, credentialValuesByID)
 	}
+
+	return tcp.ConnectorFunc(newConnectorFunc)
 }
 
 // PluginInfo is required as part of the Secretless plugin spec. It provides

--- a/internal/proxyservice/tcp/proxy_service.go
+++ b/internal/proxyservice/tcp/proxy_service.go
@@ -109,7 +109,7 @@ func (proxy *proxyService) handleConnection(clientConn net.Conn) error {
 
 	logger.Infof("New connection on %v.\n", clientConn.LocalAddr())
 
-	targetConn, err = proxy.connector(clientConn, backendCredentials)
+	targetConn, err = proxy.connector.Connect(clientConn, backendCredentials)
 	if err != nil {
 		return fmt.Errorf("failed on connect: %s", err)
 	}

--- a/pkg/secretless/plugin/connector/http/http.go
+++ b/pkg/secretless/plugin/connector/http/http.go
@@ -6,28 +6,40 @@ import (
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
 )
 
-// Plugin is the main interface that HTTP plugins need to implement
-// to be loaded by our codebase.
+// Plugin is the interface that HTTP plugins need to implement.  Conceptually, a
+// Plugin is is something that can create a Connector, and a Connector is
+// something that knows how to "Connect", ie, how to authenticate http requests.
 type Plugin interface {
 	// NewConnector creates a new Connector based on the ConnectorResources
 	// passed into it.
 	NewConnector(connector.Resources) Connector
 }
 
-// Connector is the function that will be invoked when a matching
-// request comes in. It uses both the request object and the credentials
-// map to authenticate the client.
-type Connector func(
-	request *http.Request,
-	credentialValuesByID connector.CredentialValuesByID,
-) error
+// Connector is an interface with a single method, "Connect".  "Connect" is a
+// function that knows how to authenticate an http request. It uses
+// its credential values argument passed in to modify the http.Request
+// request object and the credentials map to authenticate the client.
+type Connector interface {
+	Connect(
+		request *http.Request,
+		credentialValuesByID connector.CredentialValuesByID,
+	) error
+}
 
-// ConnectorConstructor, through type-conversion e.g. ConnectorConstructor(NewConnector),
-// allows a free-standing NewConnector func to conform to the http.Plugin interface without
-// the need for additional boilerplate. It does this by giving any function of the type
-// ConnectorConstructor a constructor method called NewConnector that simply calls the function
-// itself
+
+// ConnectorConstructor allows a free-standing constructor function -- anything
+// that takes connector.Resources and returns a Connector -- to fulfill the
+// Plugin interface. Thus you can cast to it:
+//
+//     ConnectorConstructor(NewConnector)
+//
+// and you now have a Plugin. It does this by giving any function of the type
+// ConnectorConstructor a constructor method called NewConnector that simply
+// calls the function itself
 type ConnectorConstructor func (connector.Resources) Connector
+
+// NewConnector is a ConnectorConstructor's implementation of the Plugin
+// interface. It simply delegates to the underlying function.
 func (cc ConnectorConstructor) NewConnector(cr connector.Resources) Connector {
 	return cc(cr)
 }

--- a/pkg/secretless/plugin/connector/tcp/tcp.go
+++ b/pkg/secretless/plugin/connector/tcp/tcp.go
@@ -6,29 +6,53 @@ import (
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
 )
 
-// Plugin is the main interface that TCP plugins need to implement
-// to be loaded by our codebase.
+// Plugin is the interface that TCP plugins need to implement.  Conceptually, a
+// Plugin is is something that can create a Connector, and a Connector is
+// something that knows how to "Connect", ie, how to authenticate tcp requests.
 type Plugin interface {
 	// NewConnector creates a new Connector based on the ConnectorResources
 	// passed into it.
 	NewConnector(connector.Resources) Connector
 }
 
-// Connector is the function that will be invoked when a matching
-// TCP request comes in. It uses both the initiating connection and the
-// credentials map to authenticate the client, returning the backend
-// network connection.
-type Connector func(
+// Connector is an interface with a single method, "Connect".  "Connect" is a
+// function that takes credentials and an unauthenticated connection and returns
+// an authenticated connection to the target service.
+type Connector interface {
+	Connect(
+		clientConn net.Conn,
+		credentialValuesByID connector.CredentialValuesByID,
+	) (backendConn net.Conn, err error)
+}
+
+// ConnectorFunc is a type that allows a free-standing "Connect" function to
+// fulfill the Connector interface.  You simply cast a "Connect" function into
+// a "ConnectorFunc", and it becomes a proper type with a "Connect" method,
+// which simply calls the function itself.
+type ConnectorFunc func(net.Conn, connector.CredentialValuesByID) (net.Conn, error)
+
+// Connect is a ConnectorFunc's implementation of the Connector interface. It
+// simply delegates to the underlying function itself.
+func (cf ConnectorFunc) Connect(
 	clientConn net.Conn,
 	credentialValuesByID connector.CredentialValuesByID,
-) (backendConn net.Conn, err error)
+) (backendConn net.Conn, err error) {
+	return cf(clientConn, credentialValuesByID)
+}
 
-// ConnectorConstructor, through type-conversion e.g. ConnectorConstructor(NewConnector),
-// allows a free-standing NewConnector func to conform to the tcp.Plugin interface without
-// the need for additional boilerplate. It does this by giving any function of the type
-// ConnectorConstructor a constructor method called NewConnector that simply calls the function
-// itself
+// ConnectorConstructor allows a free-standing constructor function -- anything
+// that takes connector.Resources and returns a Connector -- to fulfill the
+// Plugin interface. Thus you can cast to it:
+//
+//     ConnectorConstructor(NewConnector)
+//
+// and you now have a Plugin. It does this by giving any function of the type
+// ConnectorConstructor a constructor method called NewConnector that simply
+// calls the function itself
 type ConnectorConstructor func (connector.Resources) Connector
+
+// NewConnector is a ConnectorConstructor's implementation of the Plugin
+// interface. It simply delegates to the underlying function.
 func (cc ConnectorConstructor) NewConnector(cr connector.Resources) Connector {
 	return cc(cr)
 }

--- a/test/plugin/example/example_plugin.go
+++ b/test/plugin/example/example_plugin.go
@@ -77,7 +77,7 @@ func (c *Connector) Connect(
 // The single argument passed in is of type connector.Resources. It contains
 // connector-specific config and a logger.
 func NewConnector(conRes connector.Resources) tcp.Connector {
-	return func(
+	connectorFunc := func(
 		clientConn net.Conn,
 		credentialValuesByID connector.CredentialValuesByID,
 	) (backendConn net.Conn, err error) {
@@ -88,6 +88,7 @@ func NewConnector(conRes connector.Resources) tcp.Connector {
 
 		return connConnector.Connect(clientConn, credentialValuesByID)
 	}
+	return tcp.ConnectorFunc(connectorFunc)
 }
 
 // PluginInfo is required as part of the Secretless plugin spec. It provides


### PR DESCRIPTION
Prior to this PR, both the tcp and http `Connector` interfaces were defined as naked functions.

While this choice was well-intentioned ("nothing is simpler than a function"), it turned out to create some awkwardness in the code itself, because we needed to refer to the "connector" (a noun) as well as _call_ it, which meant doing semantically incorrect things like `x.Connector(request, creds)` which doesn't make any literal sense.

A "connector" is still fundamentally a simple function -- that hasn't changed -- but it is now defined technically as an interface with that single function on it.  This resolves the problems mentioned above and makes talking about connectors easier and more accurate.