### PR TITLE
Fixed failing `proxyservice/tcp/proxy_service_test.go` tests

### DIFF
--- a/internal/proxyservice/tcp/proxy_service_test.go
+++ b/internal/proxyservice/tcp/proxy_service_test.go
@@ -32,7 +32,7 @@ func TestNewProxyService(t *testing.T) {
 
 	t.Run("non-empty constructor arguments result in no error", func(t *testing.T) {
 		_, err := NewProxyService(
-			mock.NewConnector().Connect,
+			mock.NewConnector(),
 			mock.NewListener(),
 			loggerMock.NewLogger(),
 			mock.NewCredentialRetriever().RetrieveCredentials,
@@ -59,7 +59,7 @@ func TestNewProxyService(t *testing.T) {
 
 		// exercise
 		ps := proxyService{
-			connector:           connector.Connect,
+			connector:           connector,
 			retrieveCredentials: credentialRetriever.RetrieveCredentials,
 			listener:            listener,
 		}
@@ -87,7 +87,7 @@ func TestProxyService_Start(t *testing.T) {
 		logger := loggerMock.NewLogger()
 
 		ps, _ := NewProxyService(
-			connector.Connect,
+			connector,
 			listener,
 			logger,
 			credentialRetriever.RetrieveCredentials,
@@ -122,7 +122,7 @@ func TestProxyService_Start(t *testing.T) {
 		// exercise
 
 		ps, err := NewProxyService(
-			connector.Connect,
+			connector,
 			listener,
 			logger,
 			credentialRetriever.RetrieveCredentials)
@@ -160,7 +160,7 @@ func TestProxyService_Start(t *testing.T) {
 		// exercise
 
 		ps, err := NewProxyService(
-			connector.Connect,
+			connector,
 			listener,
 			logger,
 			credentialRetriever.RetrieveCredentials)
@@ -199,7 +199,7 @@ func TestProxyService_Start(t *testing.T) {
 		// exercise
 
 		ps, err := NewProxyService(
-			connector.Connect,
+			connector,
 			listener,
 			logger,
 			credentialRetriever.RetrieveCredentials)
@@ -212,7 +212,7 @@ func TestProxyService_Start(t *testing.T) {
 		}
 
 		// assert
-		<- logger.ReceivedCall
+		<-logger.ReceivedCall
 		logger.AssertCalled(t, "Errorf")
 	})
 
@@ -239,7 +239,7 @@ func TestProxyService_Start(t *testing.T) {
 
 		// exercise
 		ps, err := NewProxyService(
-			connector.Connect,
+			connector,
 			listener,
 			logger,
 			credentialRetriever.RetrieveCredentials)
@@ -303,7 +303,7 @@ func TestProxyService_Start(t *testing.T) {
 
 		// exercise
 		ps, err := NewProxyService(
-			connector.Connect,
+			connector,
 			listener,
 			logger,
 			credentialRetriever.RetrieveCredentials)


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?

Fixes tests in `internal/proxyservice/tcp/proxy_service_test.go`

#### What ticket does this PR close?
N/A

#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
