### PR TITLE
Adds IT tests for different versions of MSSQL servers

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,7 @@ github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=

--- a/test/connector/tcp/mssql/mssql-2017-cu1/dev
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/dev
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+./start -d

--- a/test/connector/tcp/mssql/mssql-2017-cu1/docker-compose.yml
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.0'
+
+services:
+
+  mssql-2017-cu1:
+    image: mcr.microsoft.com/mssql/server:2017-CU1-ubuntu
+    ports:
+      - 1434:1433
+    environment:
+      # This hardcoded password must match the one in secretless.yml.
+      SA_PASSWORD: "yourStrong()Password"
+      ACCEPT_EULA: Y
+
+  secretless-2017-cu1:
+    image: secretless-broker
+    ports:
+      - 2224:2223
+    volumes:
+      - ./secretless.yml:/secretless.yml
+    depends_on:
+      - mssql-2017-cu1
+
+  secretless-2017-cu1-dev:
+    image: secretless-dev
+    command: ./bin/reflex
+    ports:
+      - 2224:2223
+    volumes:
+      - ../../../../..:/secretless
+      - ./secretless.yml:/secretless.yml
+    depends_on:
+      - mssql-2017-cu1
+
+  test:
+    build:
+      context: ..
+    command: sleep 999d
+    environment:
+      TEST_ROOT: /secretless/test/connector/tcp/mssql
+      DB_PROTOCOL: mssql
+      DB_HOST_TLS: mssql-2017-cu1
+      DB_HOST_NO_TLS: mssql-2017-cu1 # TODO: configure a non-ssl container?
+      DB_PORT: 1433
+      DB_USER: sa
+      DB_PASSWORD: yourStrong()Password
+      SECRETLESS_HOST:
+    volumes:
+      - ../../../../..:/secretless

--- a/test/connector/tcp/mssql/mssql-2017-cu1/secretless.yml
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/secretless.yml
@@ -1,0 +1,12 @@
+version: 2
+
+services:
+  mssql:
+    connector: mssql
+    listenOn: tcp://0.0.0.0:2223
+    credentials:
+      username: sa
+      # This hardcoded password must match the one in the docker-compose.
+      password: yourStrong()Password
+      host: mssql-2017-cu1
+      port: 1433

--- a/test/connector/tcp/mssql/mssql-2017-cu1/start
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/start
@@ -1,0 +1,12 @@
+#!/bin/bash -ex
+
+mssql_host="mssql-2017-cu1"
+secretless_host="secretless-2017-cu1"
+while getopts ":d" opt; do
+    case $opt in
+        d) secretless_host=secretless-2017-cu1-dev;;
+        *) echo "Unknown option -$OPTARG"; exit 1;;
+    esac
+done
+
+../start -m $mssql_host -s $secretless_host

--- a/test/connector/tcp/mssql/mssql-2017-cu1/stop
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/stop
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+../stop

--- a/test/connector/tcp/mssql/mssql-2017-cu1/test
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/test
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# Automatically detect if we're devmode based on the existence
+# of the secretless-dev container.  We assume that you started
+# your workflow using `./dev` if you are developing, and this
+# command will use the secretless-dev container.
+secretless_host="secretless-2017-cu1"
+if [[ ! -z $(docker-compose ps -q secretless-2017-cu1-dev) ]]; then
+  secretless_host=secretless-2017-cu1-dev
+fi
+
+../test -s $secretless_host

--- a/test/connector/tcp/mssql/mssql-2017-cu1/test-local
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/test-local
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# this is for local testing
+
+export TEST_ROOT="/secretless/test/connector/tcp/mssql"
+export DB_PROTOCOL="mssql"
+export DB_HOST_TLS="mssql-2017-cu1"
+export DB_HOST_NO_TLS="mssql-2017-cu1"
+export DB_PORT="1434"
+export DB_USER="sa"
+export DB_PASSWORD="yourStrong()Password"
+export SECRETLESS_HOST="127.0.0.1"
+export SECRETLESS_PORT="2224"
+
+cd ..
+go test -v

--- a/test/connector/tcp/mssql/mssql-2017-cu1/wait_for_mssql
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/wait_for_mssql
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+../wait_for_mssql -m mssql-2017-cu1

--- a/test/connector/tcp/mssql/mssql-2019/dev
+++ b/test/connector/tcp/mssql/mssql-2019/dev
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+./start -d

