### PR TITLE
Bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.3.0] 2019-11-18
+
+### Added
+- Added trivy security scan to project pipeline (#986)
+- Added unit tests to ConfigEnv, profile and signal packages
+- Added alpha MSSQL connector (#964)
+- Added template skeleton for connector plugins (#967)
+
+### Changed
+- Extract config validation from ProxyServices and add unit tests
+- Improved available_plugins unit tests
+- Updated juxtaposer configs for perf tests (#969)
+
+### Fixed
+- Ensure MySQL uses appropriate default sslmode value (#928)
+- Improved pg error propagation (#974)
+
 ## [1.2.0] 2019-10-21
 
 ### Added
@@ -352,7 +369,7 @@ external plugins
 
 The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.3.0...HEAD
 [0.2.0]: https://github.com/cyberark/secretless-broker/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/cyberark/secretless-broker/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/cyberark/secretless-broker/compare/v0.3.0...v0.4.0
@@ -370,3 +387,4 @@ The first tagged version.
 [1.0.0]: https://github.com/cyberark/secretless-broker/compare/v0.8.0...v1.0.0 
 [1.1.0]: https://github.com/cyberark/secretless-broker/compare/v1.0.0...v1.1.0 
 [1.2.0]: https://github.com/cyberark/secretless-broker/compare/v1.1.0...v1.2.0 
+[1.3.0]: https://github.com/cyberark/secretless-broker/compare/v1.2.0...v1.3.0 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,23 +322,26 @@ information on the types of plugins we currently support, visit the [plugin API 
 
 ### Verify and update dependencies
 1. Check whether any dependencies have been changed since the last release by running
-   `./bin/check_dependencies`. The script will tell you what has changed.
-1. If any dependencies have changed, you'll need to update NOTICES.txt - which involves
-   updating the dependency files in `assets/` using the [LicenseFinder](https://github.com/Pivotal/LicenseFinder)
-   and updating the [spreadsheet](https://cyberark365.sharepoint.com/:x:/s/Conjur/Edko_eT7CfpEuPxnnbIEfmAB4j2ybNozY9B8QAIDOxKynQ?e=CfP6ym) before preparing the revised
-   NOTICES.txt.
+   `./bin/check_dependencies`. The script will tell you what has changed. Beware - the script at current DOES NOT appropriately handle `replace` directives - you will need to process these manually.
 
-   Note: to update the dependency file you run the following command:
-   ```
-   docker run --rm \
-     -v $PWD:/scan \
-     licensefinder/license_finder \
-     /bin/bash -lc "
-       cd /scan && \
-       license_finder approvals add \
-         --decisions-file=assets/dependency_decisions.yml \
-         [DEPENDENCY] --version=[VERSION]"
-   ```
+1. If any dependencies have changed, for each changed dependency in assets/license_finder.txt you'll need to do the following:
+
+   - if it is a new dependency, add an approval to the dependency decisions fileusing the [LicenseFinder](https://github.com/Pivotal/LicenseFinder):
+     ```
+     docker run --rm \
+       -v $PWD:/scan \
+       licensefinder/license_finder \
+       /bin/bash -lc "
+         cd /scan && \
+         license_finder approvals add \
+           --decisions-file=assets/dependency_decisions.yml \
+           [DEPENDENCY] --version=[VERSION]"
+     ```
+
+   - update the [spreadsheet](https://cyberark365.sharepoint.com/:x:/s/Conjur/Edko_eT7CfpEuPxnnbIEfmAB4j2ybNozY9B8QAIDOxKynQ?e=CfP6ym) with the updated dependency info (add / edit / remove a row), including a link to the relevant license file
+
+   - prepare the revised NOTICES.txt by adding / removing / editing dependency
+     information
 
    If no dependencies have changed, you can move on to the next step.
 

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -38,11 +38,12 @@ SECTION 2: BSD 2-clause "Simplified" License
 
 SECTION 3: BSD 3-clause "New" or "Revised" License
 
+>>> github.com/cyberark/go-mssqldb-0.0.0-20191030142036-b5a965a47dd3
 >>> github.com/fsnotify/fsnotify-1.4.7
 >>> github.com/ghodss/yaml-1.0.0
 >>> github.com/imdario/mergo-0.3.6
 >>> github.com/spf13/pflag-1.0.2
->>> golang.org/x/crypto-0.0.0-20190308221718-c2843e01d9a2
+>>> golang.org/x/crypto-0.0.0-20190325154230-a5d413f7728c
 >>> gopkg.in/airbrake/gobrake.v2-2.0.9
 >>> gopkg.in/DATA-DOG/go-sqlmock.v1-1.3.0
 >>> gopkg.in/fsnotify.v1-1.4.7
@@ -72,6 +73,7 @@ SECTION 4: MIT License
 >>> github.com/smartystreets/goconvey-0.0.0-20190330032615-68dc04aab96a
 >>> github.com/stretchr/testify-1.3.0
 >>> gopkg.in/gemnasium/logrus-airbrake-hook.v2-2.1.2
+>>> gopkg.in/yaml.v2-2.2.2
 
 
 
@@ -447,6 +449,37 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 BSD 3-clause "New" or "Revised" License is applicable to the following component(s).
 
 
+>>> github.com/cyberark/go-mssqldb-0.0.0-20191030142036-b5a965a47dd3
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+Copyright (c) 2019 CyberArk Software Ltd. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 >>> github.com/fsnotify/fsnotify-1.4.7
 
 Copyright (c) 2012 The Go Authors. All rights reserved.
@@ -573,7 +606,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
->>> golang.org/x/crypto-0.0.0-20190308221718-c2843e01d9a2
+>>> golang.org/x/crypto-0.0.0-20190325154230-a5d413f7728c
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 
@@ -1182,6 +1215,41 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+>>> gopkg.in/yaml.v2-2.2.2
+
+The following files were ported to Go from C files of libyaml, and thus
+are still covered by their original copyright and license:
+
+    apic.go
+    emitterc.go
+    parserc.go
+    readerc.go
+    scannerc.go
+    writerc.go
+    yamlh.go
+    yamlprivateh.go
+
+Copyright (c) 2006 Kirill Simonov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 --------------- SECTION 6: Mozilla Public License 2.0 ----------

--- a/assets/dependency_decisions.yml
+++ b/assets/dependency_decisions.yml
@@ -335,3 +335,17 @@
     :versions:
     - v0.0.0-20170717145745-c0da73ca9dde
     :when: 2019-07-15 16:35:02.626060100 Z
+- - :approve
+  - golang.org/x/crypto
+  - :who: 
+    :why: 
+    :versions:
+    - v0.0.0-20190325154230-a5d413f7728c
+    :when: 2019-11-19 14:35:20.471553200 Z
+- - :approve
+  - github.com/cyberark/go-mssqldb
+  - :who: 
+    :why: 
+    :versions:
+    - v0.0.0-20191030142036-b5a965a47dd3
+    :when: 2019-11-19 16:04:45.437019600 Z

--- a/assets/license_finder.txt
+++ b/assets/license_finder.txt
@@ -8,6 +8,7 @@ github.com/codegangsta/cli, v1.20.0, unknown
 github.com/cyberark/conjur-api-go, v0.5.2, unknown
 github.com/cyberark/conjur-authn-k8s-client, v0.13.0, unknown
 github.com/cyberark/summon, v0.7.0, unknown
+github.com/denisenkom/go-mssqldb, v0.0.0-20191001013358-cfbb681360f0, unknown
 github.com/fsnotify/fsnotify, v1.4.7, unknown
 github.com/ghodss/yaml, v1.0.0, unknown
 github.com/go-ozzo/ozzo-validation, v0.0.0-20170913164239-85dcd8368eba, unknown
@@ -34,7 +35,7 @@ github.com/sirupsen/logrus, v1.0.6, unknown
 github.com/smartystreets/goconvey, v0.0.0-20190330032615-68dc04aab96a, unknown
 github.com/spf13/pflag, v1.0.2, unknown
 github.com/stretchr/testify, v1.3.0, unknown
-golang.org/x/crypto, v0.0.0-20190308221718-c2843e01d9a2, unknown
+golang.org/x/crypto, v0.0.0-20190325154230-a5d413f7728c, unknown
 gopkg.in/DATA-DOG/go-sqlmock.v1, v1.3.0, unknown
 gopkg.in/airbrake/gobrake.v2, v2.0.9, unknown
 gopkg.in/fsnotify.v1, v1.4.7, unknown

--- a/bin/check_dependencies
+++ b/bin/check_dependencies
@@ -5,21 +5,17 @@ set -uo pipefail
 current_dir=$("$(dirname "$0")"/abspath)
 toplevel_dir=$current_dir/..
 
-function finish {
-  rm -f "$toplevel_dir/assets/updated_licenses.txt"
-}
-trap finish EXIT
-
 # get a new list of project licenses
 # this command syntax is wild but it's what the license_finder image requires
 docker run --rm \
   -v "$toplevel_dir":/scan \
   licensefinder/license_finder \
   /bin/bash -lc "cd /scan && license_finder" \
-  > "$toplevel_dir/assets/updated_licenses.txt"
+  > "$toplevel_dir/assets/license_finder.txt"
 
-# check if there are any differences; if not, exit
-diff=$(diff "$toplevel_dir/assets/updated_licenses.txt" "$toplevel_dir/assets/license_finder.txt")
+# check if there are any differences (assumes you are working from a git clone);
+# if not, exit
+diff=$(git diff "$toplevel_dir/assets/license_finder.txt")
 
 if [ -z "$diff" ]; then
   echo "No dependencies have changed."

--- a/pkg/secretless/version.go
+++ b/pkg/secretless/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the broker
-var Version = "1.2.0"
+var Version = "1.3.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Bumps the version to 1.3.0 to include new automated tests and the alpha MSSQL connector, and a bug fix for MySQL to ensure the `sslmode` config has appropriate defaults.

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [x] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [x] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

#### Links to open issues for related documentation (in READMEs, docs, etc)
#1003 is open for adding a README to the alpha MSSQL connector, since there is currently no documentation available for how to try it out