### PR TITLE
Move "ensureSocketIsDeleted" logic into "ConfigEnv" and unit test it.

### DIFF
--- a/internal/proxyservice/proxy_service.go
+++ b/internal/proxyservice/proxy_service.go
@@ -3,8 +3,6 @@ package proxyservice
 import (
 	"fmt"
 	"net"
-	"net/url"
-	"os"
 	"strings"
 
 	"github.com/go-ozzo/ozzo-validation"
@@ -38,14 +36,6 @@ type proxyServices struct {
 
 // Start starts all proxy services
 func (s *proxyServices) Start() error {
-	for _, service := range s.config.Services {
-		err := s.ensureSocketIsDeleted(service.ListenOn)
-		if err != nil {
-			// TODO: Add Fatalf to our logger and use that
-			s.logger.Panic(err)
-		}
-	}
-
 	for _, svc := range s.servicesToStart() {
 		err := svc.Start()
 		if err != nil {
@@ -144,39 +134,6 @@ func (s *proxyServices) servicesToStart() (servicesToStart []internal.Service) {
 	}
 
 	return servicesToStart
-}
-
-// If we are a socket listener and there is a socket file already
-// we need to ensure that the socket file is remoed before starting
-// the service.
-func (s *proxyServices) ensureSocketIsDeleted(address string) error {
-	parsedURL, err := url.Parse(address)
-	if err != nil {
-		return fmt.Errorf("unable to parse ListenOn location '%s'", address)
-	}
-
-	// If we're not a unix socket address, we don't need to worry about pre-emptive cleanup
-	if parsedURL.Scheme != "unix" {
-		return nil
-	}
-
-	socketFile := parsedURL.Path
-	s.logger.Debugf("Ensuring that the socketfile '%s' is not present...", socketFile)
-
-	// If file is not present, then we are ok to continue
-	if _, err := os.Stat(socketFile); os.IsNotExist(err) {
-		s.logger.Debugf("Socket file '%s' not present. Skipping deletion.", socketFile)
-		return nil
-	}
-
-	// Otherwise delete the file first
-	s.logger.Warnf("Socket file '%s' already present. Deleting...", socketFile)
-	err = os.Remove(socketFile)
-	if err != nil {
-		return fmt.Errorf("unable to delete stale ocket file '%s'", socketFile)
-	}
-
-	return nil
 }
 
 func (s *proxyServices) createHTTPService(

--- a/internal/proxyservice/proxy_service.go
+++ b/internal/proxyservice/proxy_service.go
@@ -197,7 +197,7 @@ func (s *proxyServices) createSSHService(
 	// TODO: Add validation somewhere about overlapping listenOns
 	// TODO: v2.NetworkAddress is a value type.  It needs to be moved to its
 	//   own package with no deps (stdlib deps are ok).
-	netAddr := v2.NetworkAddress(config.ListenOn)
+	netAddr := config.ListenOn
 	listener, err := net.Listen(netAddr.Network(), netAddr.Address())
 	if err != nil {
 		return nil, err
@@ -228,7 +228,7 @@ func (s *proxyServices) createSSHAgentService(
 	// TODO: Add validation somewhere about overlapping listenOns
 	// TODO: v2.NetworkAddress is a value type.  It needs to be moved to its
 	//   own package with no deps (stdlib deps are ok).
-	netAddr := v2.NetworkAddress(config.ListenOn)
+	netAddr := config.ListenOn
 	listener, err := net.Listen(netAddr.Network(), netAddr.Address())
 	if err != nil {
 		return nil, err
@@ -260,7 +260,7 @@ func (s *proxyServices) createTCPService(
 	// TODO: Add validation somewhere about overlapping listenOns
 	// TODO: v2.NetworkAddress is a value type.  It needs to be moved to its
 	//   own package with no deps (stdlib deps are ok).
-	netAddr := v2.NetworkAddress(config.ListenOn)
+	netAddr := config.ListenOn
 	listener, err := net.Listen(netAddr.Network(), netAddr.Address())
 	if err != nil {
 		return nil, err

--- a/pkg/secretless/config/v1/v2_conversion.go
+++ b/pkg/secretless/config/v1/v2_conversion.go
@@ -59,7 +59,7 @@ func newV2ServiceFromListenerAndHandler(listener Listener, linkedHandler Handler
 		Connector:       connector,
 		ConnectorConfig: connectorConfig,
 		Credentials:     credentials,
-		ListenOn:        listenOn,
+		ListenOn:        config_v2.NetworkAddress(listenOn),
 		Name:            linkedHandler.Name,
 	}, nil
 }

--- a/pkg/secretless/config/v2/config_env.go
+++ b/pkg/secretless/config/v2/config_env.go
@@ -1,0 +1,148 @@
+package v2
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/log"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin"
+	"github.com/go-ozzo/ozzo-validation"
+)
+
+// DeleteFileFunc is a function that takes a filename, attempts to delete the
+// file, and returns an error if it can't.
+type DeleteFileFunc func(name string) error
+
+// FileInfoFunc is a function that takes a filename and returns information
+// about that file, or an error if it cannot be found or read.
+type FileInfoFunc func(name string) (os.FileInfo, error)
+
+// ConfigEnv represents the runtime environment that will fulfill the services
+// requested by the Config.  It has a single public method, Prepare, that
+// ensures the runtime environment supports the requested services.
+type ConfigEnv struct {
+	availPlugins plugin.AvailablePlugins
+	deleteFile   DeleteFileFunc
+	getFileInfo  FileInfoFunc
+	logger       log.Logger
+}
+
+// NewConfigEnv creates a new instance of ConfigEnv.
+func NewConfigEnv(logger log.Logger, availPlugins plugin.AvailablePlugins) ConfigEnv {
+	// Return *PathError
+	// &PathError{"remove", name, e}
+	// os.Remove("blah")
+	return NewConfigEnvWithOptions(logger, availPlugins, os.Stat, os.Remove)
+}
+
+// NewConfigEnvWithOptions allows injecting all dependencies.  Used for unit
+// testing.
+func NewConfigEnvWithOptions(
+	logger log.Logger,
+	availPlugins plugin.AvailablePlugins,
+	getFileInfo func(name string) (os.FileInfo, error),
+	deleteFile func(name string) error,
+) ConfigEnv {
+	// Return *PathError
+	// &PathError{"remove", name, e}
+	// os.Remove("blah")
+	return ConfigEnv{
+		logger:       logger,
+		availPlugins: availPlugins,
+		getFileInfo:  getFileInfo,
+		deleteFile:   deleteFile,
+	}
+}
+
+// Prepare ensures the runtime environment is prepared to handle the Config's
+// service requests. It checks both that the requested connectors exist, and
+// that the requested sockets are available, or can be deleted.  If any of these
+// checks fail, it will error.
+func (c *ConfigEnv) Prepare(cfg Config) error {
+	err := c.validateRequestedPlugins(cfg)
+	if err != nil {
+		return err
+	}
+
+	return c.ensureAllSocketsAreDeleted(cfg)
+}
+
+// validateRequestedPlugins ensures that the AvailablePlugins can fulfill the
+// services requested by the given Config, and return an error if not.
+func (c *ConfigEnv) validateRequestedPlugins(cfg Config) error {
+	pluginIDs := plugin.AvailableConnectorIDs(c.availPlugins)
+
+	c.logger.Infof(
+		"Validating config against available plugins: %s",
+		strings.Join(pluginIDs, ","),
+	)
+
+	// Convert available plugin IDs to a map, so that we can check if they exist
+	// in the loop below using a map lookup rather than a nested loop.
+	pluginIDsMap := map[string]bool{}
+	for _, p := range pluginIDs {
+		pluginIDsMap[p] = true
+	}
+
+	errors := validation.Errors{}
+	for _, service := range cfg.Services {
+		// A plugin ID and a connector name are equivalent.
+		pluginExists := pluginIDsMap[service.Connector]
+		if !pluginExists {
+			errors[service.Name] = fmt.Errorf(
+				`missing service connector "%s"`,
+				service.Connector,
+			)
+			continue
+		}
+	}
+
+	err := errors.Filter()
+	if err != nil {
+		err = fmt.Errorf("services validation failed: %s", err.Error())
+	}
+
+	return err
+}
+
+func (c *ConfigEnv) ensureAllSocketsAreDeleted(cfg Config) error {
+	errors := validation.Errors{}
+
+	for _, service := range cfg.Services {
+		err := c.ensureSocketIsDeleted(service.ListenOn)
+		if err != nil {
+			errors[service.Name] = fmt.Errorf(
+				"socket can't be deleted: %s", service.ListenOn,
+			)
+		}
+	}
+	return errors.Filter()
+}
+
+func (c *ConfigEnv) ensureSocketIsDeleted(address NetworkAddress) error {
+	// If we're not a unix socket address, we don't need to worry about
+	// pre-emptive cleanup
+	if address.Network() != "unix" {
+		return nil
+	}
+
+	socketFile := address.Address()
+	c.logger.Debugf("Ensuring that the socketfile '%s' is not present...", socketFile)
+
+	// If file is not present, then we are ok to continue.
+	// NOTE: os.IsNotExist is a pure function, so does not need to be injected.
+	if _, err := c.getFileInfo(socketFile); os.IsNotExist(err) {
+		c.logger.Debugf("Socket file '%s' not present. Skipping deletion.", socketFile)
+		return nil
+	}
+
+	// Otherwise delete the file first
+	c.logger.Warnf("Socket file '%s' already present. Deleting...", socketFile)
+	err := c.deleteFile(socketFile)
+	if err != nil {
+		return fmt.Errorf("unable to delete stale socket file '%s'", socketFile)
+	}
+
+	return nil
+}

--- a/pkg/secretless/config/v2/config_env.go
+++ b/pkg/secretless/config/v2/config_env.go
@@ -30,9 +30,6 @@ type ConfigEnv struct {
 
 // NewConfigEnv creates a new instance of ConfigEnv.
 func NewConfigEnv(logger log.Logger, availPlugins plugin.AvailablePlugins) ConfigEnv {
-	// Return *PathError
-	// &PathError{"remove", name, e}
-	// os.Remove("blah")
 	return NewConfigEnvWithOptions(logger, availPlugins, os.Stat, os.Remove)
 }
 
@@ -44,9 +41,6 @@ func NewConfigEnvWithOptions(
 	getFileInfo func(name string) (os.FileInfo, error),
 	deleteFile func(name string) error,
 ) ConfigEnv {
-	// Return *PathError
-	// &PathError{"remove", name, e}
-	// os.Remove("blah")
 	return ConfigEnv{
 		logger:       logger,
 		availPlugins: availPlugins,

--- a/pkg/secretless/config/v2/config_env_test.go
+++ b/pkg/secretless/config/v2/config_env_test.go
@@ -67,4 +67,6 @@ func TestConfigEnv(t *testing.T) {
 		assert.Regexp(t, "FAKE PLUGIN 1", err)
 		assert.Regexp(t, "FAKE PLUGIN 2", err)
 	})
+
+	// returns error when socket can't be delted
 }

--- a/pkg/secretless/config/v2/config_test.go
+++ b/pkg/secretless/config/v2/config_test.go
@@ -101,7 +101,7 @@ func RunNewConfigTestCases(t *testing.T, label string, sampleContents string) {
 
 		assert.Equal(t, "postgres-db", cfg.Services[1].Name)
 		assert.Equal(t, "pg", cfg.Services[1].Connector)
-		assert.Equal(t, "tcp://0.0.0.0:5432", cfg.Services[1].ListenOn)
+		assert.Equal(t, NetworkAddress("tcp://0.0.0.0:5432"), cfg.Services[1].ListenOn)
 	})
 
 	t.Run(label + ": config hydration", func(t *testing.T) {
@@ -124,7 +124,7 @@ func RunNewConfigTestCases(t *testing.T, label string, sampleContents string) {
 
 		assert.Equal(t, "aws-proxy", cfg.Services[0].Name)
 		assert.Equal(t, "aws", cfg.Services[0].Connector)
-		assert.Equal(t, "tcp://0.0.0.0:8080", cfg.Services[0].ListenOn)
+		assert.Equal(t, NetworkAddress("tcp://0.0.0.0:8080"), cfg.Services[0].ListenOn)
 	})
 
 	t.Run(label + ": credential hydration", func(t *testing.T) {


### PR DESCRIPTION
History is clean-ish but could be better.

- Moves `ensureSocketIsDeleted()` out of `ProxyServices` and into `ConfigEnv`
- Add unit tests for the logic
- Move all the logic for `ConfigEnv` into its own file
- Sepatately: Changes `Service` to use a proper `NetworkAddress` type for `ListenOn`
- (related to previous point) Updates existing unit tests involving `ListenOn` as needed
- Improves formatting on some existing unit tests with long lines (since I was in the file anyway)