### PR TITLE
Adds UT test cases for generic connector validator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/onsi/ginkgo v1.6.0 // indirect
 	github.com/onsi/gomega v1.4.1 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/pkg/profile v1.2.1
 	github.com/prometheus/client_golang v0.9.2 // indirect
 	github.com/sirupsen/logrus v1.0.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,8 @@ github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+v
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1 h1:F++O52m40owAmADcojzM+9gyjmMOY/T4oYJkgFDH8RE=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/plugin/connectors/http/generic/config_test.go
+++ b/internal/plugin/connectors/http/generic/config_test.go
@@ -1,15 +1,17 @@
 package generic
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
-func sampleConfig() []byte {
+func sampleConfigYAML() []byte {
 	return []byte(`
-  credentialValidation:
-    username: '[^:]+'
+  credentialValidations:
+    username: '^[^:]+$'
   headers:
     Authorization: 'Basic {{ printf "%s:%s" .username .password | base64 }}'
     Name-With-Dashes: '{{ .username }}'
@@ -20,15 +22,21 @@ func sampleConfig() []byte {
 `)
 }
 
+func sampleConfig() (*config, error) {
+	cfgYAML, err := NewConfigYAML(sampleConfigYAML())
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing sample config YAML")
+	}
+	cfg, err := newConfig(cfgYAML)
+	if err != nil {
+		return nil, errors.Wrap(err, "error calling newConfig()")
+	}
+	return cfg, err
+}
+
 func Test_newConfig(t *testing.T) {
 	t.Run("creates expected headers", func(t *testing.T) {
-		cfgYAML, err := NewConfigYAML(sampleConfig())
-		if err != nil {
-			assert.Fail(t, "sampleConfig should never fail")
-			return
-		}
-		cfg, err := newConfig(cfgYAML)
-
+		cfg, err := sampleConfig()
 		assert.NoError(t, err)
 		if err != nil {
 			return
@@ -52,4 +60,55 @@ func Test_newConfig(t *testing.T) {
 		assert.Equal(t, "Basic Sm9uYWg6c2VjcmV0", headers["Authorization"])
 	})
 }
-// TODO: Add validation tests
+
+func Test_validate(t *testing.T) {
+	testCases := []struct {
+		description string
+		creds       map[string][]byte
+		expErrStr   string
+	}{
+		{
+			description: "validates good credentials",
+			creds: map[string][]byte{
+				"username": []byte("Jonah"),
+				"password": []byte("secret"),
+			},
+			expErrStr: "",
+		},
+		{
+			description: "errors on missing required credential",
+			creds: map[string][]byte{
+				"password": []byte("secret"),
+			},
+			expErrStr: "missing required credential",
+		},
+		{
+			description: "errors on invalid credential",
+			creds: map[string][]byte{
+				"username": []byte("Jon:ah"),
+				"password": []byte("secret"),
+			},
+			expErrStr: "doesn't match pattern",
+		},
+	}
+
+	cfg, err := sampleConfig()
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err = cfg.validate(tc.creds)
+			if tc.expErrStr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			assert.Error(t, err)
+			if err != nil {
+				assert.True(t, strings.Contains(err.Error(), tc.expErrStr))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds UT test cases for the generic HTTP connector's
validate method. This includes:
- Creating a common getSampleConfig() testing function for parsing
  the UT sampleConfig
- Add test cases for:
  * Valid username and password.
  * Missing required credential.
  * Credential that doesn't match corresponding validation string.

Fixes: https://github.com/cyberark/secretless-broker/issues/1025

#### What does this PR do (include background context, if relevant)?

#### What ticket does this PR close?
Issue #1025 

#### Where should the reviewer start?
internal/plugin/connectors/http/generic/config_test.go:Test_validate()

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ Y ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [ N ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
