### PR TITLE
Add gofmt to code climate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,3 +15,5 @@ engines:
         enabled: false
       SC2148:
         enabled: false
+  gofmt:
+    enabled: true

--- a/bin/juxtaposer/formatter/util/util.go
+++ b/bin/juxtaposer/formatter/util/util.go
@@ -58,10 +58,10 @@ func GetStandardDeviation(mappedCounts *map[int]int) float64 {
 	mean := GetMean(mappedCounts)
 	var totalDeviation float64
 	for valueAmount, occurrences := range *mappedCounts {
-		deviation := math.Pow(float64(valueAmount) - mean, 2)
+		deviation := math.Pow(float64(valueAmount)-mean, 2)
 		totalDeviation += deviation * float64(occurrences)
 	}
-	standardDeviation := math.Pow(totalDeviation/float64(getMappedDataPointCount(mappedCounts) - 1), 0.5)
+	standardDeviation := math.Pow(totalDeviation/float64(getMappedDataPointCount(mappedCounts)-1), 0.5)
 
 	return standardDeviation
 }

--- a/internal/plugin/connectors/http/aws/plugin.go
+++ b/internal/plugin/connectors/http/aws/plugin.go
@@ -20,7 +20,7 @@ func PluginInfo() map[string]string {
 // request with authorization data.
 func NewConnector(conRes connector.Resources) http.Connector {
 	return &Connector{
-		logger:   conRes.Logger(),
+		logger: conRes.Logger(),
 	}
 }
 

--- a/internal/plugin/connectors/http/generic/config.go
+++ b/internal/plugin/connectors/http/generic/config.go
@@ -13,8 +13,8 @@ import (
 
 type config struct {
 	CredentialPatterns map[string]*regexp.Regexp
-	Headers map[string]*template.Template
-	ForceSSL bool
+	Headers            map[string]*template.Template
+	ForceSSL           bool
 }
 
 // validate validates that the given creds satisfy the CredentialValidations of
@@ -71,8 +71,8 @@ func newConfig(cfgYAML *ConfigYAML) (*config, error) {
 
 	cfg := &config{
 		CredentialPatterns: make(map[string]*regexp.Regexp),
-		Headers: make(map[string]*template.Template),
-		ForceSSL: cfgYAML.ForceSSL,
+		Headers:            make(map[string]*template.Template),
+		ForceSSL:           cfgYAML.ForceSSL,
 	}
 
 	// Validate and save regexps

--- a/internal/plugin/connectors/ssh/proxy_service.go
+++ b/internal/plugin/connectors/ssh/proxy_service.go
@@ -119,7 +119,6 @@ func (proxy *proxyService) Start() error {
 
 		serverConfig.AddHostKey(private)
 
-
 		// TODO: is it possible to use the duplex func to stream ?
 		for !proxy.done {
 			nConn, err := proxy.listener.Accept()

--- a/internal/plugin/connectors/sshagent/proxy_service.go
+++ b/internal/plugin/connectors/sshagent/proxy_service.go
@@ -122,7 +122,6 @@ func (proxy *proxyService) populateKeyring(
 	return proxy.keyring.Add(key)
 }
 
-
 // Start initiates the net.Listener to listen for incoming connections
 func (proxy *proxyService) Start() error {
 	logger := proxy.logger

--- a/internal/plugin/connectors/tcp/mssql/connector.go
+++ b/internal/plugin/connectors/tcp/mssql/connector.go
@@ -90,7 +90,7 @@ Overview of the connection process
 	MsSQL->Driver: Login Response
 	Driver->Secretless: Login success or failure
 	Secretless->Client: Login Response (Premade)
- */
+*/
 
 // SingleUseConnector is used to create an authenticated connection to an MSSQL target
 type SingleUseConnector struct {
@@ -188,10 +188,10 @@ func (connector *SingleUseConnector) Connect(
 		//  working as an implicit lock
 		driverConn, err = driverConnector.Connect(loginContext)
 		connectPhaseFinished <- struct{}{}
-	} ()
+	}()
 
 	// Blocks continuation until we've received the preLoginResponse from the driver
-	preloginResponse := <- preLoginResponseChannel
+	preloginResponse := <-preLoginResponseChannel
 
 	// Since the communication between the client and Secretless must be unencrypted,
 	// we fool the client into thinking that it's talking to a server that does not support
@@ -218,7 +218,7 @@ func (connector *SingleUseConnector) Connect(
 	clientLoginChannel <- *clientLogin
 
 	// Block continuation until driver has completed connection
-	<- connectPhaseFinished
+	<-connectPhaseFinished
 	if err != nil {
 		wrappedError := errors.Wrap(err, "failed to connect to mssql server")
 		connector.sendError(wrappedError)
@@ -241,7 +241,6 @@ func (connector *SingleUseConnector) Connect(
 
 	return connector.backendConn, nil
 }
-
 
 // TODO: Add ability to receive an MSSQL error and send it to the client (#1013)
 func (connector *SingleUseConnector) sendError(err error) {

--- a/internal/plugin/connectors/tcp/mysql/packet.go
+++ b/internal/plugin/connectors/tcp/mysql/packet.go
@@ -18,4 +18,3 @@ func (pkt *Packet) SequenceID() byte {
 func (pkt *Packet) SetSequenceID(id byte) {
 	(*pkt)[3] = id
 }
-

--- a/internal/plugin/connectors/tcp/mysql/protocol/error.go
+++ b/internal/plugin/connectors/tcp/mysql/protocol/error.go
@@ -63,7 +63,7 @@ func (e Error) Error() string {
 // GetPacket formats an Error into a protocol message.
 // https://dev.mysql.com/doc/internals/en/packet-ERR_Packet.html
 func (e Error) GetPacket() []byte {
-	data := make([]byte, 4, 4 + 1 + 2 + 1 + 5 + len(e.Message))
+	data := make([]byte, 4, 4+1+2+1+5+len(e.Message))
 	data = append(data, 0xff)
 	data = append(data, byte(e.Code), byte(e.Code>>8))
 
@@ -83,4 +83,3 @@ func (e Error) GetPacket() []byte {
 
 	return data
 }
-

--- a/internal/plugin/connectors/tcp/mysql/protocol/protocol.go
+++ b/internal/plugin/connectors/tcp/mysql/protocol/protocol.go
@@ -73,7 +73,7 @@ func UnpackErrResponse(data []byte) error {
 	pos++
 
 	// Error Number [16 bit uint]
-	errno := binary.LittleEndian.Uint16(data[pos:pos + 2])
+	errno := binary.LittleEndian.Uint16(data[pos : pos+2])
 	pos = pos + 2
 
 	sqlstate := ""
@@ -81,7 +81,7 @@ func UnpackErrResponse(data []byte) error {
 	if data[pos] == '#' {
 		pos++
 
-		sqlstate = string(data[pos : pos + 5])
+		sqlstate = string(data[pos : pos+5])
 		pos = pos + 5
 	}
 
@@ -190,7 +190,6 @@ type HandshakeV10 struct {
 	AuthPlugin         string
 	Salt               []byte
 }
-
 
 // UnpackHandshakeV10 decodes initial handshake request from server.
 // Basic packet structure shown below.

--- a/internal/providers/kubernetessecrets/provider.go
+++ b/internal/providers/kubernetessecrets/provider.go
@@ -26,7 +26,7 @@ func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, err
 	}
 
 	provider := &Provider{
-		Name:   options.Name,
+		Name:          options.Name,
 		SecretsClient: SecretsClient,
 	}
 

--- a/pkg/secretless/config/v2/config_http.go
+++ b/pkg/secretless/config/v2/config_http.go
@@ -12,7 +12,6 @@ type httpConfigYAML struct {
 	AuthenticateURLsMatching []string `yaml:"authenticateURLsMatching"`
 }
 
-
 // HTTPConfig represents service-specific configuration for service connectors
 // built on top of the http protocol
 type HTTPConfig struct {
@@ -61,7 +60,7 @@ func NewHTTPConfig(cfgBytes []byte) (*HTTPConfig, error) {
 	}
 
 	AuthenticateURLsMatching := make([]*regexp.Regexp, len(cfg.AuthenticateURLsMatching))
-	for i, matchPattern := range cfg.AuthenticateURLsMatching{
+	for i, matchPattern := range cfg.AuthenticateURLsMatching {
 		pattern, err := regexp.Compile(matchPattern)
 		if err != nil {
 			panic(err.Error())
@@ -91,7 +90,7 @@ func (cfg *httpConfigYAML) UnmarshalYAML(bytes []byte) error {
 	// Populate actual http config from tempCfg
 	switch v := tempCfg.AuthenticateURLsMatching.(type) {
 	case string:
-		cfg.AuthenticateURLsMatching = []string{ v }
+		cfg.AuthenticateURLsMatching = []string{v}
 	case []interface{}:
 		urlMatchStrings := make([]string, len(v))
 		for i, urlMatch := range v {

--- a/pkg/secretless/log/mock/logger.go
+++ b/pkg/secretless/log/mock/logger.go
@@ -25,36 +25,52 @@ func (l *LoggerMock) Errorf(format string, args ...interface{}) {
 func (l *LoggerMock) CopyWith(prefix string, isDebug bool) log.Logger {
 	return new(LoggerMock)
 }
+
 // DebugEnabled mocks the method of the same name on the log.Logger interface
-func (l *LoggerMock) DebugEnabled() bool {return false}
+func (l *LoggerMock) DebugEnabled() bool { return false }
+
 // Prefix mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Prefix() string { return "" }
+
 // Debug mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Debug(...interface{}) {}
+
 // Debugf mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Debugf(string, ...interface{}) {}
+
 // Debugln mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Debugln(...interface{}) {}
+
 // Info mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Info(...interface{}) {}
+
 // Infof mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Infof(string, ...interface{}) {}
+
 // Infoln mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Infoln(...interface{}) {}
+
 // Warn mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Warn(...interface{}) {}
+
 // Warnf mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Warnf(string, ...interface{}) {}
+
 // Warnln mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Warnln(...interface{}) {}
+
 // Error mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Error(...interface{}) {}
+
 // Errorln mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Errorln(...interface{}) {}
+
 // Panic mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Panic(...interface{}) {}
+
 // Panicf mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Panicf(string, ...interface{}) {}
+
 // Panicln mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Panicln(...interface{}) {}
 

--- a/pkg/secretless/plugin/sharedobj/available_plugins.go
+++ b/pkg/secretless/plugin/sharedobj/available_plugins.go
@@ -106,6 +106,7 @@ func NewPlugins() Plugins {
 		TCPPluginsByID:  map[string]tcp.Plugin{},
 	}
 }
+
 // Plugins represent a holding object for a bundle of plugins of different types.
 type Plugins struct {
 	HTTPPluginsByID map[string]http.Plugin

--- a/pkg/secretless/plugin/sharedobj/mock/http_plugin.go
+++ b/pkg/secretless/plugin/sharedobj/mock/http_plugin.go
@@ -5,7 +5,7 @@ import (
 )
 
 // HTTPPlugin is a mock struct that implements http.Plugin interface
-type HTTPPlugin struct{
+type HTTPPlugin struct {
 	http.Plugin
 
 	id string
@@ -14,5 +14,5 @@ type HTTPPlugin struct{
 // NewHTTPPlugin creates a new HTTPPlugin mock with an id, so that it may
 // be distinguished from other mocks by DeepEqual.
 func NewHTTPPlugin(id string) HTTPPlugin {
-	return HTTPPlugin{ id: id }
+	return HTTPPlugin{id: id}
 }

--- a/pkg/secretless/plugin/sharedobj/mock/plugins.go
+++ b/pkg/secretless/plugin/sharedobj/mock/plugins.go
@@ -69,7 +69,7 @@ func TCPExternalPluginsByID() map[string]tcp.Plugin {
 func InternalPlugins() plugin.AvailablePlugins {
 	return &Plugins{
 		HTTPPluginsByID: HTTPInternalPluginsByID(),
-		TCPPluginsByID: TCPInternalPluginsByID(),
+		TCPPluginsByID:  TCPInternalPluginsByID(),
 	}
 }
 
@@ -77,7 +77,7 @@ func InternalPlugins() plugin.AvailablePlugins {
 func ExternalPlugins() plugin.AvailablePlugins {
 	return &Plugins{
 		HTTPPluginsByID: HTTPExternalPluginsByID(),
-		TCPPluginsByID: TCPExternalPluginsByID(),
+		TCPPluginsByID:  TCPExternalPluginsByID(),
 	}
 }
 

--- a/pkg/secretless/plugin/sharedobj/mock/tcp_plugin.go
+++ b/pkg/secretless/plugin/sharedobj/mock/tcp_plugin.go
@@ -5,7 +5,7 @@ import (
 )
 
 // TCPPlugin is a mock struct that implements tcp.Plugin interface
-type TCPPlugin struct{
+type TCPPlugin struct {
 	tcp.Plugin
 
 	id string
@@ -14,5 +14,5 @@ type TCPPlugin struct{
 // NewTCPPlugin creates a new TCPPlugin mock with an id, so that it may
 // be distinguished from other mocks by DeepEqual.
 func NewTCPPlugin(id string) TCPPlugin {
-	return TCPPlugin{ id: id }
+	return TCPPlugin{id: id}
 }

--- a/resource-definitions/crd_injector.go
+++ b/resource-definitions/crd_injector.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	GroupName = "secretless" + os.Getenv("SECRETLESS_CRD_SUFFIX") + ".io"
-	CRDName = "configurations." + GroupName
+	CRDName   = "configurations." + GroupName
 )
 
 func getHomeDir() string {

--- a/third_party/ctxtypes/mssql_types.go
+++ b/third_party/ctxtypes/mssql_types.go
@@ -6,5 +6,6 @@ type ContextKey string
 
 // PreLoginResponseKey is used to obtain PreLogin Response fields
 const PreLoginResponseKey ContextKey = "preLoginResponse"
+
 // ClientLoginKey is used to pass the client Login
 const ClientLoginKey ContextKey = "clientLogin"


### PR DESCRIPTION
This PR adds `gofmt` to the CC checks that are automatically run for each PR

It also fixes all current `gofmt` errors 

To see the results, view the CC build for this PR