--- a/test/connector/tcp/mssql/mssql-2019/docker-compose.yml
+++ b/test/connector/tcp/mssql/mssql-2019/docker-compose.yml
@@ -1,0 +1,48 @@
+version: '3.0'
+
+services:
+
+  mssql-2019:
+    image: mcr.microsoft.com/mssql/server:2019-latest
+    ports:
+      - 1435:1433
+    environment:
+      # This hardcoded password must match the one in secretless.yml.
+      SA_PASSWORD: "yourStrong()Password"
+      ACCEPT_EULA: Y
+
+  secretless-2019:
+    image: secretless-broker
+    ports:
+      - 2225:2223
+    volumes:
+      - ./secretless.yml:/secretless.yml
+    depends_on:
+      - mssql-2019
+
+  secretless-2019-dev:
+    image: secretless-dev
+    command: ./bin/reflex
+    ports:
+      - 2225:2223
+    volumes:
+      - ../../../../..:/secretless
+      - ./secretless.yml:/secretless.yml
+    depends_on:
+      - mssql-2019
+
+  test:
+    build:
+      context: ..
+    command: sleep 999d
+    environment:
+      TEST_ROOT: /secretless/test/connector/tcp/mssql
+      DB_PROTOCOL: mssql
+      DB_HOST_TLS: mssql-2019
+      DB_HOST_NO_TLS: mssql-2019 # TODO: configure a non-ssl container?
+      DB_PORT: 1433
+      DB_USER: sa
+      DB_PASSWORD: yourStrong()Password
+      SECRETLESS_HOST:
+    volumes:
+      - ../../../../..:/secretless

--- a/test/connector/tcp/mssql/mssql-2019/secretless.yml
+++ b/test/connector/tcp/mssql/mssql-2019/secretless.yml
@@ -1,0 +1,12 @@
+version: 2
+
+services:
+  mssql:
+    connector: mssql
+    listenOn: tcp://0.0.0.0:2223
+    credentials:
+      username: sa
+      # This hardcoded password must match the one in the docker-compose.
+      password: yourStrong()Password
+      host: mssql-2019
+      port: 1433

--- a/test/connector/tcp/mssql/mssql-2019/start
+++ b/test/connector/tcp/mssql/mssql-2019/start
@@ -1,0 +1,12 @@
+#!/bin/bash -ex
+
+mssql_host="mssql-2019"
+secretless_host="secretless-2019"
+while getopts ":d" opt; do
+    case $opt in
+        d) secretless_host=secretless-2019-dev;;
+        *) echo "Unknown option -$OPTARG"; exit 1;;
+    esac
+done
+
+../start -m $mssql_host -s $secretless_host

--- a/test/connector/tcp/mssql/mssql-2019/stop
+++ b/test/connector/tcp/mssql/mssql-2019/stop
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+../stop

--- a/test/connector/tcp/mssql/mssql-2019/test
+++ b/test/connector/tcp/mssql/mssql-2019/test
@@ -1,0 +1,12 @@
+#!/bin/bash -e
+
+# Automatically detect if we're devmode based on the existence
+# of the secretless-dev container.  We assume that you started
+# your workflow using `./dev` if you are developing, and this
+# command will use the secretless-dev container.
+secretless_host="secretless-2019"
+if [[ ! -z $(docker-compose ps -q secretless-2019-dev) ]]; then
+  secretless_host=secretless-2019-dev
+fi
+
+../test -s $secretless_host

--- a/test/connector/tcp/mssql/mssql-2019/test-local
+++ b/test/connector/tcp/mssql/mssql-2019/test-local
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# this is for local testing
+
+export TEST_ROOT="/secretless/test/connector/tcp/mssql"
+export DB_PROTOCOL="mssql"
+export DB_HOST_TLS="mssql-2019"
+export DB_HOST_NO_TLS="mssql-2019"
+export DB_PORT="1435"
+export DB_USER="sa"
+export DB_PASSWORD="yourStrong()Password"
+export SECRETLESS_HOST="127.0.0.1"
+export SECRETLESS_PORT="2225"
+
+cd ..
+go test -v

--- a/test/connector/tcp/mssql/mssql-2019/wait_for_mssql
+++ b/test/connector/tcp/mssql/mssql-2019/wait_for_mssql
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+../wait_for_mssql -m mssql-2019

