### PR TITLE
Update juxtaposer configs

### DIFF
--- a/bin/juxtaposer/aggregate.py
+++ b/bin/juxtaposer/aggregate.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Ensure we are on Python3
+import sys
+assert sys.version_info >= (3, 0), "Python3 should be used to run this program"
+
 import argparse
 import re
 

--- a/bin/juxtaposer/deploy/bootstrap.sh
+++ b/bin/juxtaposer/deploy/bootstrap.sh
@@ -1,15 +1,15 @@
 export CONFIG_TEMPLATE=pg
-export TEST_DURATION=96h
+export TEST_DURATION=1h
 
 export APP_NAME=juxtaposer-${CONFIG_TEMPLATE}
 
 export APP_SERVICE_ACCOUNT=secretless-xa
-export AUTHENTICATOR_ID=openshift/secretless-xa
+export AUTHENTICATOR_ID=openshift/xa-secretless
 export DAP_ACCOUNT=xa
 export DAP_NAMESPACE_NAME=xa-secretless
 export DAP_SSL_CERT_CONFIG_MAP=dap-ssl-cert
 export DOCKER_REGISTRY_PATH=REPLACEME
-export SECRETELESS_IMAGE="cyberark/secretless-broker:0.7.1-becf48d"
+export SECRETELESS_IMAGE="cyberark/secretless-broker:1.2.0"
 export TEST_APP_NAMESPACE_NAME=srdjan-secretless-xa
 
 OC_REPOSITORY="docker-registry.default.svc:5000/$TEST_APP_NAMESPACE_NAME"

--- a/bin/juxtaposer/deploy/juxtaposer_mysql.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_mysql.yml
@@ -5,7 +5,7 @@ comparison:
   baselineBackend: mysql_direct
 #  recreateConnections: true
   rounds: 10000
-  threads: 10
+  threads: 1
   silent: false
 
 formatters:
@@ -24,8 +24,8 @@ backends:
   mysql_secretless_tcp:
     host: localhost
     port: 13306
-    database: secretless_xa
+    database: secretless
 
   mysql_secretless_socket:
     host: /sock/mysql
-    database: secretless_xa
+    database: secretless

--- a/bin/juxtaposer/deploy/juxtaposer_pg.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_pg.yml
@@ -6,7 +6,7 @@ comparison:
 #  recreateConnections: true
   rounds: 10000
   silent: false
-  threads: 10
+  threads: 1
 
 formatters:
   json:
@@ -24,14 +24,14 @@ backends:
   pg_secretless_tcp:
     host: localhost
     port: 15432
-    database: secretless_xa
+    database: secretless
     username: foo
     password: foo
     sslmode: disable
 
   pg_secretless_socket:
     host: /sock
-    database: secretless_xa
+    database: secretless
     username: foo
     password: foo
     sslmode: disable

--- a/bin/juxtaposer/deploy/secretless.yml
+++ b/bin/juxtaposer/deploy/secretless.yml
@@ -7,16 +7,16 @@ services:
     credentials:
       username:
         from: conjur
-        get: secretless-xa-db/mysql/username
+        get: conjur/xa-secretless-db/mysql/username
       password:
         from: conjur
-        get: secretless-xa-db/mysql/password
+        get: conjur/xa-secretless-db/mysql/password
       host:
         from: conjur
-        get: secretless-xa-db/mysql/hostname
+        get: conjur/xa-secretless-db/mysql/hostname
       port:
         from: conjur
-        get: secretless-xa-db/mysql/port
+        get: conjur/xa-secretless-db/mysql/port
 
   mysql-sock:
     connector: mysql
@@ -24,16 +24,16 @@ services:
     credentials:
       username:
         from: conjur
-        get: secretless-xa-db/mysql/username
+        get: conjur/xa-secretless-db/mysql/username
       password:
         from: conjur
-        get: secretless-xa-db/mysql/password
+        get: conjur/xa-secretless-db/mysql/password
       host:
         from: conjur
-        get: secretless-xa-db/mysql/hostname
+        get: conjur/xa-secretless-db/mysql/hostname
       port:
         from: conjur
-        get: secretless-xa-db/mysql/port
+        get: conjur/xa-secretless-db/mysql/port
 
   pg-tcp:
     connector: pg
@@ -41,13 +41,16 @@ services:
     credentials:
       username:
         from: conjur
-        get: secretless-xa-db/postgresql/username
+        get: conjur/xa-secretless-db/postgresql/username
       password:
         from: conjur
-        get: secretless-xa-db/postgresql/password
-      address:
+        get: conjur/xa-secretless-db/postgresql/password
+      host:
         from: conjur
-        get: secretless-xa-db/postgresql/hostname
+        get: conjur/xa-secretless-db/postgresql/hostname
+      port:
+        from: conjur
+        get: conjur/xa-secretless-db/postgresql/port
 
   pg-sock:
     connector: pg
@@ -55,10 +58,13 @@ services:
     credentials:
       username:
         from: conjur
-        get: secretless-xa-db/postgresql/username
+        get: conjur/xa-secretless-db/postgresql/username
       password:
         from: conjur
-        get: secretless-xa-db/postgresql/password
-      address:
+        get: conjur/xa-secretless-db/postgresql/password
+      host:
         from: conjur
-        get: secretless-xa-db/postgresql/hostname
+        get: conjur/xa-secretless-db/postgresql/hostname
+      port:
+        from: conjur
+        get: conjur/xa-secretless-db/postgresql/port


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
- Juxtaposer default configuration have been updated
- Better error handling was added to `aggregate.py` script

#### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

#### Where should the reviewer start?

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
