### PR TITLE
Update conjur-authn-k8s-client version

### DIFF
--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -157,9 +157,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
->>> github.com/cyberark/conjur-authn-k8s-client-0.13.0
+>>> github.com/cyberark/conjur-authn-k8s-client-0.15.0
 
-Copyright [yyyy] [name of copyright owner]
+Copyright (c) 2019 CyberArk Software Ltd. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/cenkalti/backoff v2.0.0+incompatible
 	github.com/codegangsta/cli v1.20.0
 	github.com/cyberark/conjur-api-go v0.5.2
-	github.com/cyberark/conjur-authn-k8s-client v0.13.0
+	github.com/cyberark/conjur-authn-k8s-client v0.15.0
 	github.com/cyberark/summon v0.7.0
 	github.com/denisenkom/go-mssqldb v0.0.0-20191001013358-cfbb681360f0
 	github.com/fsnotify/fsnotify v1.4.7

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/codegangsta/cli v1.20.0/go.mod h1:/qJNoX69yVSKu5o4jLyXAENLRyk1uhi7zkbQ3slBdOA=
 github.com/cyberark/conjur-api-go v0.5.2 h1:8ntk07YNRz5bBwjNXkDEAPR70Yr+J2MN8NGlkhaMC3k=
 github.com/cyberark/conjur-api-go v0.5.2/go.mod h1:hwaReWirzgKor+JtH6vbwZaASDXulvd0SzGCloC5uOc=
-github.com/cyberark/conjur-authn-k8s-client v0.13.0 h1:sKh0yS6lSHT34FnMRR738+Q0dP+ebC6N/h4Bm9rhq0A=
-github.com/cyberark/conjur-authn-k8s-client v0.13.0/go.mod h1:JTeGIeRO59J7mMEc5yF6FPtk1QnaAzs4GyZa4WldqZc=
+github.com/cyberark/conjur-authn-k8s-client v0.15.0 h1:HFSkyKtaWkxhOc+Whh2CV3x1HWsYWXu8yR4w6RS3umw=
+github.com/cyberark/conjur-authn-k8s-client v0.15.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
 github.com/cyberark/secretless-broker v1.4.1-0.20191211191712-251c5ec034af/go.mod h1:+GueI3WCJL5gDYaYa38ZokAR8ceEyCVet7MkuZyjf80=
 github.com/cyberark/summon v0.7.0/go.mod h1:S7grcxHeUxfL1vRTQUyq9jGK8yG6V/tSlLPQ6tHRO4k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/providers/conjur/provider.go
+++ b/internal/providers/conjur/provider.go
@@ -97,7 +97,7 @@ func ProviderFactory(options plugin_v1.ProviderOptions) (plugin_v1.Provider, err
 		log.Printf("Info: Conjur provider using Kubernetes authenticator-based authentication")
 
 		// Load the authenticator with the config from the environment, and log in to Conjur
-		if authenticator, err = loadAuthenticator(provider.AuthnURL, provider.Version, authenticatorTokenFile, provider.Config); err != nil {
+		if authenticator, err = loadAuthenticator(provider.AuthnURL, provider.Version, provider.Config); err != nil {
 			return nil, fmt.Errorf("ERROR: Conjur provider could not retrieve access token using the authenticator client: %s", err)
 		}
 		provider.Authenticator = authenticator
@@ -185,16 +185,13 @@ func (p *Provider) GetValue(id string) ([]byte, error) {
 // Currently the deployment manifest for Secretless must also specify
 // MY_POD_NAMESPACE and MY_POD_NAME from the pod metadata, but there is a GH
 // issue logged in the authenticator for doing this via the Kubernetes API
-func loadAuthenticator(authnURL string, version string, tokenFilePath string,
+func loadAuthenticator(authnURL string, version string,
 	providerConfig conjurapi.Config) (*authenticator.Authenticator, error) {
 
 	var err error
 
-	// Set the client cert / token paths
-	clientCertPath := "/etc/conjur/ssl/client.pem"
-
 	// Check that required environment variables are set
-	config, err := authnConfig.NewFromEnv(&clientCertPath, &tokenFilePath)
+	config, err := authnConfig.NewFromEnv()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Blocked by  #1057 

#### What does this PR do (include background context, if relevant)?
We released a new authn-client that adds the ability to authenticate hosts from anywhere in the policy branch. This PR updates the version of the conjur-authn-k8s-client that is used in this project
Tests for this feature are already implemented in `kubernetes-conjur-demo`.

#### What ticket does this PR close?
Connected to cyberark/conjur#1239