--- a/test/connector/tcp/mssql/mssql_connector_test.go
+++ b/test/connector/tcp/mssql/mssql_connector_test.go
@@ -2,6 +2,7 @@ package mssqltest
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,9 +38,14 @@ func RunTests(t *testing.T, queryExec dbQueryExecutor) {
 	})
 
 	t.Run("Cannot connect directly to MSSQL", func(t *testing.T) {
+		// Set Host and Port to $DB_HOST_TLS and $DB_PORT environment
+		// variables, respectively.
+		envCfg := testutil.NewDbConfigFromEnv()
 		cfg := defaultSecretlessDbConfig()
-		cfg.Port = 1433
-		cfg.Host = "mssql"
+		cfg.Host = envCfg.HostWithTLS
+		var err error
+		cfg.Port, err = strconv.Atoi(envCfg.Port)
+		assert.NoError(t, err)
 
 		// This is for local testing. Locally, Secretless and and the target service
 		// are exposed on 127.0.0.1 via port mappings
@@ -47,7 +53,7 @@ func RunTests(t *testing.T, queryExec dbQueryExecutor) {
 			cfg.Host = "127.0.0.1"
 		}
 
-		_, err := queryExec(
+		_, err = queryExec(
 			cfg,
 			"",
 		)

--- a/test/connector/tcp/mssql/mssql_query.go
+++ b/test/connector/tcp/mssql/mssql_query.go
@@ -8,14 +8,12 @@ import (
 	"os/exec"
 	"text/tabwriter"
 
-	_ "github.com/denisenkom/go-mssqldb"
-
 	"github.com/cyberark/secretless-broker/test/util/testutil"
 )
 
 type dbConfig struct {
-	Host string
-	Port int
+	Host     string
+	Port     int
 	Username string
 	Password string
 	Database string
@@ -26,7 +24,7 @@ type dbQueryExecutor func(cfg dbConfig, query string) (string, error)
 func defaultSecretlessDbConfig() dbConfig {
 	return dbConfig{
 		Host:     testutil.SecretlessHost,
-		Port:     2223,
+		Port:     testutil.SecretlessPort,
 		Username: "dummy",
 		Password: "dummy",
 	}
@@ -50,7 +48,7 @@ func sqlcmdExec(
 
 	out, err := exec.Command(
 		"sqlcmd",
-		args...
+		args...,
 	).Output()
 
 	if err != nil {
@@ -98,7 +96,6 @@ func gomssqlExec(
 		return "", err
 	}
 	defer rows.Close()
-
 
 	// Execute the query
 	cols, err := rows.Columns()

--- a/test/connector/tcp/mssql/start
+++ b/test/connector/tcp/mssql/start
@@ -1,21 +1,33 @@
 #!/bin/bash -ex
 
-SECRETLESS_HOST=secretless
-while getopts :d opt; do
+mssql_host=mssql
+while getopts :dm:s: opt; do
     case $opt in
-        d) SECRETLESS_HOST=secretless-dev;;
+        d) dev_mode=true;;
+        m) mssql_host=${OPTARG};;
+        s) secretless_host=${OPTARG};;
        \?) echo "Unknown option -$OPTARG"; exit 1;;
     esac
 done
+# If the secretless host is not explicitly set on the command line,
+# then use one of the default names (either secretless or
+# secretless-dev, depending on whether testing is being done in
+# development mode) for the secretless host.
+if [[ -z $secretless_host ]]; then
+    secretless_host=secretless
+    if [[ "$dev_mode" = true ]]; then
+        secretless_host=secretless-dev
+    fi
+fi
 
 ./stop
 
 docker-compose build
 
 # the order of the services is important. mssql must be up before we start secretless
-docker-compose up -d mssql
+docker-compose up -d $mssql_host
 
-time ./wait_for_mssql
-docker-compose logs mssql
+time ./wait_for_mssql -m $mssql_host
+docker-compose logs $mssql_host
 
-docker-compose up -d $SECRETLESS_HOST
+docker-compose up -d $secretless_host

--- a/test/connector/tcp/mssql/test
+++ b/test/connector/tcp/mssql/test
@@ -1,12 +1,22 @@
 #!/bin/bash -e
 
-# Automatically detect if we're devmode based on the existence
-# of the secretless-dev container.  We assume that you started
-# your workflow using `./dev` if you are developing, and this
-# command will use the secretless-dev container.
-export SECRETLESS_HOST=secretless
-if [[ ! -z $(docker-compose ps -q secretless-dev) ]]; then
-  export SECRETLESS_HOST=secretless-dev
+while getopts :s: opt; do
+    case $opt in
+        s) SECRETLESS_HOST=${OPTARG};;
+       \?) echo "Unknown option -$OPTARG"; exit 1;;
+    esac
+done
+# If the secretless host is not explicitly set on the command line,
+# then use the default names (either secretless or secretless-dev)
+# for the secretless host. Automatically detect if we're devmode
+# based on the existence of the secretless-dev container.  We assume
+# that you started your workflow using `./dev` if you are developing,
+# and this command will use the secretless-dev container.
+if [[ -z $SECRETLESS_HOST ]]; then
+  export SECRETLESS_HOST=secretless
+  if [[ ! -z $(docker-compose ps -q secretless-dev) ]]; then
+    SECRETLESS_HOST=secretless-dev
+  fi
 fi
 
 echo "Waiting for '$SECRETLESS_HOST' service to start"

