### PR TITLE
Fix flapping tests caused by MySQL integration tests

### DIFF
--- a/test/mysql_handler/start
+++ b/test/mysql_handler/start
@@ -14,10 +14,11 @@ done
 # ./ssl is REQUIRED during the build phase to make test ssl cert artifacts available to the docker context
 # The ssl certs are stored in ROOT/test/util/ssl and need to be copied because they are shared
 #
-rm -rf ssl
-cp -rf ../util/ssl ssl
+mkdir -p ssl
+rm -rf ssl/*
+cp -rf ../util/ssl/* ssl
+
 docker-compose build
-rm -rf ssl
 
 docker-compose up -d mysql mysql_no_tls
 

--- a/test/mysql_handler/stop
+++ b/test/mysql_handler/stop
@@ -1,5 +1,6 @@
 #!/bin/bash -ex
 
+rm -rf ssl
 rm -rf .env
 docker-compose down -v
 rm -rf sock/*


### PR DESCRIPTION
We were creating an unstable view of the FS by adding and removing
folders for docker-compose so we are now working around that by only
doing that on MySQL handler stop action.

#### What does this PR do (include background context, if relevant)?
#### What ticket does this PR close?
Connected to [relevant GitHub issues, eg #76]
#### Where should the reviewer start?
#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
#### Links to open issues for related automated integration and unit tests
#### Links to open issues for related documentation (in READMEs, docs, etc)
#### Screenshots (if appropriate)
