### PR TITLE
propagate client params via secretless

### DIFF
--- a/test/connector/tcp/mssql/Dockerfile
+++ b/test/connector/tcp/mssql/Dockerfile
@@ -1,6 +1,22 @@
-FROM mcr.microsoft.com/mssql-tools:latest
+FROM secretless-dev
 
+# apt-get and system utilities
+RUN apt-get update && apt-get install -y \
+	curl apt-transport-https debconf-utils \
+    && rm -rf /var/lib/apt/lists/*
+
+# adding custom MS repository
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+
+# install SQL Server drivers and tools
+RUN apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools
 ENV PATH $PATH:/opt/mssql-tools/bin
+
+RUN apt-get -y install locales
+RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen
+RUN locale-gen en_US.UTF-8
+RUN update-locale LANG=en_US.UTF-8
 
 # Install wget.
 #
@@ -12,9 +28,8 @@ ENV PATH $PATH:/opt/mssql-tools/bin
 #      Reading package lists...
 #      E: Failed to fetch https://packages.microsoft.com/ubuntu/16.04/
 #      prod/dists/xenial/main/binary-amd64/Packages.gz  Hash Sum mismatch
-# Since the install of wget does not require any updates to the packages in
+# Since the installs beyond this point will likely not require any updates to the packages in
 # this distro, we remove this distro list before doing `apt-get update` so
 # that we're agnostic to these transient checksum errors.
 RUN rm -rf /etc/apt/sources.list.d/mssql-release.list && \
-    apt-get update && \
-    apt-get install -y wget
+    apt-get update

--- a/test/connector/tcp/mssql/Dockerfile
+++ b/test/connector/tcp/mssql/Dockerfile
@@ -5,17 +5,28 @@ RUN apt-get update && apt-get install -y \
 	curl apt-transport-https debconf-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# adding custom MS repository
+# Add custom MS repository
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
 
-# install SQL Server drivers and tools
+# Install SQL Server drivers and tools
 RUN apt-get update && ACCEPT_EULA=Y apt-get install -y msodbcsql mssql-tools
 ENV PATH $PATH:/opt/mssql-tools/bin
 
+# Install and set locale to en_US.UTF-8
+#
+# sqlcmd expects the en_US.UTF-8 locale to be available otherwise it'll throw the following error:
+# terminate called after throwing an instance of 'std::runtime_error'
+#  what():  locale::facet::_S_create_c_locale name not valid
+#
+
+# Install locales package
 RUN apt-get -y install locales
+# Uncomment en_US.UTF-8 for inclusion in generation
 RUN sed -i 's/^# *\(en_US.UTF-8\)/\1/' /etc/locale.gen
+# Generate en_US.UTF-8 locale
 RUN locale-gen en_US.UTF-8
+# Set locale to en_US.UTF-8
 RUN update-locale LANG=en_US.UTF-8
 
 # Install wget.

--- a/test/connector/tcp/mssql/docker-compose.yml
+++ b/test/connector/tcp/mssql/docker-compose.yml
@@ -34,3 +34,14 @@ services:
     build:
       context: .
     command: sleep 999d
+    environment:
+      TEST_ROOT: /secretless/test/connector/tcp/mssql
+      DB_PROTOCOL: mssql
+      DB_HOST_TLS: mssql
+      DB_HOST_NO_TLS: mssql # TODO: configure a non-ssl container?
+      DB_PORT: 1433
+      DB_USER: sa
+      DB_PASSWORD: yourStrong()Password
+      SECRETLESS_HOST:
+    volumes:
+      - ../../../..:/secretless

--- a/test/connector/tcp/mssql/mssql_connector_test.go
+++ b/test/connector/tcp/mssql/mssql_connector_test.go
@@ -1,0 +1,82 @@
+package mssqltest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/test/util/testutil"
+)
+
+func TestMSSQLConnector(t *testing.T) {
+	t.Run("go-mssql", func(t *testing.T) {
+		RunTests(t, gomssqlExec)
+	})
+
+	t.Run("sqlcmd", func(t *testing.T) {
+		RunTests(t, sqlcmdExec)
+	})
+}
+
+func RunTests(t *testing.T, queryExec dbQueryExecutor) {
+	t.Run("Can connect to MSSQL through Secretless", func(t *testing.T) {
+		// Open connection and run test query
+		testInt := "1+1"
+		testString := "abc"
+		out, err := queryExec(
+			defaultSecretlessDbConfig(),
+			fmt.Sprintf("select %s, '%s'", testInt, testString),
+		)
+
+		assert.NoError(t, err)
+
+		// Test the returned values
+		assert.Contains(t, out, "2")
+		assert.Contains(t, out, testString)
+	})
+
+	t.Run("Cannot connect directly to MSSQL", func(t *testing.T) {
+		cfg := defaultSecretlessDbConfig()
+		cfg.Port = 1433
+		cfg.Host = "mssql"
+
+		// This is for local testing. Locally, Secretless and and the target service
+		// are exposed on 127.0.0.1 via port mappings
+		if testutil.SecretlessHost == "127.0.0.1" {
+			cfg.Host = "127.0.0.1"
+		}
+
+		_, err := queryExec(
+			cfg,
+			"",
+		)
+
+		assert.Contains(t, err.Error(), "Login failed")
+	})
+
+	t.Run("Passes valid database name to MSSQL through Secretless", func(t *testing.T) {
+		// Open connection and run test query
+		cfg := defaultSecretlessDbConfig()
+		cfg.Database = "master"
+		_, err := queryExec(
+			cfg,
+			"",
+		)
+
+		assert.NoError(t, err, "valid db should not error")
+	})
+
+	t.Run("Passes invalid database name to MSSQL through Secretless", func(t *testing.T) {
+		cfg := defaultSecretlessDbConfig()
+		cfg.Database = "meow"
+		_, err := queryExec(
+			cfg,
+			"",
+		)
+
+		assert.Error(t, err, "invalid db should error")
+		assert.Contains(t, err.Error(), "Generic SQL Error")
+	})
+
+}

--- a/test/connector/tcp/mssql/mssql_query.go
+++ b/test/connector/tcp/mssql/mssql_query.go
@@ -1,0 +1,143 @@
+package mssqltest
+
+import (
+	"bytes"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os/exec"
+	"text/tabwriter"
+
+	_ "github.com/denisenkom/go-mssqldb"
+
+	"github.com/cyberark/secretless-broker/test/util/testutil"
+)
+
+type dbConfig struct {
+	Host string
+	Port int
+	Username string
+	Password string
+	Database string
+}
+
+type dbQueryExecutor func(cfg dbConfig, query string) (string, error)
+
+func defaultSecretlessDbConfig() dbConfig {
+	return dbConfig{
+		Host:     testutil.SecretlessHost,
+		Port:     2223,
+		Username: "dummy",
+		Password: "dummy",
+	}
+}
+
+// runs queries using sqlcmd
+func sqlcmdExec(
+	cfg dbConfig,
+	query string,
+) (string, error) {
+	args := []string{
+		"-S", fmt.Sprintf("%s,%d", cfg.Host, cfg.Port),
+		"-U", cfg.Username,
+		"-P", cfg.Password,
+		"-Q", query,
+	}
+
+	if db := cfg.Database; db != "" {
+		args = append(args, "-d", db)
+	}
+
+	out, err := exec.Command(
+		"sqlcmd",
+		args...
+	).Output()
+
+	if err != nil {
+		if exitErrr, ok := err.(*exec.ExitError); ok {
+			return "", errors.New(string(exitErrr.Stderr))
+		}
+
+		return "", err
+	}
+
+	return string(out), nil
+}
+
+// runs queries using go-mssqldb
+func gomssqlExec(
+	cfg dbConfig,
+	query string,
+) (string, error) {
+	dsnString := fmt.Sprintf(
+		"user id=%s;password=%s;server=%s;port=%d;encrypt=%s",
+		cfg.Username,
+		cfg.Password,
+		cfg.Host,
+		cfg.Port,
+		"disable",
+	)
+
+	if db := cfg.Database; db != "" {
+		dsnString += fmt.Sprintf(";database=%s", db)
+	}
+
+	// Open the connection
+	conn, err := sql.Open(
+		"mssql",
+		dsnString,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	// Execute the query
+	rows, err := conn.Query(query)
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+
+	// Execute the query
+	cols, err := rows.Columns()
+	if err != nil {
+		return "", err
+	}
+
+	rawResult := make([][]byte, len(cols))
+
+	dest := make([]interface{}, len(cols)) // A temporary interface{} slice
+	for i := range rawResult {
+		dest[i] = &rawResult[i] // Put pointers to each string in the interface slice
+	}
+
+	w := new(tabwriter.Writer)
+	buf := &bytes.Buffer{}
+	w.Init(buf, 0, 0, 0, ' ', tabwriter.Debug|tabwriter.AlignRight)
+
+	for rows.Next() {
+		err = rows.Scan(dest...)
+		if err != nil {
+			return "", nil
+		}
+
+		rowString := ""
+		for _, raw := range rawResult {
+			if raw == nil {
+				rowString += "\\N"
+			} else {
+				rowString += string(raw)
+			}
+
+			rowString += "\t"
+		}
+
+		fmt.Fprintln(w, rowString)
+	}
+
+	w.Flush()
+
+	return string(buf.Bytes()), err
+}

--- a/test/connector/tcp/mssql/start
+++ b/test/connector/tcp/mssql/start
@@ -10,6 +10,8 @@ done
 
 ./stop
 
+docker-compose build
+
 # the order of the services is important. mssql must be up before we start secretless
 docker-compose up -d mssql
 

--- a/test/connector/tcp/mssql/test
+++ b/test/connector/tcp/mssql/test
@@ -1,95 +1,21 @@
 #!/bin/bash -e
 
-readonly db_host_tls="mssql"
-readonly db_host_no_tls="mssql" # TODO: configure a non-ssl container?
-readonly db_port=1433
-readonly db_user="sa"
-readonly db_password="yourStrong()Password"
-readonly secretless_port=2223
-readonly db_success_resp="1 rows affected"
-readonly db_fail_resp="Login failed for user"
-test_failed=false
-secretless_host="secretless"
 # Automatically detect if we're devmode based on the existence
 # of the secretless-dev container.  We assume that you started
 # your workflow using `./dev` if you are developing, and this
 # command will use the secretless-dev container.
-if [[ -n $(docker-compose ps -q secretless-dev) ]]; then
-  secretless_host="secretless-dev"
+export SECRETLESS_HOST=secretless
+if [[ ! -z $(docker-compose ps -q secretless-dev) ]]; then
+  export SECRETLESS_HOST=secretless-dev
 fi
 
-help_and_exit() {
-  local retval=${1:-1}
-  cat <<EOF
-This script tests access to an MSSQL server, first accessing the
-server directly (to establish a testing baseline), and then
-via a secretless broker.
-
-This script detects if you're in "dev" mode by the existence of
-the secretless-dev container. That container will exist only if
-the development process was started using the "./dev" command.
-
-Options:
-  -h Show this command usage
-EOF
-  exit "$retval"
-}
-
-while getopts "h" opt; do
-    case $opt in
-        h) help_and_exit 0;;
-        *) echo "Unknown option -$OPTARG"; help_and_exit 1;;
-    esac
-done
-
-assert_contains_substring() {
-  # assert_contains_substring <string> <substring>
-  local string=$1
-  local substring=$2
-
-  if [[ "${string}" =~ ${substring} ]]; then
-      echo "."
-      return
-  fi
-
-  echo ""
-  echo "FAIL:"
-  echo ""
-  echo "The string:"
-  echo ""
-  echo "    ${string}"
-  echo ""
-  echo "Did not contain expected substring:"
-  echo ""
-  echo "    ${substring}"
-  echo ""
-
-  test_failed=true
-}
-
-query_sql_service() {
-  # query_sql_service <server> <port> <user> <password>
-  server=$1
-  port=$2
-  user=$3
-  pw=$4
-
-  docker_cmd="docker-compose run --rm --no-deps"
-  sql_cmd=(sqlcmd -S "$server,$port" -U "$user" -P "$pw" -Q "SELECT 1+1")
-
-  # NOTE: We need to 2>&1 because we need to assert on sqlcmd's error messages
-  # and we need to "|| true" because we don't want the script to exit when this
-  # happens
-  $docker_cmd test "${sql_cmd[@]}" 2>&1 || true
-}
-
-echo "Waiting for '$secretless_host' service to start"
+echo "Waiting for '$SECRETLESS_HOST' service to start"
 
 # single quotes are intentional:
 # shellcheck disable=SC2016
 docker-compose run --rm --no-deps test bash -ec '
 counter=0
-while ! wget --quiet --output-document - http://'$secretless_host':5335/ready > /dev/null 2>&1; do
+while ! wget --quiet --output-document - http://'$SECRETLESS_HOST':5335/ready > /dev/null 2>&1; do
     if expr $counter = 5 > /dev/null; then
       echo ""
       echo "Timed out waiting for Secretless"
@@ -99,27 +25,21 @@ while ! wget --quiet --output-document - http://'$secretless_host':5335/ready > 
     >&2 printf ". "
     sleep 1
 done
+printf "\n"
 '
 
-echo "'$secretless_host' service is up - continuing "
+echo "'$SECRETLESS_HOST' service is up - continuing "
 echo ""
 echo "Running tests"
 echo ""
 
-echo "Test: Query mssql service directly with correct password succeeds"
-good_resp=$(query_sql_service $db_host_tls $db_port $db_user $db_password)
-assert_contains_substring "$good_resp" $db_success_resp
+docker-compose run \
+  -e SECRETLESS_HOST="$SECRETLESS_HOST" \
+  --rm \
+  --no-deps \
+  test bash -c "go test -v ./test/connector/tcp/mssql"
 
-echo "Test: Query mssql service directly with incorrect password fails"
-bad_resp=$(query_sql_service $db_host_tls $db_port "BAD_USER" "BAD_PASSWORD")
-assert_contains_substring "$bad_resp" $db_fail_resp
-
-echo "Test: Query mssql via secretless with incorrect password succeeds"
-good_resp=$(query_sql_service $secretless_host $secretless_port "NONEXISTENT_USER" "BOGUS_PASSWORD")
-assert_contains_substring "$good_resp" $db_success_resp
-
-if $test_failed; then
-  echo "FAIL"
-else
-  echo "PASS"
-fi
+# print secretless logs after tests run
+ret=$?
+docker-compose logs $SECRETLESS_HOST
+exit $ret

--- a/test/connector/tcp/mssql/test-local
+++ b/test/connector/tcp/mssql/test-local
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# this is for local testing
+
+export TEST_ROOT="/secretless/test/connector/tcp/mssql"
+export DB_PROTOCOL="mssql"
+export DB_HOST_TLS="mssql"
+export DB_HOST_NO_TLS="mssql"
+export DB_PORT="1433"
+export DB_USER="sa"
+export DB_PASSWORD="yourStrong()Password"
+export SECRETLESS_HOST="127.0.0.1"
+
+go test -v

--- a/third_party/ctxtypes/mssql_types.go
+++ b/third_party/ctxtypes/mssql_types.go
@@ -6,3 +6,5 @@ type ContextKey string
 
 // PreLoginResponseKey is used to obtain PreLogin Response fields
 const PreLoginResponseKey ContextKey = "preLoginResponse"
+// ClientLoginKey is used to pass the client Login
+const ClientLoginKey ContextKey = "clientLogin"


### PR DESCRIPTION
This PR makes enables client's param propagation via Secretless. This propagates the params that go-mssqldb supports via the Login packet:

+ Database
+ HostName
+ ServerName
+ AppName
+ TypeFlags

See https://github.com/cyberark/go-mssqldb/blob/master/tds.go#L988-L999.

~This PR relies on the ReadLogin method introduced over at cyberark/go-mssqldb#6. The build will fail until that dependency is merged.~