### PR TITLE
Add support of `sslmode` parameter to the mysql plugin

### DIFF
--- a/internal/plugin/connectors/tcp/mysql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mysql/connection_details.go
@@ -6,10 +6,10 @@ import "strconv"
 // These values are pulled from the SingleUseConnector credentials config
 type ConnectionDetails struct {
 	Host     string
+	Options  map[string]string
+	Password string
 	Port     uint
 	Username string
-	Password string
-	Options  map[string]string
 }
 
 const DefaultMySQLPort = uint(3306)
@@ -37,6 +37,12 @@ func NewConnectionDetails(credentials map[string][]byte) (
 
 	if credentials["password"] != nil {
 		connDetails.Password = string(credentials["password"])
+	}
+
+	// Make sure that we process the SSL mode arg even if it's not specified
+	// otherwise it will get ignored
+	if _, ok := credentials["sslmode"]; !ok {
+		credentials["sslmode"] = []byte("")
 	}
 
 	delete(credentials, "host")

--- a/internal/plugin/connectors/tcp/mysql/connection_details_test.go
+++ b/internal/plugin/connectors/tcp/mysql/connection_details_test.go
@@ -12,14 +12,17 @@ func TestExpectedFields(t *testing.T) {
 		"port":     []byte("1234"),
 		"username": []byte("myusername"),
 		"password": []byte("mypassword"),
+		"sslmode":  []byte("disable"),
 	}
 
 	expectedConnDetails := ConnectionDetails{
-		Host:     "myhost",
+		Host: "myhost",
+		Options: map[string]string{
+			"sslmode": "disable",
+		},
+		Password: "mypassword",
 		Port:     1234,
 		Username: "myusername",
-		Password: "mypassword",
-		Options:  make(map[string]string),
 	}
 
 	actualConnDetails, err := NewConnectionDetails(credentials)
@@ -42,7 +45,9 @@ func TestDefaultPort(t *testing.T) {
 		Port:     DefaultMySQLPort,
 		Username: "myusername",
 		Password: "mypassword",
-		Options:  make(map[string]string),
+		Options: map[string]string{
+			"sslmode": "",
+		},
 	}
 
 	actualConnDetails, err := NewConnectionDetails(credentials)
@@ -64,8 +69,9 @@ func TestUnexpectedFieldsAreSavedAsOptions(t *testing.T) {
 	}
 
 	expectedOptions := map[string]string{
-		"foo": "5432",
-		"bar": "data",
+		"foo":     "5432",
+		"bar":     "data",
+		"sslmode": "",
 	}
 
 	actualConnDetails, err := NewConnectionDetails(credentials)

--- a/internal/plugin/connectors/tcp/ssl/ssl.go
+++ b/internal/plugin/connectors/tcp/ssl/ssl.go
@@ -12,9 +12,9 @@ type options map[string]string
 // DbSSLMode holds information about the DB's SSL options.
 type DbSSLMode struct {
 	tls.Config
-	UseTLS bool
+	UseTLS       bool
 	VerifyCaOnly bool
-	Options options
+	Options      options
 }
 
 // NewDbSSLMode configures and creates a DbSSLMode


### PR DESCRIPTION
Old code had no way to pass this parameter into the connector so now we
support it in that capacity. This inclusion of the flag still does nto
mean that we are actively using it though.

#### What does this PR do (include background context, if relevant)?

#### What ticket does this PR close?
Connected to #928 

#### Where should the reviewer start?

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
