### PR TITLE
Broker logs+exits now when Conjur provider repeatedly fails

### DIFF
--- a/internal/providers/conjur/provider.go
+++ b/internal/providers/conjur/provider.go
@@ -108,10 +108,17 @@ func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, err
 		}
 
 		go func() {
-			// sleep until token needs refresh
+			// Sleep until token needs refresh
 			time.Sleep(provider.Authenticator.Config.TokenRefreshTimeout)
-			// authenticate in a loop
-			provider.fetchAccessTokenLoop()
+
+			// Authenticate in a loop
+			err := provider.fetchAccessTokenLoop()
+
+			// On repeated errors in getting the token, we need to exit the
+			// broker since the provider cannot be used.
+			if err != nil {
+				log.Fatal(err)
+			}
 		}()
 
 		// Once the token file has been loaded, create a new instance of the Conjur client


### PR DESCRIPTION
Old code would allow a state of the broker where the token was unable to
be fetched and would end up in a non-recoverable state. This change
ensures that we both log the error poperly as well as exit the broker
when we cannot repeatedly reach the Conjur server.

#### What ticket does this PR close?
Connected to #1035 

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/1035-conjur-provider-graceful-failure/)

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
