### PR TITLE
Bump version to 1.2.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,17 +1,22 @@
 #### What does this PR do (include background context, if relevant)?
+
 #### What ticket does this PR close?
-Connected to [relevant GitHub issues, eg #76]
+Connected to #[relevant GitHub issues, eg 76]
+
 #### Where should the reviewer start?
+
 #### What is the status of the manual tests?
 Have you run the following manual tests to verify existing functionality continues to function as expected?
 - [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
-- [ ] Manually run the [K8s demo](https://github.com/cyberark/secretless-broker/tree/master/demos/k8s-demo) (which requires changing the image the demo uses to the local build of Secretless)
 - [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
 
 If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
 - [ ] An updated README with instructions on how to manually test this feature
 - [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
 - [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
+
 #### Links to open issues for related automated integration and unit tests
+
 #### Links to open issues for related documentation (in READMEs, docs, etc)
+
 #### Screenshots (if appropriate)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.2.0] 2019-10-21
+
+### Added
+
+- Added a new public [plugin interface](pkg/secretless/plugin) for building connector plugins
+- Added a new public [log interface](pkg/secretless/log) for standardizing logging
+- Added code coverage reporting to unit test output
+- Added ability to run k8s-demo test on GKE
+
+### Changed
+
+- Refactored existing connectors to use new public connector plugin interface
+- Changed the core proxy and plugin manager to support the new public connector
+  plugin interface
+- Edited website Google Group links to link to Discourse
+- Updated the [example plugin](test/plugin) to implement the new plugin interface
+- Minor format changes to Apache 2.0 license
+- Project structure reorganized
+- Internal code updated to use v2 config instead of v1 config
+- Goreleaser build updated to cross-compile linux and darwin
+- Updated Conjur tests to use official CLI image
+
+### Fixed
+
+- Improve namespace cleanup in k8s-ci/test
+- Add COMPOSE_PROJECT_NAME to tests to fix namespace collision errors
+- Updated k8s-demo to use LoadBalancer on Services to avoid NodePort conflicts
+- Clarified quick demo directions
+- Improved error-handling / retry logic in k8s-ci
+
+### Deprecated
+
+- `Protocol` key in v2 config is replaced with `connector` key
+
 ## [1.1.0] 2019-08-09
 
 ### Added
@@ -318,7 +352,7 @@ external plugins
 
 The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.2.0...HEAD
 [0.2.0]: https://github.com/cyberark/secretless-broker/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/cyberark/secretless-broker/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/cyberark/secretless-broker/compare/v0.3.0...v0.4.0
@@ -335,3 +369,4 @@ The first tagged version.
 [0.8.0]: https://github.com/cyberark/secretless-broker/compare/v0.7.1...v0.8.0 
 [1.0.0]: https://github.com/cyberark/secretless-broker/compare/v0.8.0...v1.0.0 
 [1.1.0]: https://github.com/cyberark/secretless-broker/compare/v1.0.0...v1.1.0 
+[1.2.0]: https://github.com/cyberark/secretless-broker/compare/v1.1.0...v1.2.0 

--- a/pkg/secretless/version.go
+++ b/pkg/secretless/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the broker
-var Version = "1.1.0"
+var Version = "1.2.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
# PR Description
This PR bumps the Secretless version to v1.2.0.

Please review the changelog carefully, and if you have any suggestions for the prerelease notes please let me know by commenting on this PR.

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [x] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [x] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

#### Links to open issues for related automated integration and unit tests
Please see #901, #903, #904, and #899 (in progress) for automated unit tests we would still like to add after this effort.

We would also like to promote this release to stable, and #864 captures the work related to the performance testing we intend to perform.

#### Links to open issues for related documentation (in READMEs, docs, etc)
Remaining docs issues include cyberark/secretless-docs#181, #863, cyberark/secretless-docs#192