### PR TITLE
Bumps the version to 1.4.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ Connected to #[relevant GitHub issues, eg 76]
 
 #### What is the status of the manual tests?
 Have you run the following manual tests to verify existing functionality continues to function as expected?
-- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
+- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
 - [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
 
 If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.4.0] 2019-12-04
+
+### Added
+- Added generic HTTP connector to enable writing new HTTP connectors via
+  config (#995)
+
+### Changed
+- Improved logs for k8s CRD test failure debugging (#1027)
+- Updated Ruby version in docs container (#1028)
+- Updated Conjur HTTP connector to leverage the generic HTTP connector (#1009)
+- Reorganized integration tests (#958)
+- Updated Basic Auth HTTP connector to leverage the generic HTTP connector
+  (#1007)
+- Replaced "honnef.co/go/tools" dependency in go.sum with a github link
+- Updated "ozzo-validation" dependency to latest version
+- Make forceSSL setting explicit in e2e tests
+
 ## [1.3.0] 2019-11-18
 
 ### Added
@@ -369,7 +386,7 @@ external plugins
 
 The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.4.0...HEAD
 [0.2.0]: https://github.com/cyberark/secretless-broker/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/cyberark/secretless-broker/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/cyberark/secretless-broker/compare/v0.3.0...v0.4.0
@@ -388,3 +405,4 @@ The first tagged version.
 [1.1.0]: https://github.com/cyberark/secretless-broker/compare/v1.0.0...v1.1.0 
 [1.2.0]: https://github.com/cyberark/secretless-broker/compare/v1.1.0...v1.2.0 
 [1.3.0]: https://github.com/cyberark/secretless-broker/compare/v1.2.0...v1.3.0 
+[1.4.0]: https://github.com/cyberark/secretless-broker/compare/v1.3.0...v1.4.0 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ stage('Integration: PG Handler') {
 
 If you are on a Mac, you may also test the OSX Keychain provider:
 ```sh-session
-cd test/manual/keychain_provider/
+cd test/providers/keychain/
 ./start
 ./test
 ```

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -32,7 +32,8 @@ SECTION 1: Apache License 2.0
 
 SECTION 2: BSD 2-clause "Simplified" License
 
-   >>> github.com/pkg/profile-1.2.1
+>>> github.com/pkg/errors-0.8.1
+>>> github.com/pkg/profile-1.2.1
 
 
 
@@ -43,7 +44,7 @@ SECTION 3: BSD 3-clause "New" or "Revised" License
 >>> github.com/ghodss/yaml-1.0.0
 >>> github.com/imdario/mergo-0.3.6
 >>> github.com/spf13/pflag-1.0.2
->>> golang.org/x/crypto-0.0.0-20190325154230-a5d413f7728c
+>>> golang.org/x/crypto-0.0.0-20190510104115-cbcb75029529
 >>> gopkg.in/airbrake/gobrake.v2-2.0.9
 >>> gopkg.in/DATA-DOG/go-sqlmock.v1-1.3.0
 >>> gopkg.in/fsnotify.v1-1.4.7
@@ -59,7 +60,7 @@ SECTION 4: MIT License
 >>> github.com/codegangsta/cli-1.20.0
 >>> github.com/cyberark/summon-0.7.0
 >>> github.com/ghodss/yaml-1.0.0
->>> github.com/go-ozzo/ozzo-validation-0.0.0-20170913164239-85dcd8368eba
+>>> github.com/go-ozzo/ozzo-validation-3.6.0
 >>> github.com/gregjones/httpcache-0.0.0-20180305231024-9cad4c3443a7
 >>> github.com/hpcloud/tail-1.0.0
 >>> github.com/joho/godotenv-1.2.0
@@ -416,6 +417,33 @@ limitations under the License.
 BSD 2-clause "Simplified" License is applicable to the following component(s).
 
 
+>>> github.com/pkg/errors-0.8.1
+
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
 >>> github.com/pkg/profile-1.2.1
 
 Copyright (c) 2013 Dave Cheney. All rights reserved.
@@ -606,7 +634,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
->>> golang.org/x/crypto-0.0.0-20190325154230-a5d413f7728c
+>>> golang.org/x/crypto-0.0.0-20190510104115-cbcb75029529
 
 Copyright (c) 2009 The Go Authors. All rights reserved.
 
@@ -926,7 +954,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 
->>> github.com/go-ozzo/ozzo-validation-0.0.0-20170913164239-85dcd8368eba
+>>> github.com/go-ozzo/ozzo-validation-3.6.0
 
 The MIT License (MIT)
 Copyright (c) 2016, Qiang Xue

--- a/assets/dependency_decisions.yml
+++ b/assets/dependency_decisions.yml
@@ -349,3 +349,24 @@
     :versions:
     - v0.0.0-20191030142036-b5a965a47dd3
     :when: 2019-11-19 16:04:45.437019600 Z
+- - :approve
+  - github.com/go-ozzo/ozzo-validation
+  - :who: 
+    :why: 
+    :versions:
+    - v3.6.0+incompatible
+    :when: 2019-12-04 19:04:27.546105300 Z
+- - :approve
+  - github.com/pkg/errors
+  - :who: 
+    :why: 
+    :versions:
+    - v0.8.1
+    :when: 2019-12-04 19:04:49.791897800 Z
+- - :approve
+  - golang.org/x/crypto
+  - :who: 
+    :why: 
+    :versions:
+    - v0.0.0-20190510104115-cbcb75029529
+    :when: 2019-12-04 19:10:14.735186800 Z

--- a/assets/license_finder.txt
+++ b/assets/license_finder.txt
@@ -11,7 +11,7 @@ github.com/cyberark/summon, v0.7.0, unknown
 github.com/denisenkom/go-mssqldb, v0.0.0-20191001013358-cfbb681360f0, unknown
 github.com/fsnotify/fsnotify, v1.4.7, unknown
 github.com/ghodss/yaml, v1.0.0, unknown
-github.com/go-ozzo/ozzo-validation, v0.0.0-20170913164239-85dcd8368eba, unknown
+github.com/go-ozzo/ozzo-validation, v3.6.0+incompatible, unknown
 github.com/golang/groupcache, v0.0.0-20180513044358-24b0969c4cb7, unknown
 github.com/google/btree, v0.0.0-20180813153112-4030bb1f1f0c, unknown
 github.com/google/gofuzz, v0.0.0-20170612174753-24818f796faf, unknown
@@ -29,13 +29,14 @@ github.com/modern-go/reflect2, v0.0.0-20180718012357-94122c33edd3, unknown
 github.com/onsi/ginkgo, v1.6.0, unknown
 github.com/onsi/gomega, v1.4.1, unknown
 github.com/peterbourgon/diskv, v2.0.1+incompatible, unknown
+github.com/pkg/errors, v0.8.1, unknown
 github.com/pkg/profile, v1.2.1, unknown
 github.com/prometheus/client_golang, v0.9.2, unknown
 github.com/sirupsen/logrus, v1.0.6, unknown
 github.com/smartystreets/goconvey, v0.0.0-20190330032615-68dc04aab96a, unknown
 github.com/spf13/pflag, v1.0.2, unknown
 github.com/stretchr/testify, v1.3.0, unknown
-golang.org/x/crypto, v0.0.0-20190325154230-a5d413f7728c, unknown
+golang.org/x/crypto, v0.0.0-20190510104115-cbcb75029529, unknown
 gopkg.in/DATA-DOG/go-sqlmock.v1, v1.3.0, unknown
 gopkg.in/airbrake/gobrake.v2, v2.0.9, unknown
 gopkg.in/fsnotify.v1, v1.4.7, unknown

--- a/pkg/secretless/version.go
+++ b/pkg/secretless/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the broker
-var Version = "1.3.0"
+var Version = "1.4.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
- Bumps the version
- Updates the acknowledgements file
- Updates the docs for the keychain provider integration test (which moved)

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [x] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/manual/keychain_provider)
- [x] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
