### PR TITLE
client params passed to backend via Secretless

### DIFF
--- a/internal/plugin/connectors/tcp/mssql/authentication.go
+++ b/internal/plugin/connectors/tcp/mssql/authentication.go
@@ -24,7 +24,7 @@ func (connector *SingleUseConnector) performPreLoginHandshake() error {
 
 	// we actually don't need the client's handshake response.
 	// we just need for them to not be blocked
-	err = clientBuffer.ReadNextPacket()
+	connector.clientLogin, err = mssql.ReadLogin(clientBuffer)
 	if err != nil {
 		return fmt.Errorf("failed to read client login message: %s", err)
 	}

--- a/internal/plugin/connectors/tcp/mssql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details.go
@@ -2,6 +2,8 @@ package mssql
 
 import (
 	"strconv"
+
+	mssql "github.com/denisenkom/go-mssqldb"
 )
 
 // ConnectionDetails stores the connection info to the real backend database.
@@ -11,13 +13,15 @@ type ConnectionDetails struct {
 	Port     uint
 	Username string
 	Password string
+	AppName string
+	Database string
 }
 
 const defaultMSSQLPort = uint(1433)
 
 // NewConnectionDetails is a constructor of ConnectionDetails structure from a
 // map of credentials.
-func NewConnectionDetails(credentials map[string][]byte) (*ConnectionDetails, error) {
+func NewConnectionDetails(credentials map[string][]byte, login *mssql.Login) (*ConnectionDetails, error) {
 
 	connDetails := &ConnectionDetails{}
 
@@ -37,6 +41,11 @@ func NewConnectionDetails(credentials map[string][]byte) (*ConnectionDetails, er
 
 	if credentials["password"] != nil {
 		connDetails.Password = string(credentials["password"])
+	}
+
+	if login != nil {
+		connDetails.AppName = login.AppName
+		connDetails.Database = login.Database
 	}
 
 	return connDetails, nil


### PR DESCRIPTION
This PR makes it so that client's params are propagated via Secretless. At present, it only focuses on app name and database.

This PR relies on the ReadLogin method introduced over at https://github.com/cyberark/go-mssqldb/pull/6. The build will fail until that dependency is merged.
