### PR TITLE
Update community page

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ In addition, the following must be true for any stable release:
 
 # Community
 
-Our primary channel for support is through our [Secretless Broker mailing list](https://groups.google.com/forum/#!forum/secretless). More info here: [community support](https://secretless.io/community)
+Our primary channel for support is through our [Secretless Broker Discourse](https://discuss.cyberarkcommons.org/c/secretless-broker). More info here: [community support](https://secretless.io/community)
 
 # Performance
 

--- a/demos/k8s-demo/README.md
+++ b/demos/k8s-demo/README.md
@@ -174,6 +174,5 @@ The application is connecting to a password-protected Postgres database
 
 Please let us know what you think of Secretless! You can submit [Github
 issues](https://github.com/cyberark/secretless-broker/issues) for features
-you'd like to see, or send a message to our [mailing
-list](https://groups.google.com/forum/#!forum/secretless) with comments or
+you'd like to see, or send a message to our [Discourse](https://discuss.cyberarkcommons.org/c/secretless-broker) with comments or
 questions.

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -31,7 +31,7 @@
 						<ul class="link-col">
 								<p class="footer-title">Contribute</p>
 							<li class="footer-resource"><i class="fab fa-github"></i><a target="_blank" rel="noopener noreferrer" href="https://github.com/cyberark/secretless-broker">GitHub</a></li>
-							<li class="footer-resource"><i class="fas fa-comment-alt"></i><a target="_blank" rel="noopener noreferrer" href="https://groups.google.com/forum/#!forum/secretless">Google Group</a></li>
+							<li class="footer-resource"><i class="fas fa-comment-alt"></i><a target="_blank" rel="noopener noreferrer" href="https://discuss.cyberarkcommons.org/c/secretless-broker">Discourse</a></li>
 						</ul>
 					</div>
 				</div>

--- a/docs/_posts/2018-12-06-meet-us-at-kubecon.md
+++ b/docs/_posts/2018-12-06-meet-us-at-kubecon.md
@@ -26,7 +26,7 @@ will be speaking.
 
 Please stop by to chat with our engineers and representatives
 at any of these events and learn more about the Secretless Broker project. Feel free to reach
-out to us on our [mailing list](https://groups.google.com/forum/#!forum/secretless)
+out to us on our [Discourse](https://discuss.cyberarkcommons.org/c/secretless-broker)
 if you have any questions.
 
 You can find someone from the Secretless Broker engineering team at the CyberArk

--- a/docs/community.md
+++ b/docs/community.md
@@ -8,12 +8,12 @@ description: Secretless Broker Community
 <div class="row community">
 	<div class="col-md-4 col-sm-12">
     <h2><i class="slss-icon fas fa-code"></i> Contribute</h2>
-    <p>Secretless Broker development is open to contributions from the community, including feature requests and issues (which should be logged in our<a href="https://github.com/cyberark/secretless-broker">GitHub repository</a>.)</p>
+    <p>Secretless Broker development is open to contributions from the community, including feature requests and issues (which should be logged in our <a href="https://github.com/cyberark/secretless-broker">GitHub repository</a>.)</p>
     <p>Before contributing code changes, you will need to sign our <a href="https://github.com/cyberark/secretless-broker/blob/master/Contributing_OSS/CyberArk_Open_Source_Contributor_Agreement.pdf">Contributor Agreement</a> and submit the signed copy to <a href="mailto:oss@cyberark.com">oss@cyberark.com</a>.</p>
 	</div>
 	<div class="col-md-4 col-sm-12">
 		<h2><i class="slss-icon fas fa-comments"></i> Discuss</h2>
-    <p>For discussions on the product and to ask our engineering team about the specifics of deploying and using the Secretless Broker, please join our <a href="https://groups.google.com/forum/#!forum/secretless">Google group</a>.</p>
+    <p>For discussions on the product and to ask our engineering team about the specifics of deploying and using the Secretless Broker, please join our <a href="https://discuss.cyberarkcommons.org/c/secretless-broker">Discourse</a>.</p>
 	</div>
 	<div class="col-md-4 col-sm-12">
 		<h2><i class="slss-icon fas fa-exclamation-triangle"></i> Report</h2>


### PR DESCRIPTION
This PR updates all links in the repo / on the website to refer to the Discourse category for Secretless instead of the google group.