### PR TITLE
Improved logs for k8s CRD test failure debugging

### DIFF
--- a/k8s-ci/Dockerfile
+++ b/k8s-ci/Dockerfile
@@ -5,19 +5,27 @@ WORKDIR /src
 
 # Install Docker client
 RUN apt-get update -y && \
-    apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common wget && \
-    curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") $(lsb_release -cs) stable" && \
+    apt-get install -y apt-transport-https ca-certificates curl gnupg2 \
+      software-properties-common wget && \
+    curl -fsSL \
+      https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg \
+      | apt-key add - && \
+    add-apt-repository "deb [arch=amd64] \
+      https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+      $(lsb_release -cs) stable" && \
     apt-get update && \
     apt-get install -y docker-ce && \
     rm -rf /var/lib/apt/lists/*
 
 # Install kubectl CLI
-RUN wget -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl && \
-  chmod +x /usr/local/bin/kubectl
+RUN wget -q -O /usr/local/bin/kubectl \
+      https://storage.googleapis.com/kubernetes-release/release/v1.11.3/bin/linux/amd64/kubectl && \
+    chmod +x /usr/local/bin/kubectl
 
 # Install kubectx and kubens
-RUN wget -O /usr/local/bin/kubectx https://raw.githubusercontent.com/ahmetb/kubectx/master/kubectx && \
-  chmod +x /usr/local/bin/kubectx
-RUN wget -O /usr/local/bin/kubens https://raw.githubusercontent.com/ahmetb/kubectx/master/kubens && \
-  chmod +x /usr/local/bin/kubens
+RUN wget -q -O /usr/local/bin/kubectx \
+      https://raw.githubusercontent.com/ahmetb/kubectx/master/kubectx && \
+    chmod +x /usr/local/bin/kubectx
+RUN wget -q -O /usr/local/bin/kubens \
+      https://raw.githubusercontent.com/ahmetb/kubectx/master/kubens && \
+    chmod +x /usr/local/bin/kubens

--- a/k8s-ci/k8s_crds/test
+++ b/k8s-ci/k8s_crds/test
@@ -111,7 +111,7 @@ function assert_on_http_proxy_resp() {
   if printf "%s" "${resp}" | grep -q "${expected_header}"; then
     echo "test passed ✔"
   else
-    echo "expected to find '${expected_header}', in response:" > ${log}
+    echo "expected to find '${expected_header}', in response:" >> ${log}
     echo "${resp}"  >> ${log}
     exit_err "test failed ✗"
   fi


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
This change adds some minor improvements to logging for the Kubernetes
CRD tests, as suggested by @ismarc. Hopefully this will help diagnose
failures in secretless-server Issue #1027 "Failing CRD tests are fixed".

The change includes:
* For the HTTP Proxy test, change the `redirect` of stderr (to ${log}) to a
  `concatenate` so that previous logs are not truncated... perhaps there are
  previous errors to give us a clue.
* For Dockerfile builds, wgets of Kubernetes binaries are run in quiet
  mode to eliminate lots of noise in the console logs.

#### What ticket does this PR close?
Connected to #1027 

#### What is the status of the manual tests?
This change was tested by running the Kubernetes CRD test manually on
GKE with:
    summon -f ./k8s-ci/secrets.yml -p conjurcli-docker ./k8s-ci/test k8s-ci/k8s_crds

Also, I'm running this on GKE in a loop to try to reproduce the previously seen failures:
```
#!/bin/bash

cd ~/cyberark/secretless-broker
for i in {0..1000}
do
  echo "Run Kubernetes CRD test, iteration number $i"
  summon -f ./k8s-ci/secrets.yml -p conjurcli-docker ./k8s-ci/test k8s-ci/k8s_crds >~/temp/k8s-crd-log-$i 2>&1
  echo "==========================================================="
done
```
But I'm not seeing any failures.

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
