### PR TITLE
Reenable full configfile manager functionality

### DIFF
--- a/cmd/secretless-broker/main.go
+++ b/cmd/secretless-broker/main.go
@@ -19,7 +19,7 @@ func CmdLineParams() *entrypoint.SecretlessOptions {
 
 	params := entrypoint.SecretlessOptions{}
 
-	flag.StringVar(&params.ConfigFile, "f", "secretless.yml", "Location of the configuration file.")
+	flag.StringVar(&params.ConfigFile, "f", "", "Location of the configuration file.")
 
 	// for CPU and Memory profiling
 	// Acceptable values to input: cpu or memory

--- a/internal/configurationmanagers/configfile/manager.go
+++ b/internal/configurationmanagers/configfile/manager.go
@@ -171,8 +171,8 @@ func ConfigurationManagerFactory(options plugin_v1.ConfigurationManagerOptions) 
 	}
 }
 
-// NewManager returns a file-based ConfigurationManager channel object
-func NewManager(configfile string, fsWatchEnabled bool) (<-chan config_v2.Config, error) {
+// NewConfigChannel returns a file-based ConfigurationManager channel object
+func NewConfigChannel(configfile string, fsWatchEnabled bool) (<-chan config_v2.Config, error) {
 	configChangedChan := make(chan config_v2.Config)
 
 	manager := &configurationManager{}

--- a/internal/configurationmanagers/configfile/manager.go
+++ b/internal/configurationmanagers/configfile/manager.go
@@ -29,6 +29,17 @@ type configurationManager struct {
 	Name              string
 }
 
+// Local adapter struct that changes the ConfigurationChangedHandler events to
+// chan config_v2.Config messages
+type changeHandler struct {
+	ConfigChangeChan chan config_v2.Config
+}
+
+func (ch *changeHandler) ConfigurationChanged(_ string, config config_v2.Config) error {
+	ch.ConfigChangeChan <- config
+	return nil
+}
+
 func (configManager *configurationManager) getConfigFilePreferenceOrder() ([]string, error) {
 	configFileOrder := []string{
 		"./" + ConfigFileName,
@@ -158,4 +169,25 @@ func ConfigurationManagerFactory(options plugin_v1.ConfigurationManagerOptions) 
 	return &configurationManager{
 		Name: options.Name,
 	}
+}
+
+// NewManager returns a file-based ConfigurationManager channel object
+func NewManager(configfile string, fsWatchEnabled bool) (<-chan config_v2.Config, error) {
+	configChangedChan := make(chan config_v2.Config)
+
+	manager := &configurationManager{}
+
+	cfgChangeHandler := changeHandler{
+		ConfigChangeChan: configChangedChan,
+	}
+
+	// Managers expect parameters to be passed in as URL params
+	cfgSpec := fmt.Sprintf("%s?watch=%t", configfile, fsWatchEnabled)
+
+	err := manager.Initialize(&cfgChangeHandler, cfgSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	return cfgChangeHandler.ConfigChangeChan, nil
 }

--- a/internal/proxyservice/tcp/proxy_service.go
+++ b/internal/proxyservice/tcp/proxy_service.go
@@ -174,5 +174,6 @@ func (proxy *proxyService) Start() error {
 func (proxy *proxyService) Stop() error {
 	proxy.logger.Infof("Stopping service")
 	proxy.done = true
+
 	return proxy.listener.Close()
 }

--- a/pkg/secretless/entrypoint/entrypoint.go
+++ b/pkg/secretless/entrypoint/entrypoint.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/cyberark/secretless-broker/internal"
 	"github.com/cyberark/secretless-broker/internal/configurationmanagers/configfile"
 	secretlessLog "github.com/cyberark/secretless-broker/internal/log"
 	"github.com/cyberark/secretless-broker/internal/plugin/v1/eventnotifier"
@@ -35,6 +36,11 @@ type SecretlessOptions struct {
 func StartSecretless(params *SecretlessOptions) {
 	showVersion(params.ShowVersion)
 
+	// Health check
+
+	util.SetAppInitializedFlag()
+	util.SetAppIsLive(false)
+
 	// Construct the deps of Service
 
 	// Coordinates processes interested in exit signals
@@ -55,6 +61,7 @@ func StartSecretless(params *SecretlessOptions) {
 	// Optional Performance Profiling
 	handlePerformanceProfiling(params.ProfilingMode, exitListener)
 
+	// Get a channel that notifies on configuration changes
 	configChangedChan, err := newConfigChangeChan(
 		params.ConfigFile,
 		params.ConfigManagerSpec,
@@ -64,25 +71,17 @@ func StartSecretless(params *SecretlessOptions) {
 		log.Fatalln(err)
 	}
 
-	// Health check: Initialized
-	util.SetAppInitializedFlag()
-	util.SetAppIsLive(false)
+	// Main event callbacks definitions
 
-	configChangedFunc := func(cfg v2.Config) {
+	var allServices internal.Service
+
+	// Main service reload callback
+	reloadConfig := func(cfg v2.Config) {
+		// Health check: Not live
 		util.SetAppIsLive(false)
+
 		// Start Services
-		allServices := proxyservice.NewProxyServices(cfg, availPlugins, logger, evtNotifier)
-		exitListener.AddHandler(func() {
-			fmt.Println("Received a stop signal")
-			err := allServices.Stop()
-			if err != nil {
-				// Log but but allow cleanup of other subscribers to continue.
-				log.Println(err)
-			}
-
-			os.Exit(0)
-		})
-
+		allServices = proxyservice.NewProxyServices(cfg, availPlugins, logger, evtNotifier)
 		err = allServices.Start()
 		if err != nil {
 			log.Fatalln(err)
@@ -90,15 +89,51 @@ func StartSecretless(params *SecretlessOptions) {
 
 		// Health check: Live
 		util.SetAppIsLive(true)
-		exitListener.Wait()
 	}
 
-	logger.Info("Waiting for configuration...")
-	cfg := <-configChangedChan
+	// Main listener for exit signals
+	exitListener.AddHandler(func() {
+		fmt.Println("Received a stop signal")
 
-	logger.Debug("Got new configuration")
-	configChangedFunc(cfg)
+		if allServices == nil {
+			os.Exit(0)
+		}
 
+		err := allServices.Stop()
+		if err != nil {
+			// Log but but allow cleanup of other subscribers to continue.
+			log.Println(err)
+		}
+
+		// TODO: Ideally we would soft-close all goroutines rather than rely on the
+		//       heavy-handed os.Exit to exit the broker when we want to.
+		os.Exit(0)
+	})
+
+	// Main processing loop
+
+	// Listen for and restart on config changes
+	go func() {
+		// TODO: This loop should probably be cleaned up rather than
+		//       rely on os.Exit() to end it.
+		for {
+			logger.Info("Waiting for configuration...")
+			cfg := <-configChangedChan
+
+			if allServices != nil {
+				err := allServices.Stop()
+				if err != nil {
+					// We don't expect problems with stopping services to be fatal
+					logger.Warnf("Problem stopping all services: %s", err)
+				}
+			}
+
+			logger.Debug("Got new configuration")
+			reloadConfig(cfg)
+		}
+	}()
+
+	exitListener.Wait()
 	logger.Info("Exiting...")
 }
 
@@ -112,7 +147,7 @@ func newConfigChangeChan(
 		return nil, fmt.Errorf("only 'configfile' configuration manager is supported")
 	}
 
-	return configfile.NewManager(cfgFile, fsWatchEnabled)
+	return configfile.NewConfigChannel(cfgFile, fsWatchEnabled)
 }
 
 func showVersion(showAndExit bool) {


### PR DESCRIPTION
New code used a bespoke (and basic) configfile loading procedure so with
these commits, we are reattaching the old configfile manager to it.
There's no new API yet, and we still need to get the CRDs configuration manager
attached but this should be a stepping stone for that.

Changes:
- Bespoke configuration loader removed
- `configfile` manager re-enabled
- Indirect result of this also enables USR1 signal reload-config trigger
- `configfile` manager modified to support this feature
- Proxy loop modified to remove existing socket files before reloading (to prevent failures from lack of cleanups)
- Main proxy loop modified to support a config channel configuration

#### What ticket does this PR close?
Connected to #916 

#### Where should the reviewer start?
Diff

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
