### PR TITLE
Update connector plugin examples

### DIFF
--- a/examples/connector_templates/http/template/connector.go
+++ b/examples/connector_templates/http/template/connector.go
@@ -7,15 +7,16 @@ import (
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
 )
 
-// Connector injects an HTTP request with AWS authorization headers.
+// Connector modifies an HTTP request to include required authentication information
 type Connector struct {
 	logger log.Logger
+	config []byte // Note: this can be removed if your plugin does not use any custom config
 }
 
 /*
-	This function has access to the client http.Request and the credentials
-	(as a map), and is expected to modify the request so that it will authenticate.
-	This typically means adding required authorization headers.
+Connect has access to the client http.Request and the credentials
+(as a map), and is expected to modify the request so that it will authenticate.
+This typically means adding required authorization headers.
 */
 func (c *Connector) Connect(
 	r *gohttp.Request,

--- a/examples/connector_templates/http/template/plugin.go
+++ b/examples/connector_templates/http/template/plugin.go
@@ -17,10 +17,12 @@ func PluginInfo() map[string]string {
 	}
 }
 
-// NewConnector returns an http.Connector that decorates each incoming HTTP request with a basic auth header.
+// NewConnector returns an http.Connector that decorates each incoming HTTP request
+// so that it contains the necessary authentication information (typically by adding appropriate headers)
 func NewConnector(conRes connector.Resources) http.Connector {
 	return &Connector{
 		logger: conRes.Logger(),
+		config: conRes.Config(), // Note: you may skip sending this if your plugin doesn't use any custom config
 	}
 }
 

--- a/examples/connector_templates/tcp/template/connector.go
+++ b/examples/connector_templates/tcp/template/connector.go
@@ -7,11 +7,14 @@ import (
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
 )
 
+// SingleUseConnector is passed the client's net.Conn and the current CredentialValuesById,
+// and returns an authenticated net.Conn to the target service
 type SingleUseConnector struct {
 	logger log.Logger
+	config []byte // Note: this can be removed if your plugin does not use any custom config
 }
 
-// This function receives a connection to the client, and opens a connection to the target using the client's connection
+// Connect receives a connection to the client, and opens a connection to the target using the client's connection
 // and the credentials provided in credentialValuesByID
 func (connector *SingleUseConnector) Connect(
 	clientConn net.Conn,

--- a/examples/connector_templates/tcp/template/plugin.go
+++ b/examples/connector_templates/tcp/template/plugin.go
@@ -21,6 +21,7 @@ func NewConnector(conRes connector.Resources) tcp.Connector {
 		// to the target service for each incoming client connection
 		singleUseConnector := &SingleUseConnector{
 			logger: conRes.Logger(),
+			config: conRes.Config(), // Note: you may skip sending this if your plugin doesn't use any custom config
 		}
 
 		return singleUseConnector.Connect(clientConn, credentialValuesByID)


### PR DESCRIPTION
Make sure all examples include passing the `connector.Resources.Config()` when
instantiating a new `Connector`

Also updates the comments to generalize, follow go lint standards, and remove
references to specific internal connectors