### PR TITLE
Update contributing readme to consider best practices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -346,7 +346,9 @@ this happens.
 
 1. Enter the submodule directory and create a branch to store your changes, publishing
 this branch now or once you have completed your work.
+
 `cd third_party/<submodule>`
+
 `git checkout -b <branch name>`
 
 2. Commit any neccessary changes within the submodule repository to your new branch. If
@@ -365,7 +367,8 @@ Changes not staged for commit:
 ```
 
 4. From the super directory, stage the changes to the submodule. It should only require
-a single `git add <submodule_dir>` statement. This will update the remote that the
+a single `git submodule add <submodule_dir>` statement. This will update the remote that
+ the
 super repository uses to reference the submodule to point to the new branch you
 created, and all the commits contained within.
 
@@ -390,6 +393,22 @@ There are a few benefits to this approach
  can easily pull both at the same time and build without issues.
 - Reviewers can see the context for a change that may span more than one repository
  when Github links the two pull requests.
+ 
+We want secretless to point to specific commits within a submodule, rather
+than master. Make sure your change to secretless considers this.
+ 1. `cd` into the submodule
+ 2. Checkout the commit we want secretless to use from within the submodule
+ 3. Return to the secretless-broker directory, and create a new PR with the modified
+    reference
+ 
+ 
+ ### Helpful Commands for working with submodules
+ To check the current hash for a submodule:
+ 
+ `git ls-tree <branch> third_party/<submodule-directory>`
+ 
+ To set (checkout) the SHA-1 of a submodule to the most recent commit:
+ `git submodule --update <optional directory path>`
 
 ## Releasing
 

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/cyberark/conjur-authn-k8s-client v0.13.0 h1:sKh0yS6lSHT34FnMRR738+Q0d
 github.com/cyberark/conjur-authn-k8s-client v0.13.0/go.mod h1:JTeGIeRO59J7mMEc5yF6FPtk1QnaAzs4GyZa4WldqZc=
 github.com/cyberark/go-mssqldb v0.0.0-20191030142036-b5a965a47dd3 h1:qOMkK2hnBmmX40z/MHcZ0eVGATFK6lz+2VnsZFKMhY0=
 github.com/cyberark/go-mssqldb v0.0.0-20191030142036-b5a965a47dd3/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
+github.com/cyberark/secretless-broker v1.4.1-0.20191211191712-251c5ec034af/go.mod h1:+GueI3WCJL5gDYaYa38ZokAR8ceEyCVet7MkuZyjf80=
 github.com/cyberark/summon v0.7.0 h1:eBjyNzpJEeFb7BFcOgidM6S/UbEsN7LGSFeQE7szPsk=
 github.com/cyberark/summon v0.7.0/go.mod h1:S7grcxHeUxfL1vRTQUyq9jGK8yG6V/tSlLPQ6tHRO4k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
We want master in secretless to point to safe submodule commits,
and that is reflected here.

Additionally, I've added a 'helpful commands' section that can be used to check the
hash of the current commit of a submodule that the parent
directory is pointing at.