### PR TITLE
Revise integration tests to use existing images

### DIFF
--- a/test/http_basic_auth/docker-compose.yml
+++ b/test/http_basic_auth/docker-compose.yml
@@ -14,8 +14,7 @@ services:
       - ./basic_auth.htpasswd:/etc/nginx/.htpasswd:ro
 
   secretless:
-    build:
-      context: ../..
+    image: secretless-broker
     environment:
       HTTP_HOST: nginx
       HTTP_PORT: 8080

--- a/test/pg_handler/docker-compose.yml
+++ b/test/pg_handler/docker-compose.yml
@@ -25,9 +25,7 @@ services:
       timeout: 30s
 
   secretless-dev:
-    build:
-      context: ../..
-      dockerfile: Dockerfile.dev
+    image: secretless-dev
     command: ./bin/reflex
     volumes:
       - ../../:/secretless
@@ -35,8 +33,7 @@ services:
       - pg-socket:/sock
 
   secretless:
-    build:
-      context: ../..
+    image: secretless-broker
     volumes:
       - ../../test/util/ssl:/secretless/test/util/ssl
       - ./fixtures/secretless.yml:/secretless.yml

--- a/test/ssh_handler/docker-compose.yml
+++ b/test/ssh_handler/docker-compose.yml
@@ -12,8 +12,7 @@ services:
       - ./basic_auth.htpasswd:/etc/nginx/.htpasswd:ro
 
   secretless:
-    build:
-      context: ../..
+    image: secretless-broker
     ports:
       - 2222
     volumes:


### PR DESCRIPTION
At current, a handful of integration tests assume you'll build the needed
image at test time instead of using an existing image built using bin/build

This commit revises it so that all integration tests refer to images built
on top of an existing image (eg secretless-broker or secretless-dev) or uses
an existing image directly.