### PR TITLE
Add mssql connector

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,13 @@ pipeline {
           }
         }
 
+        stage('Integration: MSSQL Handler') {
+          steps {
+            sh './bin/run_integration mssql_connector'
+            junit 'test/mssql_connector/junit.xml'
+          }
+        }
+
         stage('Integration: PG Handler') {
           steps {
             sh './bin/run_integration pg_handler'

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/cyberark/conjur-api-go v0.5.2
 	github.com/cyberark/conjur-authn-k8s-client v0.13.0
 	github.com/cyberark/summon v0.7.0
+	github.com/denisenkom/go-mssqldb v0.0.0-20191001013358-cfbb681360f0
 	github.com/fsnotify/fsnotify v1.4.7
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-ozzo/ozzo-validation v0.0.0-20170913164239-85dcd8368eba
@@ -34,7 +35,7 @@ require (
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
 	github.com/spf13/pflag v1.0.2 // indirect
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
+	golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0 // indirect
 	gopkg.in/airbrake/gobrake.v2 v2.0.9 // indirect
 	gopkg.in/fsnotify.v1 v1.4.7 // indirect
@@ -48,3 +49,5 @@ require (
 	k8s.io/client-go v0.0.0-20180806134042-1f13a808da65
 	k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c // indirect
 )
+
+replace github.com/denisenkom/go-mssqldb => github.com/cyberark/go-mssqldb v0.0.0-20191030142036-b5a965a47dd3

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/cyberark/conjur-api-go v0.5.2 h1:8ntk07YNRz5bBwjNXkDEAPR70Yr+J2MN8NGl
 github.com/cyberark/conjur-api-go v0.5.2/go.mod h1:hwaReWirzgKor+JtH6vbwZaASDXulvd0SzGCloC5uOc=
 github.com/cyberark/conjur-authn-k8s-client v0.13.0 h1:sKh0yS6lSHT34FnMRR738+Q0dP+ebC6N/h4Bm9rhq0A=
 github.com/cyberark/conjur-authn-k8s-client v0.13.0/go.mod h1:JTeGIeRO59J7mMEc5yF6FPtk1QnaAzs4GyZa4WldqZc=
+github.com/cyberark/go-mssqldb v0.0.0-20191030142036-b5a965a47dd3 h1:qOMkK2hnBmmX40z/MHcZ0eVGATFK6lz+2VnsZFKMhY0=
+github.com/cyberark/go-mssqldb v0.0.0-20191030142036-b5a965a47dd3/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/cyberark/summon v0.7.0 h1:eBjyNzpJEeFb7BFcOgidM6S/UbEsN7LGSFeQE7szPsk=
 github.com/cyberark/summon v0.7.0/go.mod h1:S7grcxHeUxfL1vRTQUyq9jGK8yG6V/tSlLPQ6tHRO4k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -39,6 +41,8 @@ github.com/go-ozzo/ozzo-validation v0.0.0-20170913164239-85dcd8368eba/go.mod h1:
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20180513044358-24b0969c4cb7 h1:u4bArs140e9+AfE52mFHOXVFnOSBJBRlzTHrOPLOIhE=
@@ -183,6 +187,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0FNOmBrHfq7vN4btdGoDZgI=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/internal/plugin/connectors/tcp/mssql/authentication.go
+++ b/internal/plugin/connectors/tcp/mssql/authentication.go
@@ -1,0 +1,165 @@
+package mssql
+
+import (
+	"fmt"
+
+	mssql "github.com/denisenkom/go-mssqldb"
+)
+
+func (connector *SingleUseConnector) performPreLoginHandshake() error {
+	// using the default packet size of 4096
+	// (see https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/configure-the-network-packet-size-server-configuration-option)
+	clientBuffer := mssql.NewTdsBuffer(4096, connector.clientConn)
+	preloginRequest, err := mssql.ReadPreloginWithPacketType(clientBuffer, mssql.PackPrelogin)
+	if err != nil {
+		return fmt.Errorf("failed to read prelogin request: %s", err)
+	}
+
+	preloginResponse := preparePreloginResponse(preloginRequest)
+
+	err = mssql.WritePreloginWithPacketType(clientBuffer, preloginResponse, mssql.PackReply)
+	if err != nil {
+		return fmt.Errorf("failed to write prelogin response: %s", err)
+	}
+
+	// we actually don't need the client's handshake response.
+	// we just need for them to not be blocked
+	err = clientBuffer.ReadNextPacket()
+	if err != nil {
+		return fmt.Errorf("failed to read client login message: %s", err)
+	}
+
+	return nil
+}
+
+func preparePreloginResponse(preLoginRequest map[uint8][]byte) map[uint8][]byte {
+	// PRELOGIN message docs - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/60f56408-0188-4cd5-8b90-25c6f2423868
+
+	// The prelogin response message is identical to the request with minor changes
+	preloginResponse := preLoginRequest
+
+	// According to the mssql docs, The client can use the VERSION returned from
+	// the server to determine which features SHOULD be enabled or disabled.
+	// TODO: Extract version from server instead of hard-coded one.
+	// we use now the version of the sql server in the test
+	preloginResponse[mssql.PreloginVERSION] = []byte{0x0e, 0x00, 0x0c, 0xa6, 0x00, 0x00}
+
+	// Remove Client SSL Capability from Server Handshake Packet
+	// to force client to connect to Secretless without SSL
+	preloginResponse[mssql.PreloginENCRYPTION] = []byte{mssql.EncryptNotSup}
+
+	// According to the docs, this value should be empty when being sent from
+	// the server to the client.
+	preloginResponse[mssql.PreloginTHREADID] = []byte{}
+
+	// TODO: verify the rest of the message stays the same
+
+	return preloginResponse
+}
+
+// CreateAuthenticationOKMessage creates an MSSQL message which indicates
+// successful authentication.
+func (connector *SingleUseConnector) CreateAuthenticationOKMessage() []byte {
+	// The packet format - https://www.freetds.org/tds.html#packet
+	// The login ack response - https://www.freetds.org/tds.html#t173
+
+	// TODO: This message should stay static but it's better to build it the same way
+	// we do in the pg connector -
+	// https://github.com/cyberark/secretless-broker/blob/master/internal/plugin/connectors/tcp/pg/protocol/auth.go#L150
+
+	// TODO: Also check if we can (and need to) use the actual TDS version & server
+	//  details using go-mssqldb.
+	//  If so, we need to merge this PR - https://github.com/cyberark/go-mssqldb/pull/3
+
+	// Create a hard-coded OK response message
+	message := []byte{
+		// header
+		// [ REPLY packet type, last packet indicator, packet size (2 bytes),
+		// channel (2 bytes, can be zeroed), packet number, window (can be zeroed) ]
+		0x04, 0x01, 0x00, 0x4E, 0x00, 0x00, 0x01, 0x00,
+
+		// LoginAck Token
+		// Login ack indicator
+		0xad,
+		// Packet length - 54 bytes from the next one until the Done Token (not including)
+		0x36, 0x00,
+		// ack success - TODO: test with TDS 5.0, because there the success ack is 0x05
+		0x01,
+		// TDS version - TODO: verify that it can be hard coded regardless to
+		//  the actual TDS version of the server
+		0x74, 0x00, 0x00, 0x04,
+		// server name length - 22 chars
+		0x16,
+		// server name - 'Microsoft SQL Server'
+		0x4d, 0x00, 0x69, 0x00, 0x63, 0x00, 0x72, 0x00, 0x6f, 0x00, 0x73, 0x00,
+		0x6f, 0x00, 0x66, 0x00, 0x74, 0x00, 0x20, 0x00, 0x53, 0x00, 0x51, 0x00,
+		0x4c, 0x00, 0x20, 0x00, 0x53, 0x00, 0x65, 0x00, 0x72, 0x00, 0x76, 0x00,
+		0x65, 0x00, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00,
+		// server version - TODO: verify that it can be hard coded regardless
+		//  to the actual server version
+		0x0e, 0x00, 0x0c, 0xa6,
+
+		// Done Token - indicates the end of the packet
+		0xfd, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	return message
+}
+
+// CreateGenericErrorMessage creates an MSSQL error message
+func (connector *SingleUseConnector) CreateGenericErrorMessage() []byte {
+	// The packet format - https://www.freetds.org/tds.html#packet
+	// The Error token - https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-tds/9805e9fa-1f8b-4cf8-8f78-8d2602228635
+
+	// TODO: Create the error object with go-mssqldb. In order to use it, we should
+	// add there a function to convert the object to a byte array
+
+	// Create a hard-coded error response message
+	message := []byte{
+		// header
+		// [ REPLY packet type, last packet indicator, packet size (2 bytes),
+		// channel (2 bytes, can be zeroed), packet number, window (can be zeroed) ]
+		0x04, 0x01, 0x00, 0x7a, 0x00, 0x33, 0x01, 0x00,
+
+		// Error Token
+		// Error token indicator
+		0xaa,
+		// Token length - 2 bytes
+		0x62, 0x00,
+		// SQL Error Number - currently using 18456 (login failed for user)
+		// TODO: Find generic error number
+		0x18, 0x48, 0x00, 0x00,
+		// state - TODO: better understand this.
+		0x01,
+		// severity - 16 indicates a general error that can be corrected by the user.
+		0x0e,
+		// Error message length
+		0x1e, 0x00,
+		// Error message: "Generic SQL Error"
+		0x47, 0x00, 0x65, 0x00, 0x6e, 0x00, 0x65, 0x00, 0x72, 0x00,
+		0x69, 0x00, 0x63, 0x00, 0x20, 0x00, 0x53, 0x00, 0x51, 0x00,
+		0x4c, 0x00, 0x20, 0x00, 0x45, 0x00, 0x72, 0x00, 0x72, 0x00,
+		0x6f, 0x00, 0x72, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		// server name length - TODO: Change this according to the name
+		0x0c,
+		// server name - TODO: Understand this and change accordingly.
+		//  This is the value received from the sql server in the test
+		0x61, 0x00, 0x64, 0x00, 0x30, 0x00, 0x39, 0x00,
+		0x37, 0x00, 0x33, 0x00, 0x31, 0x00, 0x37, 0x00,
+		0x35, 0x00, 0x38, 0x00, 0x33, 0x00, 0x35, 0x00,
+		// process name length (can be zero)
+		0x00,
+		// Line number - zero indicates that it's not related to an SQL batch line
+		0x00, 0x00, 0x00, 0x00,
+		// Done Token - indicates the end of the packet
+		0xfd,
+		0x02, 0x00,
+		0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	}
+
+	return message
+}

--- a/internal/plugin/connectors/tcp/mssql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details.go
@@ -1,0 +1,50 @@
+package mssql
+
+import (
+	"strconv"
+)
+
+// ConnectionDetails stores the connection info to the real backend database.
+// These values are pulled from the SingleUseConnector credentials config
+type ConnectionDetails struct {
+	Host     string
+	Port     uint
+	Username string
+	Password string
+}
+
+const defaultMSSQLPort = uint(1433)
+
+// NewConnectionDetails is a constructor of ConnectionDetails structure from a
+// map of credentials.
+func NewConnectionDetails(credentials map[string][]byte) (*ConnectionDetails, error) {
+
+	connDetails := &ConnectionDetails{}
+
+	if host := credentials["host"]; host != nil {
+		connDetails.Host = string(credentials["host"])
+	}
+
+	connDetails.Port = defaultMSSQLPort
+	if credentials["port"] != nil {
+		port64, _ := strconv.ParseUint(string(credentials["port"]), 10, 64)
+		connDetails.Port = uint(port64)
+	}
+
+	if credentials["username"] != nil {
+		connDetails.Username = string(credentials["username"])
+	}
+
+	if credentials["password"] != nil {
+		connDetails.Password = string(credentials["password"])
+	}
+
+	return connDetails, nil
+}
+
+// Address returns a string representing the network location (host and port)
+// of a MSSQL server.  This is the string you would would typically use to
+// connect to the database -- eg, in cmd line tools.
+func (cd *ConnectionDetails) Address() string {
+	return cd.Host + ":" + strconv.FormatUint(uint64(cd.Port), 10)
+}

--- a/internal/plugin/connectors/tcp/mssql/connector.go
+++ b/internal/plugin/connectors/tcp/mssql/connector.go
@@ -1,0 +1,113 @@
+package mssql
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/log"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
+
+	mssql "github.com/denisenkom/go-mssqldb"
+)
+
+// SingleUseConnector is used to create an authenticated connection to an MSSQL target
+type SingleUseConnector struct {
+	backendConn net.Conn
+	clientConn  net.Conn
+	logger      log.Logger
+}
+
+// Connect implements the tcp.Connector func signature
+//
+// It is the main method of the SingleUseConnector. It:
+//   1. Constructs connection details from the provided credentials map.
+//   2. Dials the backend using credentials.
+//   3. Runs through the connection phase steps to authenticate.
+//
+// Connect requires "host", "port", "username" and "password" credentials.
+func (connector *SingleUseConnector) Connect(
+	clientConn net.Conn,
+	credentialValuesByID connector.CredentialValuesByID,
+) (net.Conn, error) {
+
+	connector.clientConn = clientConn
+
+	err := connector.performPreLoginHandshake()
+	if err != nil {
+		connector.logger.Errorf("Failed to handle client prelogin request: %s", err)
+		connector.sendErrorToClient()
+		return nil, err
+	}
+
+	connDetails, err := NewConnectionDetails(credentialValuesByID)
+	if err != nil {
+		connector.sendErrorToClient()
+		return nil, err
+	}
+
+	err = connector.ConnectToBackend(dataSourceName(connDetails))
+	if err != nil {
+		connector.logger.Errorf("Failed to connect to backend: %s", err)
+		connector.sendErrorToClient()
+		return nil, err
+	}
+
+	// Now that the backend connection is authenticated, send the client
+	// a successful authentication response.
+	if _, err = clientConn.Write(connector.CreateAuthenticationOKMessage()); err != nil {
+		connector.logger.Errorf("Failed to send a successful authentication"+
+			" response to the client"+
+			": %s", err)
+		connector.sendErrorToClient()
+		return nil, err
+	}
+
+	return connector.backendConn, nil
+}
+
+// ConnectToBackend establishes the connection to the target database and sets
+// the backendConnection field.
+func (connector *SingleUseConnector) ConnectToBackend(dataSourceName string) error {
+	var err error
+
+	// Using DSN (Data Source Name) string because gomssql forces us to.
+	//
+	// NOTE: Secretless has some unfortunate naming collisions with the
+	// go-mssqldb driver package.  The driver package has its own concept of a
+	// "connector", and its connectors also have a "Connect" method.
+	driverConnector, err := mssql.NewConnector(dataSourceName)
+	if err != nil {
+		connector.logger.Errorf("Failed to create a go-mssqldb connector: %s", err)
+		return err
+	}
+
+	driverConn, err := driverConnector.Connect(context.Background())
+	if err != nil {
+		connector.logger.Errorf("failed to connect to mssql server: %s", err)
+		return err
+	}
+
+	// Verify the driverConn is an mssql driverConn object and get its underlying transport
+	mssqlConn := driverConn.(*mssql.Conn)
+	connector.backendConn = mssqlConn.NetConn()
+
+	return nil
+}
+
+// TODO: add ability to receive an MSSQL error and send it to the client
+func (connector *SingleUseConnector) sendErrorToClient() {
+	mssqlError := connector.CreateGenericErrorMessage()
+	if _, e := connector.clientConn.Write(mssqlError); e != nil {
+		connector.logger.Errorf("failed to write error %s to MSSQL client", e)
+	}
+}
+
+func dataSourceName(connDetails *ConnectionDetails) string {
+	return fmt.Sprintf(
+		"sqlserver://%s:%s@%s",
+		connDetails.Username,
+		connDetails.Password,
+		connDetails.Address(),
+	)
+}

--- a/internal/plugin/connectors/tcp/mssql/plugin.go
+++ b/internal/plugin/connectors/tcp/mssql/plugin.go
@@ -1,0 +1,48 @@
+package mssql
+
+import (
+	"net"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
+)
+
+/*
+NewConnector returns a tcp.Connector which returns an authenticated connection
+to a target service for each incoming client connection. It is a required
+method on the tcp.Plugin interface. The single argument passed in is of type
+connector.Resources. It contains connector-specific config and a logger.
+*/
+func NewConnector(conRes connector.Resources) tcp.Connector {
+	connect := func(
+		clientConn net.Conn,
+		credentialValuesByID connector.CredentialValuesByID,
+	) (backendConn net.Conn, err error) {
+		// SingleUseConnector is responsible for generating the authenticated connection
+		// to the target service for each incoming client connection
+		singleUseConnector := &SingleUseConnector{
+			logger: conRes.Logger(),
+		}
+
+		return singleUseConnector.Connect(clientConn, credentialValuesByID)
+	}
+
+	return tcp.ConnectorFunc(connect)
+}
+
+// PluginInfo is required as part of the Secretless plugin spec. It provides
+// important metadata about the plugin.
+func PluginInfo() map[string]string {
+	return map[string]string{
+		"pluginAPIVersion": "0.1.0",
+		"type":             "connector.tcp",
+		"id":               "mssql",
+		"description":      "returns an authenticated connection to a MSSQL database",
+	}
+}
+
+// GetTCPPlugin is required as part of the Secretless plugin spec for TCP connector
+// plugins. It returns the TCP plugin.
+func GetTCPPlugin() tcp.Plugin {
+	return tcp.ConnectorConstructor(NewConnector)
+}

--- a/internal/plugin/connectors/tcp/mysql/connector.go
+++ b/internal/plugin/connectors/tcp/mysql/connector.go
@@ -42,7 +42,6 @@ func (connector *SingleUseConnector) sendErrorToClient(err error) {
 //   1. Constructs connection details from the provided credentials map.
 //   2. Dials the backend using credentials.
 //   3. Runs through the connection phase steps to authenticate.
-//   4. Pipes all future bytes unaltered between client and server.
 //
 // Connect requires "host", "port", "username" and "password" credentials.
 func (connector *SingleUseConnector) Connect(

--- a/internal/plugin/connectors/tcp/mysql/plugin.go
+++ b/internal/plugin/connectors/tcp/mysql/plugin.go
@@ -7,26 +7,27 @@ import (
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
 )
 
-// NewConnector returns a tcp.Connector which returns an authenticated connection
-// to a target service for each incoming client connection.
-// It is a required method on the tcp.Plugin interface.
-// The single argument passed in is of type connector.Resources. It contains
-// connector-specific config and a logger.
+/*
+NewConnector returns a tcp.Connector which returns an authenticated connection
+to a target service for each incoming client connection. It is a required
+method on the tcp.Plugin interface. The single argument passed in is of type
+connector.Resources. It contains connector-specific config and a logger.
+*/
 func NewConnector(conRes connector.Resources) tcp.Connector {
-	connectorFunc := func(
+	connect := func(
 		clientConn net.Conn,
 		credentialValuesByID connector.CredentialValuesByID,
 	) (backendConn net.Conn, err error) {
 		// singleUseConnector is responsible for generating the authenticated connection
 		// to the target service for each incoming client connection
 		singleUseConnector := &SingleUseConnector{
-			logger:   conRes.Logger(),
+			logger: conRes.Logger(),
 		}
 
 		return singleUseConnector.Connect(clientConn, credentialValuesByID)
 	}
 
-	return tcp.ConnectorFunc(connectorFunc)
+	return tcp.ConnectorFunc(connect)
 }
 
 // PluginInfo is required as part of the Secretless plugin spec. It provides

--- a/internal/plugin/connectors/tcp/pg/connector.go
+++ b/internal/plugin/connectors/tcp/pg/connector.go
@@ -49,7 +49,6 @@ func (s *SingleUseConnector) abort(err error) {
 //   1. Constructs connection details from the provided credentials map.
 //   2. Dials the backend using credentials.
 //   3. Runs through the connection phase steps to authenticate.
-//   4. Pipes all future bytes unaltered between client and server.
 //
 // Connect requires "host", "port", "username" and "password" credentials.
 func (s *SingleUseConnector) Connect(

--- a/internal/plugin/connectors/tcp/pg/plugin.go
+++ b/internal/plugin/connectors/tcp/pg/plugin.go
@@ -7,24 +7,27 @@ import (
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
 )
 
-// NewConnector returns a tcp.Connector which returns an authenticated
-// connection to a target service for each incoming client connection. It is a
-// required method on the tcp.Plugin interface.
+/*
+NewConnector returns a tcp.Connector which returns an authenticated connection
+to a target service for each incoming client connection. It is a required
+method on the tcp.Plugin interface. The single argument passed in is of type
+connector.Resources. It contains connector-specific config and a logger.
+*/
 func NewConnector(conRes connector.Resources) tcp.Connector {
-	newConnectorFunc := func(
+	connect := func(
 		clientConn net.Conn,
 		credentialValuesByID connector.CredentialValuesByID,
 	) (backendConn net.Conn, err error) {
 		// singleUseConnector is responsible for generating the authenticated connection
 		// to the target service for each incoming client connection
 		singleUseConnector := &SingleUseConnector{
-			logger:   conRes.Logger(),
+			logger: conRes.Logger(),
 		}
 
 		return singleUseConnector.Connect(clientConn, credentialValuesByID)
 	}
 
-	return tcp.ConnectorFunc(newConnectorFunc)
+	return tcp.ConnectorFunc(connect)
 }
 
 // PluginInfo is required as part of the Secretless plugin spec. It provides

--- a/pkg/secretless/plugin/connector/README.md
+++ b/pkg/secretless/plugin/connector/README.md
@@ -2,7 +2,7 @@
 
 For general info on Secretless plugins, please refer to the [plugin README](../README.md).
 
-Secretless has built-in support for PostgreSQL, MySQL, APIs that use basic
+Secretless has built-in support for PostgreSQL, MySQL, Microsoft SQL Server, APIs that use basic
 HTTP authentication, and many other target services.
 
 If you want to use Secretless with a target service that is not supported out of

--- a/pkg/secretless/plugin/sharedobj/internal_plugins.go
+++ b/pkg/secretless/plugin/sharedobj/internal_plugins.go
@@ -4,6 +4,7 @@ import (
 	"github.com/cyberark/secretless-broker/internal/plugin/connectors/http/aws"
 	"github.com/cyberark/secretless-broker/internal/plugin/connectors/http/basicauth"
 	"github.com/cyberark/secretless-broker/internal/plugin/connectors/http/conjur"
+	"github.com/cyberark/secretless-broker/internal/plugin/connectors/tcp/mssql"
 	"github.com/cyberark/secretless-broker/internal/plugin/connectors/tcp/mysql"
 	"github.com/cyberark/secretless-broker/internal/plugin/connectors/tcp/pg"
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin"
@@ -16,6 +17,7 @@ type InternalPluginLookupFunc func() (plugin.AvailablePlugins, error)
 
 // GetInternalPluginsFunc returns currently available built-in plugins.
 func GetInternalPluginsFunc() (plugin.AvailablePlugins, error) {
+	// New connectors should have an entry in the map below, according to their type (HTTP/TCP)
 	return &Plugins{
 		HTTPPluginsByID: map[string]http.Plugin{
 			"aws":        aws.GetHTTPPlugin(),
@@ -25,6 +27,7 @@ func GetInternalPluginsFunc() (plugin.AvailablePlugins, error) {
 		TCPPluginsByID: map[string]tcp.Plugin{
 			"pg":    pg.GetTCPPlugin(),
 			"mysql": mysql.GetTCPPlugin(),
+			"mssql": mssql.GetTCPPlugin(),
 		},
 	}, nil
 }

--- a/pkg/secretless/plugin/sharedobj/internal_plugins_test.go
+++ b/pkg/secretless/plugin/sharedobj/internal_plugins_test.go
@@ -93,7 +93,7 @@ func TestGetInternalPlugins(t *testing.T) {
 		}
 
 		if internalPlugins.TCPPlugins() != nil {
-			assert.Equal(t, 2, len(internalPlugins.TCPPlugins()))
+			assert.Equal(t, 3, len(internalPlugins.TCPPlugins()))
 		}
 	})
 }

--- a/test/mssql_connector/dev
+++ b/test/mssql_connector/dev
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+./start -d

--- a/test/mssql_connector/docker-compose.yml
+++ b/test/mssql_connector/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.0'
+
+services:
+  mssql:
+    image: mcr.microsoft.com/mssql/server:2017-latest
+    ports:
+      - 1433:1433
+    environment:
+      # This hardcoded password must match the one in secretless.yml.
+      SA_PASSWORD: "yourStrong()Password"
+      ACCEPT_EULA: Y
+
+  secretless:
+    image: secretless-broker
+    ports:
+      - 2223:2223
+    volumes:
+      - ./secretless.yml:/secretless.yml
+    depends_on:
+      - mssql
+
+  secretless-dev:
+    image: secretless-dev
+    command: ./bin/reflex
+    ports:
+      - 2223:2223
+    volumes:
+      - ../../:/secretless
+      - ./secretless.yml:/secretless.yml
+    depends_on:
+      - mssql
+
+  test:
+    image: secretless-dev
+    command: sleep 999d
+    environment:
+      TEST_ROOT: /secretless/test/mssql_connector
+      DB_PROTOCOL: mssql
+      DB_HOST_TLS: mssql
+      DB_HOST_NO_TLS: mssql # TODO: configure a non-ssl container?
+      DB_PORT: 1433
+      DB_USER: sa
+      DB_PASSWORD: yourStrong()Password
+      SECRETLESS_HOST:
+    volumes:
+      - ../../:/secretless

--- a/test/mssql_connector/mssql_connector_test.go
+++ b/test/mssql_connector/mssql_connector_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+
+	_ "github.com/denisenkom/go-mssqldb"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/test/util/testutil"
+)
+
+func TestMSSQLConnector(t *testing.T) {
+	t.Run("Can connect to MSSQL through Secretless", func(t *testing.T) {
+		port := 2223
+		server := testutil.SecretlessHost
+
+		// Open the connection
+		connString := fmt.Sprintf("server=%s;port=%d;encrypt=disable", server, port)
+		conn, err := sql.Open("mssql", connString)
+		assert.Nil(t, err, "you can open the db connection")
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		// Prepare the test query
+		testInt := 1
+		testString := "abc"
+		stmt, err := conn.Prepare(fmt.Sprintf("select %d, '%s'", testInt, testString))
+		assert.Nil(t, err, "you can prepare the statement")
+		if err != nil {
+			return
+		}
+		defer stmt.Close()
+
+		// Execute the query
+		row := stmt.QueryRow()
+		var actualInt int64
+		var actualString string
+		err = row.Scan(&actualInt, &actualString)
+		assert.Nil(t, err, "you can read the queried values")
+		if err != nil {
+			return
+		}
+
+		// Test the returned values
+		assert.EqualValues(t, testInt, actualInt)
+		assert.EqualValues(t, testString, actualString)
+	})
+
+	t.Run("Cannot connect directly to MSSQL", func(t *testing.T) {
+		port := 1433
+		server := "mssql"
+
+		// Open the connection
+		connString := fmt.Sprintf("server=%s;port=%d;encrypt=disable", server, port)
+		conn, err := sql.Open("mssql", connString)
+		assert.Nil(t, err, "you can open the db connection")
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		// Prepare the test query - should fail because the connection is not authenticated
+		testInt := 1
+		testString := "abc"
+		_, err = conn.Prepare(fmt.Sprintf("select %d, '%s'", testInt, testString))
+		assert.NotNil(t, err, "Prepare fails without a successful login")
+		assert.Contains(t, err.Error(), "Login failed")
+	})
+}

--- a/test/mssql_connector/secretless.yml
+++ b/test/mssql_connector/secretless.yml
@@ -1,0 +1,12 @@
+version: 2
+
+services:
+  mssql:
+    connector: mssql
+    listenOn: tcp://0.0.0.0:2223
+    credentials:
+      username: sa
+      # This hardcoded password must match the one in the docker-compose.
+      password: yourStrong()Password
+      host: mssql
+      port: 1433

--- a/test/mssql_connector/start
+++ b/test/mssql_connector/start
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+
+SECRETLESS_HOST=secretless
+while getopts :d opt; do
+    case $opt in
+        d) SECRETLESS_HOST=secretless-dev;;
+       \?) echo "Unknown option -$OPTARG"; exit 1;;
+    esac
+done
+
+./stop
+
+# the order of the services is important. mssql must be up before we start secretless
+docker-compose up -d mssql
+
+./wait_for_mssql
+docker-compose logs mssql
+
+docker-compose up -d $SECRETLESS_HOST

--- a/test/mssql_connector/stop
+++ b/test/mssql_connector/stop
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+docker-compose down -v

--- a/test/mssql_connector/test
+++ b/test/mssql_connector/test
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+export SECRETLESS_HOST=secretless
+if [[ ! -z $(docker-compose ps -q secretless-dev) ]]; then
+  export SECRETLESS_HOST=secretless-dev
+fi
+
+docker-compose run \
+  -e SECRETLESS_HOST="$SECRETLESS_HOST" \
+  --rm \
+  --no-deps \
+  test bash -c "go test -v ./test/mssql_connector"
+
+# print secretless logs after tests run
+ret=$?
+docker-compose logs $SECRETLESS_HOST
+exit $ret

--- a/test/mssql_connector/wait_for_mssql
+++ b/test/mssql_connector/wait_for_mssql
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+mssql_is_up() {
+    docker-compose logs mssql | grep "SQL Server is now ready for client connections"
+}
+
+# TODO: Use bash-lib for this function once it is implemented there
+max_tries=30
+cnt=0
+until mssql_is_up || (( cnt == max_tries )); do
+  (( cnt++ ))
+  sleep 1
+done
+
+timed_out=$(( cnt == max_tries ))
+if [[ $timed_out -eq 1 ]]; then
+  echo "MSSQL Server failed to start"
+  exit 1
+fi


### PR DESCRIPTION
This adds an end-to-end, working POC of the MSSQL connector, including a basic integration test.

Future work to make it more robust:

  - Add more integration tests
    - The current test suite includes:
      - Application can connect to MSSQL through Secretless without creds in the request
      - Application cannot connect directly to MSSQL without creds in the request
  - Add UTs
  - Verify the PRELOGIN response is created correctly
  - Test the OK message with different TDS versions and Server versions
  - Build the OK message the way we do it PG
  - Check if we can extract Login Ack response details
  - Run a security review of the 3rd party (https://github.com/denisenkom/go-mssqldb)

All the code changes requirements have TODOs in the code.
