### PR TITLE
Update goreleaser homebrew definition

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,7 +97,7 @@ dist: ./dist/goreleaser
 brews:
   - description: Secures your apps by making them Secretless
     homepage: https://secretless.io
-    url_template: https://github.com/cyberark/secretless-broker/releases/download/v{{.Version}}/secretless-broker_{{.Version}}_darwin_amd64.tar.gz
+    url_template: https://github.com/cyberark/secretless-broker/releases/download/v{{.Version}}/secretless-broker_{{.Version}}_{{.Os}}_{{.Arch}}.tar.gz
     install: |
       bin.install "secretless-broker"
     test: |


### PR DESCRIPTION
At current the auto-generated homebrew tap is hardcoded to refer to the
darwin zip, but we generate both darwin and linux zip files. This PR updates
the brew def to use variables to generate the url template correctly.

