### PR TITLE
Fixed broken entrypoint unit test

### DIFF
--- a/pkg/secretless/entrypoint/entrypoint.go
+++ b/pkg/secretless/entrypoint/entrypoint.go
@@ -36,7 +36,12 @@ type SecretlessOptions struct {
 // StartSecretless method is the main entry point into the broker after the CLI
 // flags have been parsed
 func StartSecretless(params *SecretlessOptions) {
-	showVersion(params.ShowVersion)
+	if params.ShowVersion {
+		fmt.Printf("secretless-broker v%s\n", secretless.FullVersionName)
+		return
+	}
+
+	log.Printf("Secretless v%s starting up...", secretless.FullVersionName)
 
 	// Health check
 
@@ -169,14 +174,6 @@ func newConfigChangeChan(
 	}
 
 	return nil, fmt.Errorf("'%s' configuration manager not supported", cfgManagerSpec)
-}
-
-func showVersion(showAndExit bool) {
-	if showAndExit {
-		fmt.Printf("secretless-broker v%s\n", secretless.FullVersionName)
-		os.Exit(0)
-	}
-	log.Printf("Secretless v%s starting up...", secretless.FullVersionName)
 }
 
 // handlePerformanceProfiling starts a performance profiling, and sets up an

--- a/pkg/secretless/entrypoint/entrypoint_test.go
+++ b/pkg/secretless/entrypoint/entrypoint_test.go
@@ -8,8 +8,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cyberark/secretless-broker/pkg/secretless"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless"
 )
 
 func runEntrypoint(params *SecretlessOptions) (stdoutOutput string, stderrOutput string) {


### PR DESCRIPTION
Due to ue of `os.Exit` when printing the version, our test code was
unable to print deferred output and thus the tests were failing during
conversion to xml. We now do a soft-exit so that the output can be
properly parsed as "passing"

#### What does this PR do (include background context, if relevant)?
#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
