### PR TITLE
Add trivy security scan to project pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,12 @@ pipeline {
         sh './bin/build'
       }
     }
+    
+    stage('Scan Secretless Image') {
+      steps {
+        scanAndReport("secretless-broker:latest", "HIGH")
+      }
+    }
 
     stage('Run Tests') {
 


### PR DESCRIPTION
We've enabled Trivy (https://github.com/aquasecurity/trivy) in our Jenkins pipelines
and this commit adds it to the Secretless build to scan the Secretless image

Users aren't deploying the quick start or dev images, so those are not being scanned at this time.