### PR TITLE
improve pg error propagation

### DIFF
--- a/internal/plugin/connectors/tcp/pg/protocol/auth.go
+++ b/internal/plugin/connectors/tcp/pg/protocol/auth.go
@@ -32,6 +32,11 @@ func HandleAuthenticationRequest(username string, password string, connection ne
 		return
 	}
 
+	if messageType == ErrorMessageType {
+		err = NewError(message)
+		return
+	}
+
 	if messageType != AuthenticationMessageType {
 		err = fmt.Errorf("Expected %d message type, got %d", AuthenticationMessageType, messageType)
 		return
@@ -104,6 +109,11 @@ func verifyAuthentication(connection net.Conn) (err error) {
 	var messageType byte
 	var message []byte
 	if messageType, message, err = ReadMessage(connection); err != nil {
+		return
+	}
+
+	if messageType == ErrorMessageType {
+		err = NewError(message)
 		return
 	}
 


### PR DESCRIPTION
Instead of giving the client a useless error of the form:
```
psql: FATAL:  Expected 82 message type, got 69
```
This PR makes it so that pg errors are faithfully propagated to the client:

```
psql: FATAL:  password authentication failed for user "test"
```