--- a/test/connector/tcp/mssql/wait_for_mssql
+++ b/test/connector/tcp/mssql/wait_for_mssql
@@ -1,7 +1,15 @@
 #!/bin/bash
 
+mssql_host=mssql
+while getopts :m: opt; do
+    case $opt in
+        m) mssql_host=${OPTARG};;
+       \?) echo "Unknown option -$OPTARG"; exit 1;;
+    esac
+done
+
 mssql_is_up() {
-    docker-compose logs mssql | grep "SQL Server is now ready for client connections"
+    docker-compose logs $mssql_host | grep "SQL Server is now ready for client connections"
 }
 
 # TODO: Use bash-lib for this function once it is implemented there

--- a/test/util/testutil/init.go
+++ b/test/util/testutil/init.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"log"
 	"os"
+	"strconv"
 )
 
 // Verbose reads the VERBOSE environment variable to determine output mode.
@@ -18,12 +19,12 @@ var Verbose = func() bool {
 
 // DBConfig holds configuration information for a database
 type DBConfig struct {
-	HostWithTLS string
+	HostWithTLS    string
 	HostWithoutTLS string
-	Port string
-	User string
-	Password string
-	Protocol string
+	Port           string
+	User           string
+	Password       string
+	Protocol       string
 }
 
 // NewDbConfigFromEnv creates a new DbConfig from ENV variables.  The variables
@@ -49,19 +50,19 @@ func NewDbConfigFromEnv() DBConfig {
 
 	// Validate they exist
 	for _, field := range requiredEnvVars {
-		if _, found := os.LookupEnv(field); !found  {
+		if _, found := os.LookupEnv(field); !found {
 			log.Panicf("ERROR: $%v envvar wasn't found\n", field)
 		}
 	}
 
 	// Read them into the DBConfig
 	return DBConfig{
-		HostWithTLS: os.Getenv("DB_HOST_TLS"),
+		HostWithTLS:    os.Getenv("DB_HOST_TLS"),
 		HostWithoutTLS: os.Getenv("DB_HOST_NO_TLS"),
-		Port: os.Getenv("DB_PORT"),
-		User: os.Getenv("DB_USER"),
-		Password: os.Getenv("DB_PASSWORD"),
-		Protocol: os.Getenv("DB_PROTOCOL"),
+		Port:           os.Getenv("DB_PORT"),
+		User:           os.Getenv("DB_USER"),
+		Password:       os.Getenv("DB_PASSWORD"),
+		Protocol:       os.Getenv("DB_PROTOCOL"),
 	}
 }
 
@@ -75,6 +76,21 @@ var SecretlessHost = func() string {
 		return host
 	}
 	return "secretless"
+}()
+
+// SecretlessPort gets its value from the SECRETLESS_PORT ENV variable, and
+// allows us to specify a different port to use for the secretlessy-proxy
+// host.
+var SecretlessPort = func() int {
+	port := 2223
+	if portEnv, ok := os.LookupEnv("SECRETLESS_PORT"); ok {
+		var err error
+		port, err = strconv.Atoi(portEnv)
+		if err != nil {
+			log.Panicf("ERROR: Invalid SECRETLESS_PORT envvar: $%v\n", portEnv)
+		}
+	}
+	return port
 }()
 
 func init() {


### PR DESCRIPTION
Adds IT tests for different versions of MSSQL servers

#### What does this PR do (include background context, if relevant)?
Adds IT tests for different versions of MSSQL servers

This test extends the MSSQL integration tests by adding test for
running the existing test suite against the following MSSQL server
versions:
- 2019-latest
- 2017-CU1-ubuntu
in addition to the `2017-latest` version that is used in the existing
test.

The integration tests for each new server version have been added in their
own subdirectory in the MSSQL test directory. This will allow for
different server versions to be incrementally added/removed over time
without affecting the default testing that uses MSSQL server version
2017-latest.

Each MSSQL server version test subdirectory has its own versions of
docker-compose.yml and secretless.yml that use different values of
host ports for the various services so that they can run concurrently.
Each subdirectory also has versions of the 'start', 'stop', 'test',
'test-local', and 'wait_for_mssql' scripts, but these scripts mostly
delegate to their counterparts in the parent test directory (so that any
changes to scripts in the parent directory will not have to be duplicated
in the subdirectories).

Addresses serverless-broker Issue #1017.

#### What ticket does this PR close?
Connected to #1017 

#### Where should the reviewer start?
In the server-2017-CU1 and server-2019 subdirectories.

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ No ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ No ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ n/a ] An updated README with instructions on how to manually test this feature
- [ n/a ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ n/a ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
