### PR TITLE
Broken Link: 10Factor Url corrected to reflect new location

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -63,7 +63,7 @@ Consider the guidelines in [The Ten-Factor CI Job][10factor].
 
 [cmos]: http://www.chicagomanualofstyle.org/home.html
 [names]: https://en.wikipedia.org/wiki/Alice_and_Bob#Cast_of_characters
-[10factor]: http://www.10factor.ci/
+[10factor]: http://tenfactorci-conjur.herokuapp.com
 [golint]: https://github.com/golang/lint
 
 ## Contributing


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
The URL in the style guide pointed to a broken / incorrect location. This updated URL is taken from the 10Factor GitHub page.

#### What ticket does this PR close?
None

#### Where should the reviewer start?
STYLE.md

#### What is the status of the manual tests?
Unaffected
