### PR TITLE
go-mssqldb is a submodule within secretless

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "third_party/go-mssqldb"]
+	path = third_party/go-mssqldb
+	url = https://github.com/cyberark/go-mssqldb

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,19 @@ Use [this guide][style] to maintain consistent style across the Secretless Broke
 
 ## Building
 
-First, clone `https://github.com/cyberark/secretless-broker`. If you're new to Go, be aware that Go can be very selective
+First, clone `https://github.com/cyberark/secretless-broker` with the `--recurse-submodules` flag. If you're new to Go, be aware that Go can be very selective
 about where the files are placed on the filesystem. There is an environment variable called `GOPATH`, whose default value
 is `~/go`. Secretless Broker uses [go modules](https://golang.org/cmd/go/#hdr-Modules__module_versions__and_more) which
 require either that you clone this repository outside of your `GOPATH` or you set the `GO111MODULE` environment variable to
 `on`. We recommend cloning this repository outside of your `GOPATH`.
 
 Once you've cloned the repository, you can build the Secretless Broker.
+
+Note: On git submodules, taken from git documentation.
+> Luckily, you can tell Git (>=2.14) to always use the --recurse-submodules flag by setting the configuration option 
+> submodule.recurse: git config submodule.recurse true. 
+> As noted above, this will also make Git recurse into submodules for every command that has a --recurse-submodules option 
+> (except git clone)
 
 ### Static long version tags
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,10 @@ require either that you clone this repository outside of your `GOPATH` or you se
 Once you've cloned the repository, you can build the Secretless Broker.
 
 Note: On git submodules, taken from git documentation.
-> Luckily, you can tell Git (>=2.14) to always use the --recurse-submodules flag by setting the configuration option 
-> submodule.recurse: git config submodule.recurse true. 
-> As noted above, this will also make Git recurse into submodules for every command that has a --recurse-submodules option 
-> (except git clone)
+> Luckily, you can tell Git (>=2.14) to always use the --recurse-submodules flag by setting the
+> configuration option submodule.recurse: git config submodule.recurse true. 
+> As noted above, this will also make Git recurse into submodules for every 
+> command that has a --recurse-submodules option (except git clone)
 
 ### Static long version tags
 
@@ -323,6 +323,14 @@ replace `<GOOS>/<GOARCH>` with your particular operating system and compilation 
 Secretless supports using [Go plugins](https://golang.org/pkg/plugin/) to extend
 its functionality. To learn about writing new Secretless plugins and for more
 information on the types of plugins we currently support, visit the [plugin API directory](pkg/secretless/plugin).
+
+### Submodules
+
+Secretless makes use of some plugins using [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules). 
+Development on submodules is similar to just working with a second repository, in that you can `cd` into it and 
+check out branches or make seperate commits. However, you also have the ability to commit and push recursively 
+from the parent repository. For help with this, it is recommended to review the "Publishing Submodule Changes" 
+section of the Git Submodules documentation.
 
 ## Releasing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV GOOS=linux \
     CGO_ENABLED=1
 
 COPY go.mod go.sum /secretless/
+COPY third_party/ /secretless/third_party
 
 RUN go mod download
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -40,6 +40,7 @@ RUN go get -u github.com/jstemmer/go-junit-report && \
 
 # go mod dependency management for the secretless project
 COPY go.mod go.sum /secretless/
+COPY third_party/ /secretless/third_party
 
 RUN go mod download
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,6 +12,7 @@ RUN apk add -u curl \
                musl-dev
 
 COPY go.mod go.sum /secretless/
+COPY third_party/ /secretless/third_party
 
 RUN go mod download
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,12 @@ pipeline {
   }
 
   stages {
+    stage('Update Submodules') {
+        steps {
+            sh 'git submodule update --init --recursive'
+        }
+    }
+
     stage('Image Build') {
       steps {
         sh './bin/build'

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20180731170545-e3762e86a74c // indirect
 )
 
-replace github.com/denisenkom/go-mssqldb => github.com/cyberark/go-mssqldb v0.0.0-20191030142036-b5a965a47dd3
+replace github.com/denisenkom/go-mssqldb => ./third_party/go-mssqldb
 
 // 2/19/2019: cert on honnef.co -- one of grpc's dependencies -- expired.
 // This is our fix:


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
- generated .gitmodules file with our fork of go-mssqldb
- Created new directory: /third_party, for appropriate submodules
- Updated documentation
- Updated top-level Dockerfiles to use third party submodules

#### What ticket does this PR close?
Connected to #1038 and #975
