### PR TITLE
1070 MsSQL WritePrelogin Unit Test Exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/joho/godotenv v1.2.0
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/lib/pq v0.0.0-20180123210206-19c8e9ad0095
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1
@@ -34,7 +33,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
-	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20180712090710-2d6f90ab1293
 	k8s.io/apiextensions-apiserver v0.0.0-20180808065829-408db4a50408

--- a/internal/plugin/connectors/tcp/mssql/mock/mock.go
+++ b/internal/plugin/connectors/tcp/mssql/mock/mock.go
@@ -1,6 +1,7 @@
 package mock
 
 import (
+	"bytes"
 	"context"
 	"io"
 	"net"
@@ -93,4 +94,19 @@ func (n *NetConn) Write([]byte) (numBytes int, err error) {
 // FakeTdsBufferCtor returns the ReadWriteCloser passed in.
 func FakeTdsBufferCtor(r io.ReadWriteCloser) io.ReadWriteCloser {
 	return r
+}
+
+// TdsBufferCtor returns a Buffer (with a fake transport) that can be written & read
+func TdsBufferCtor(r io.ReadWriteCloser) io.ReadWriteCloser {
+	return mssql.NewTdsBuffer(1024, new(Transport))
+}
+
+// Transport imitates a transport buffer
+type Transport struct {
+	bytes.Buffer
+}
+
+// Close imitates the Close method for the Transports structure used elsewhere
+func (t *Transport) Close() error {
+	return nil
 }


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
This test handles the following cases
  - The production version of WritePreloginWithPacketType
  succeeds when all others succeed
  - We receive the prelogin fields from the go-mssqldb driver
  - We modify the prelogin fields before sending them to the user

#### What ticket does this PR close?
Connected to #1070 

#### Where should the reviewer start?
internal/plugin/connectors/tcp/mssql/connector_test.go

#### What is the status of the manual tests?
NA

#### Links to open issues for related automated integration and unit tests
#1010 

#### Links to open issues for related documentation (in READMEs, docs, etc)
NA

#### Screenshots (if appropriate)
NA