### PR TITLE
Add ms-sql types

### DIFF
--- a/third_party/ctxtypes/mssql_types.go
+++ b/third_party/ctxtypes/mssql_types.go
@@ -1,0 +1,8 @@
+package ctxtypes
+
+// ContextKey is, as the name implied, a type reserved
+// for keys when passing values into the context
+type ContextKey string
+
+// PreLoginResponseKey is used to obtain PreLogin Response fields
+const PreLoginResponseKey ContextKey = "preLoginResponse"


### PR DESCRIPTION
These types can be used as keys for storing certain values in a context,
which can then be used to retrieve information elsewhere.

#### What ticket does this PR close?
Connected to #[975]