### PR TITLE
Added better logging of listener opening

### DIFF
--- a/internal/plugin/connectors/http/proxy_service.go
+++ b/internal/plugin/connectors/http/proxy_service.go
@@ -138,7 +138,6 @@ func (proxy *proxyService) selectSubservice(r *gohttp.Request) *Subservice {
 	return &subservice
 }
 
-
 // ServeHTTP exists to implement the go_http.Handler interface
 func (proxy *proxyService) ServeHTTP(w gohttp.ResponseWriter, r *gohttp.Request) {
 	logger := proxy.logger

--- a/internal/proxyservice/proxy_service.go
+++ b/internal/proxyservice/proxy_service.go
@@ -151,6 +151,8 @@ func (s *proxyServices) createHTTPService(
 		return nil, err
 	}
 
+	s.logger.Warnf("Starting HTTP listener on %s...", netAddr.Address())
+
 	// Create the subservices
 
 	var subservices []httpproxy.Subservice
@@ -164,8 +166,11 @@ func (s *proxyServices) createHTTPService(
 		// Get the http traffic patterns to match from the connector config.
 		httpCfg, err := v2.NewHTTPConfig(subCfg.ConnectorConfig)
 		if err != nil {
+			s.logger.Errorf("configuration parsing of '%s' failed: %s", subCfg.Connector, err)
 			return nil, err
 		}
+
+		s.logger.Warnf("Starting HTTP subservice %s...", subCfg.Connector)
 
 		subservices = append(subservices, httpproxy.Subservice{
 			ConnectorID:              subCfg.Connector, // TODO: Rename connectorID
@@ -203,6 +208,8 @@ func (s *proxyServices) createSSHService(
 		return nil, err
 	}
 
+	s.logger.Warnf("Starting SSH listener on %s...", netAddr.Address())
+
 	connResources := s.connectorResources(config)
 	credsRetriever := s.credsRetriever(config.Credentials)
 
@@ -233,6 +240,8 @@ func (s *proxyServices) createSSHAgentService(
 	if err != nil {
 		return nil, err
 	}
+
+	s.logger.Warnf("Starting SSH Agent listener on %s...", netAddr.Address())
 
 	connResources := s.connectorResources(config)
 	credsRetriever := s.credsRetriever(config.Credentials)
@@ -265,6 +274,8 @@ func (s *proxyServices) createTCPService(
 	if err != nil {
 		return nil, err
 	}
+
+	s.logger.Warnf("Starting TCP listener on %s...", netAddr.Address())
 
 	connResources := s.connectorResources(config)
 	svcConnector := pluginInst.NewConnector(connResources)


### PR DESCRIPTION
Old code gave no indication what was being listened on so this will help
debugging efforts.

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/add-more-proxy-logging/)

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
