### PR TITLE
Introduce Functional Options for MsSQL Connector

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/joho/godotenv v1.2.0
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/lib/pq v0.0.0-20180123210206-19c8e9ad0095
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1
@@ -34,7 +33,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
-	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20180712090710-2d6f90ab1293
 	k8s.io/apiextensions-apiserver v0.0.0-20180808065829-408db4a50408

--- a/internal/plugin/connectors/tcp/mssql/connector.go
+++ b/internal/plugin/connectors/tcp/mssql/connector.go
@@ -115,20 +115,20 @@ type SingleUseConnector struct {
 // This uses the production version of the dependencies, which delegate to the actual 3rd
 // party driver.
 func NewSingleUseConnector(logger log.Logger) *SingleUseConnector {
-	return NewSingleUseConnectorWithOptions(
-		logger,
-		NewMSSQLConnector,
-		mssql.ReadPreloginRequest,
-		mssql.WritePreloginResponse,
-		mssql.ReadLoginRequest,
-		mssql.WriteLoginResponse,
-		mssql.WriteError72,
+	return NewSingleUseConnectorWithOptions(func(opt *types.ConnectorOptions) {
+		opt.Logger = logger
+		opt.NewMSSQLConnector = NewMSSQLConnector
+		opt.ReadPreloginRequest = mssql.ReadPreloginRequest
+		opt.WritePreloginResponse = mssql.WritePreloginResponse
+		opt.ReadLoginRequest = mssql.ReadLoginRequest
+		opt.WriteLoginResponse = mssql.WriteLoginResponse
+		opt.WriteError = mssql.WriteError72
 		// NewIdempotentDefaultTdsBuffer is wrapped so that it conforms to the
 		// types.TdsBufferCtor func signature
-		func(transport io.ReadWriteCloser) io.ReadWriteCloser {
+		opt.NewTdsBuffer = func(transport io.ReadWriteCloser) io.ReadWriteCloser {
 			return mssql.NewIdempotentDefaultTdsBuffer(transport)
-		},
-	)
+		}
+	})
 }
 
 // NewMSSQLConnector is the production implementation of MSSQLConnectorCtor,
@@ -153,24 +153,24 @@ func NewMSSQLConnector(dsn string) (types.MSSQLConnector, error) {
 // you to specify the newMSSQLConnector explicitly.  Intended to be used in unit
 // tests only.
 func NewSingleUseConnectorWithOptions(
-	logger log.Logger,
-	newMSSQLConnector types.MSSQLConnectorCtor,
-	readPreloginRequest types.ReadPreloginRequestFunc,
-	writePreloginResponse types.WritePreloginResponseFunc,
-	readLoginRequest types.ReadLoginRequestFunc,
-	writeLoginRequest types.WriteLoginResponseFunc,
-	writeError types.WriteErrorFunc,
-	newTdsBuffer types.TdsBufferCtor,
+	options ...types.ConnectorOption,
 ) *SingleUseConnector {
+	// Default Options
+	args := &types.ConnectorOptions{}
+
+	for _, option := range options {
+		option(args)
+	}
+
 	return &SingleUseConnector{
-		logger:                logger,
-		newMSSQLConnector:     newMSSQLConnector,
-		readPreloginRequest:   readPreloginRequest,
-		writePreloginResponse: writePreloginResponse,
-		readLoginRequest:      readLoginRequest,
-		writeLoginResponse:    writeLoginRequest,
-		writeError:            writeError,
-		newTdsBuffer:          newTdsBuffer,
+		logger:                args.Logger,
+		newMSSQLConnector:     args.NewMSSQLConnector,
+		readPreloginRequest:   args.ReadPreloginRequest,
+		writePreloginResponse: args.WritePreloginResponse,
+		readLoginRequest:      args.ReadLoginRequest,
+		writeLoginResponse:    args.WriteLoginResponse,
+		writeError:            args.WriteError,
+		newTdsBuffer:          args.NewTdsBuffer,
 	}
 }
 
@@ -219,6 +219,8 @@ func (connector *SingleUseConnector) Connect(
 	}
 
 	// Prepare connection details from the client, formatted for MSSQL
+	// TODO: find out if it is possible to send errors during prelogin-phase
+	// TODO: send error to client on failed credential validation
 	connDetails := NewConnectionDetails(credentialValuesByID)
 
 	// Create a new MSSQL connector
@@ -262,7 +264,7 @@ func (connector *SingleUseConnector) Connect(
 		return nil, err
 	}
 
-	if err = connector.writeLoginResponse(connector.clientBuff, *loginResp); err != nil {
+	if err = connector.writeLoginResponse(connector.clientBuff, loginResp); err != nil {
 		wrappedError := errors.Wrap(
 			err,
 			"failed to send a successful authentication response to client",

--- a/internal/plugin/connectors/tcp/mssql/connector.go
+++ b/internal/plugin/connectors/tcp/mssql/connector.go
@@ -110,13 +110,13 @@ type SingleUseConnector struct {
 func NewSingleUseConnector(logger log.Logger) *SingleUseConnector {
 	return &SingleUseConnector{
 		ConnectorOptions: types.ConnectorOptions{
-			Logger: logger,
-			NewMSSQLConnector: NewMSSQLConnector,
-			ReadPreloginRequest: mssql.ReadPreloginRequest,
+			Logger:                logger,
+			NewMSSQLConnector:     NewMSSQLConnector,
+			ReadPreloginRequest:   mssql.ReadPreloginRequest,
 			WritePreloginResponse: mssql.WritePreloginResponse,
-			ReadLoginRequest: mssql.ReadLoginRequest,
-			WriteLoginResponse: mssql.WriteLoginResponse,
-			WriteError: mssql.WriteError72,
+			ReadLoginRequest:      mssql.ReadLoginRequest,
+			WriteLoginResponse:    mssql.WriteLoginResponse,
+			WriteError:            mssql.WriteError72,
 			// NewIdempotentDefaultTdsBuffer is wrapped so that it conforms to the
 			// types.TdsBufferCtor func signature
 			NewTdsBuffer: func(transport io.ReadWriteCloser) io.ReadWriteCloser {

--- a/internal/plugin/connectors/tcp/mssql/connector.go
+++ b/internal/plugin/connectors/tcp/mssql/connector.go
@@ -100,35 +100,30 @@ Overview of the connection process
 type SingleUseConnector struct {
 	clientConn net.Conn
 	clientBuff io.ReadWriteCloser
-	logger     log.Logger
-	// Note: We're following standard ctor naming practices with this field.
-	newMSSQLConnector     types.MSSQLConnectorCtor
-	readPreloginRequest   types.ReadPreloginRequestFunc
-	writePreloginResponse types.WritePreloginResponseFunc
-	readLoginRequest      types.ReadLoginRequestFunc
-	writeLoginResponse    types.WriteLoginResponseFunc
-	writeError            types.WriteErrorFunc
-	newTdsBuffer          types.TdsBufferCtor
+
+	types.ConnectorOptions
 }
 
 // NewSingleUseConnector creates a new production SingleUseConnector.
 // This uses the production version of the dependencies, which delegate to the actual 3rd
 // party driver.
 func NewSingleUseConnector(logger log.Logger) *SingleUseConnector {
-	return NewSingleUseConnectorWithOptions(func(opt *types.ConnectorOptions) {
-		opt.Logger = logger
-		opt.NewMSSQLConnector = NewMSSQLConnector
-		opt.ReadPreloginRequest = mssql.ReadPreloginRequest
-		opt.WritePreloginResponse = mssql.WritePreloginResponse
-		opt.ReadLoginRequest = mssql.ReadLoginRequest
-		opt.WriteLoginResponse = mssql.WriteLoginResponse
-		opt.WriteError = mssql.WriteError72
-		// NewIdempotentDefaultTdsBuffer is wrapped so that it conforms to the
-		// types.TdsBufferCtor func signature
-		opt.NewTdsBuffer = func(transport io.ReadWriteCloser) io.ReadWriteCloser {
-			return mssql.NewIdempotentDefaultTdsBuffer(transport)
-		}
-	})
+	return &SingleUseConnector{
+		ConnectorOptions: types.ConnectorOptions{
+			Logger: logger,
+			NewMSSQLConnector: NewMSSQLConnector,
+			ReadPreloginRequest: mssql.ReadPreloginRequest,
+			WritePreloginResponse: mssql.WritePreloginResponse,
+			ReadLoginRequest: mssql.ReadLoginRequest,
+			WriteLoginResponse: mssql.WriteLoginResponse,
+			WriteError: mssql.WriteError72,
+			// NewIdempotentDefaultTdsBuffer is wrapped so that it conforms to the
+			// types.TdsBufferCtor func signature
+			NewTdsBuffer: func(transport io.ReadWriteCloser) io.ReadWriteCloser {
+				return mssql.NewIdempotentDefaultTdsBuffer(transport)
+			},
+		},
+	}
 }
 
 // NewMSSQLConnector is the production implementation of MSSQLConnectorCtor,
@@ -147,31 +142,6 @@ func NewMSSQLConnector(dsn string) (types.MSSQLConnector, error) {
 		return mssqlConn, nil
 	}
 	return types.MSSQLConnectorFunc(fn), err
-}
-
-// NewSingleUseConnectorWithOptions creates a new SingleUseConnector, and allows
-// you to specify the newMSSQLConnector explicitly.  Intended to be used in unit
-// tests only.
-func NewSingleUseConnectorWithOptions(
-	options ...types.ConnectorOption,
-) *SingleUseConnector {
-	// Default Options
-	args := &types.ConnectorOptions{}
-
-	for _, option := range options {
-		option(args)
-	}
-
-	return &SingleUseConnector{
-		logger:                args.Logger,
-		newMSSQLConnector:     args.NewMSSQLConnector,
-		readPreloginRequest:   args.ReadPreloginRequest,
-		writePreloginResponse: args.WritePreloginResponse,
-		readLoginRequest:      args.ReadLoginRequest,
-		writeLoginResponse:    args.WriteLoginResponse,
-		writeError:            args.WriteError,
-		newTdsBuffer:          args.NewTdsBuffer,
-	}
 }
 
 type connectResult struct {
@@ -210,8 +180,8 @@ func (connector *SingleUseConnector) Connect(
 	// client can advance to the next stage of the process.  Otherwise the
 	// client would block forever waiting for its pre-login handshake to be
 	// read.
-	connector.clientBuff = connector.newTdsBuffer(connector.clientConn)
-	_, err := connector.readPreloginRequest(connector.clientBuff)
+	connector.clientBuff = connector.NewTdsBuffer(connector.clientConn)
+	_, err := connector.ReadPreloginRequest(connector.clientBuff)
 	if err != nil {
 		wrappedError := errors.Wrap(err, "failed to read prelogin request from client")
 		connector.writeErrorToClient(wrappedError)
@@ -229,7 +199,7 @@ func (connector *SingleUseConnector) Connect(
 	// NOTE: Secretless has some unfortunate naming collisions with the
 	// go-mssqldb driver package.  The driver package has its own concept of a
 	// "connector", and its connectors also have a "Connect" method.
-	driverConnector, err := connector.newMSSQLConnector(dataSourceName(connDetails))
+	driverConnector, err := connector.NewMSSQLConnector(dataSourceName(connDetails))
 	if err != nil {
 		wrappedError := errors.Wrap(err, "failed to create a go-mssqldb connector")
 		connector.writeErrorToClient(wrappedError)
@@ -264,7 +234,7 @@ func (connector *SingleUseConnector) Connect(
 		return nil, err
 	}
 
-	if err = connector.writeLoginResponse(connector.clientBuff, loginResp); err != nil {
+	if err = connector.WriteLoginResponse(connector.clientBuff, loginResp); err != nil {
 		wrappedError := errors.Wrap(
 			err,
 			"failed to send a successful authentication response to client",
@@ -318,7 +288,7 @@ func (connector *SingleUseConnector) waitForServerConnection(
 		preloginResponse[mssql.PreloginENCRYPTION] = []byte{mssql.EncryptNotSup}
 
 		// Write the prelogin packet back to the user
-		err = connector.writePreloginResponse(connector.clientBuff, preloginResponse)
+		err = connector.WritePreloginResponse(connector.clientBuff, preloginResponse)
 		if err != nil {
 			wrappedError := errors.Wrap(
 				err,
@@ -328,7 +298,7 @@ func (connector *SingleUseConnector) waitForServerConnection(
 
 		// We parse the client's LoginRequest packet so that we can pass on params to the
 		// server.
-		clientLoginRequest, err := connector.readLoginRequest(connector.clientBuff)
+		clientLoginRequest, err := connector.ReadLoginRequest(connector.clientBuff)
 		if err != nil {
 			wrappedError := errors.Wrap(err, "failed to handle login from client")
 			return nil, nil, wrappedError
@@ -377,7 +347,7 @@ func (connector *SingleUseConnector) waitForServerConnection(
 }
 
 func (connector *SingleUseConnector) writeErrorToClient(err error) {
-	_ = connector.writeError(connector.clientBuff, protocolError(err))
+	_ = connector.WriteError(connector.clientBuff, protocolError(err))
 }
 
 func dataSourceName(connDetails *ConnectionDetails) string {

--- a/internal/plugin/connectors/tcp/mssql/connector_test.go
+++ b/internal/plugin/connectors/tcp/mssql/connector_test.go
@@ -46,6 +46,104 @@ func TestSingleUseConnector_Connect(t *testing.T) {
 			}),
 		)
 	})
+
+	t.Run("singleUseConnector#ReadLoginRequest succeeds", func(t *testing.T) {
+		// expected login request returned from ReadLoginRequest
+		expectedLoginRequest := &mssql.LoginRequest{}
+		expectedLoginRequest.Database = "test-database"
+		expectedLoginRequest.AppName = "test-app-name"
+
+		// actual login request sent to Connect via context
+		var actualLoginRequest *mssql.LoginRequest
+		var actualClient io.ReadWriteCloser
+
+		connector := newSingleUseConnectorWithOptions(
+			mock.DefaultConnectorOptions,
+			func(connectorOptions *types.ConnectorOptions) {
+				connectorOptions.ReadLoginRequest = func(r io.ReadWriteCloser) (*mssql.LoginRequest, error) {
+					actualClient = r
+					return expectedLoginRequest, nil
+				}
+			},
+			mock.MSSQLConnectorCtor(
+				func(opt *mock.MSSQLConnectorCtorOptions) {
+					opt.ClientLoginRequestPtr = &actualLoginRequest
+				},
+			),
+		)
+
+		_, _ = runDefaultTestConnect(connector)
+		expectedClient := connector.clientConn
+
+		assert.Equal(t, actualLoginRequest, expectedLoginRequest)
+		// confirm that ReadLoginRequest is called with the client connection
+		assert.Equal(t, expectedClient, actualClient)
+	})
+
+	t.Run("singleUseConnector#ReadLoginRequest fail", func(t *testing.T) {
+		var methodFailsExpectedErr = errors.New("failed to handle login from client")
+
+		methodFails(t, methodFailsExpectedErr, func(connectorOptions *types.ConnectorOptions) {
+			connectorOptions.ReadLoginRequest = func(
+				r io.ReadWriteCloser,
+			) (request *mssql.LoginRequest, e error) {
+				return nil, methodFailsExpectedErr
+			}
+		})
+	})
+
+	t.Run("singleUseConnector#WriteLoginResponse succeeds", func(t *testing.T) {
+		// expected login response returned from server
+		expectedLoginResponse := &mssql.LoginResponse{}
+		expectedLoginResponse.Interface = 23
+		expectedLoginResponse.ProgName = "test-progname"
+		expectedLoginResponse.ProgVer = 01
+		expectedLoginResponse.TDSVersion = 12
+
+		// actual login response passed as args to WriteLoginResponse
+		var actualLoginResponse *mssql.LoginResponse
+		var actualClient io.ReadWriteCloser
+
+		connector := newSingleUseConnectorWithOptions(
+			mock.DefaultConnectorOptions,
+			func(connectorOptions *types.ConnectorOptions) {
+				connectorOptions.WriteLoginResponse = func(
+					w io.ReadWriteCloser,
+					loginRes *mssql.LoginResponse,
+				) error {
+					actualClient = w
+					actualLoginResponse = loginRes
+					return nil
+				}
+			},
+			mock.MSSQLConnectorCtor(
+				func(opt *mock.MSSQLConnectorCtorOptions) {
+					opt.ServerLoginResponse = expectedLoginResponse
+				},
+			),
+		)
+
+		_, _ = runDefaultTestConnect(connector)
+		expectedClient := connector.clientConn
+
+		assert.Equal(t, actualLoginResponse, expectedLoginResponse)
+		// confirm that WriteLoginResponse is called with the client connection
+		assert.Equal(t, expectedClient, actualClient)
+	})
+
+	t.Run("singleUseConnector#WriteLoginResponse fails", func(t *testing.T) {
+		var methodFailsExpectedErr = errors.New("failed to send a successful" +
+			"authentication response to client")
+
+		methodFails(t, methodFailsExpectedErr, func(connectorOptions *types.ConnectorOptions) {
+			connectorOptions.WriteLoginResponse = func(
+				w io.ReadWriteCloser,
+				loginRes *mssql.LoginResponse,
+			) error {
+				return methodFailsExpectedErr
+			}
+		})
+	})
 }
 
 // Test helpers

--- a/internal/plugin/connectors/tcp/mssql/connector_test.go
+++ b/internal/plugin/connectors/tcp/mssql/connector_test.go
@@ -47,6 +47,18 @@ func TestSingleUseConnector_Connect(t *testing.T) {
 		)
 	})
 
+	t.Run("singleUseConnector#ReadPreLoginRequest fail", func(t *testing.T) {
+		var methodFailsExpectedErr = errors.New("failed to read prelogin request from client")
+
+		methodFails(t, methodFailsExpectedErr, func(connectorOptions *types.ConnectorOptions) {
+			connectorOptions.ReadPreloginRequest = func(
+				io.ReadWriteCloser,
+			) (map[uint8][]byte, error) {
+				return nil, methodFailsExpectedErr
+			}
+		})
+	})
+
 	t.Run("singleUseConnector#ReadLoginRequest succeeds", func(t *testing.T) {
 		// expected login request returned from ReadLoginRequest
 		expectedLoginRequest := &mssql.LoginRequest{}
@@ -220,15 +232,3 @@ func methodFails(
 	assert.Contains(t, actualClientErr.Error(), expectedErr.Error())
 }
 
-/*
-Test cases not to forget
-
-	- This is not exhaustive.  Use the method of tracing all the code paths (for
-	each error condition, assuming the previous succeeded) and add a test for
-	each.  If that becomes too many, use judgment to eliminate less important
-	ones.
-
-	- While we shouldn't test the logger messages extensively, here is one that
-	we should test: sending an error message to the user fails.  We want to make
-	sure those are logged.
-*/

--- a/internal/plugin/connectors/tcp/mssql/connector_test.go
+++ b/internal/plugin/connectors/tcp/mssql/connector_test.go
@@ -59,6 +59,71 @@ func TestSingleUseConnector_Connect(t *testing.T) {
 		})
 	})
 
+	t.Run("singleUseConnector#WritePreloginResponse succeeds", func(t *testing.T) {
+
+		// The fields we should get back from inside the mssql.Connect method
+		fakePreLoginResponse := map[uint8][]byte{
+			mssql.PreloginVERSION:    {0, 0, 0, 0, 0, 0},
+			mssql.PreloginENCRYPTION: {mssql.EncryptOn},
+			mssql.PreloginINSTOPT:    {0},
+			mssql.PreloginTHREADID:   {0, 0, 0, 0},
+			mssql.PreloginMARS:       {0}, // MARS disabled
+		}
+
+		// The fields we should be sending to the client
+		expectedPreLoginResponse := map[uint8][]byte{
+			mssql.PreloginVERSION:    {0, 0, 0, 0, 0, 0},
+			mssql.PreloginENCRYPTION: {mssql.EncryptNotSup},
+			mssql.PreloginINSTOPT:    {0},
+			mssql.PreloginTHREADID:   {0, 0, 0, 0},
+			mssql.PreloginMARS:       {0}, // MARS disabled
+		}
+
+		// The fields we actually receive after modifying them
+		var actualPreLoginResponse map[uint8][]byte
+
+		var actualClient io.ReadWriteCloser
+
+		connector := newSingleUseConnectorWithOptions(
+			mock.DefaultConnectorOptions,
+			func(connectorOptions *types.ConnectorOptions) {
+				connectorOptions.WritePreloginResponse = func(
+					w io.ReadWriteCloser,
+					fields map[uint8][]byte,
+				) error {
+					actualClient = w
+					actualPreLoginResponse = fields
+					return nil
+				}
+			},
+			mock.MSSQLConnectorCtor(
+				func(opt *mock.MSSQLConnectorCtorOptions) {
+					opt.ServerPreloginResponse = fakePreLoginResponse
+				},
+			),
+		)
+
+		_, _ = runDefaultTestConnect(connector)
+		expectedClient := connector.clientConn
+
+		assert.Equal(t, actualPreLoginResponse, expectedPreLoginResponse)
+		// confirm that WritePreloginResponse is called with the client connection
+		assert.Equal(t, expectedClient, actualClient)
+	})
+
+	t.Run("singleUseConnector#WritePreloginResponse fails", func(t *testing.T) {
+		var methodFailsExpectedErr = errors.New("failed to write prelogin response to client")
+
+		methodFails(t, methodFailsExpectedErr, func(connectorOptions *types.ConnectorOptions) {
+			connectorOptions.WritePreloginResponse = func(
+				io.ReadWriteCloser,
+				map[uint8][]byte,
+			) error {
+				return methodFailsExpectedErr
+			}
+		})
+	})
+
 	t.Run("singleUseConnector#ReadLoginRequest succeeds", func(t *testing.T) {
 		// expected login request returned from ReadLoginRequest
 		expectedLoginRequest := &mssql.LoginRequest{}
@@ -232,3 +297,15 @@ func methodFails(
 	assert.Contains(t, actualClientErr.Error(), expectedErr.Error())
 }
 
+/*
+Test cases not to forget
+
+	- This is not exhaustive.  Use the method of tracing all the code paths (for
+	each error condition, assuming the previous succeeded) and add a test for
+	each.  If that becomes too many, use judgment to eliminate less important
+	ones.
+
+	- While we shouldn't test the logger messages extensively, here is one that
+	we should test: sending an error message to the user fails.  We want to make
+	sure those are logged.
+*/

--- a/internal/plugin/connectors/tcp/mssql/mock/mock.go
+++ b/internal/plugin/connectors/tcp/mssql/mock/mock.go
@@ -62,7 +62,7 @@ func SuccessfulReadLoginRequest(io.ReadWriteCloser) (*mssql.LoginRequest, error)
 }
 
 // SuccessfulWriteLoginResponse is a double for a WriteLoginResponseFunc that always succeeds.
-func SuccessfulWriteLoginResponse(io.ReadWriteCloser, mssql.LoginResponse) error {
+func SuccessfulWriteLoginResponse(io.ReadWriteCloser, *mssql.LoginResponse) error {
 	return nil
 }
 

--- a/internal/plugin/connectors/tcp/mssql/mock/options.go
+++ b/internal/plugin/connectors/tcp/mssql/mock/options.go
@@ -77,27 +77,25 @@ func MSSQLConnectorCtor(setters ...MSSQLConnectorCtorOption) types.ConnectorOpti
 
 // DefaultConnectorOptions returns a setter that will set ConnectorOptions to
 // mocks that result in success.
-func DefaultConnectorOptions() types.ConnectorOption {
-	return func(connectOptions *types.ConnectorOptions) {
-		connectOptions.Logger = logmock.NewLogger()
-		connectOptions.NewMSSQLConnector = NewSuccessfulMSSQLConnectorCtor(
-			func(ctx context.Context) (net.Conn, error) {
-				interceptor := mssql.ConnectInterceptorFromContext(ctx)
+var DefaultConnectorOptions types.ConnectorOption = func(connectOptions *types.ConnectorOptions) {
+	connectOptions.Logger = logmock.NewLogger()
+	connectOptions.NewMSSQLConnector = NewSuccessfulMSSQLConnectorCtor(
+		func(ctx context.Context) (net.Conn, error) {
+			interceptor := mssql.ConnectInterceptorFromContext(ctx)
 
-				interceptor.ServerPreLoginResponse <- map[uint8][]byte{}
+			interceptor.ServerPreLoginResponse <- map[uint8][]byte{}
 
-				<-interceptor.ClientLoginRequest
+			<-interceptor.ClientLoginRequest
 
-				interceptor.ServerLoginResponse <- &mssql.LoginResponse{}
+			interceptor.ServerLoginResponse <- &mssql.LoginResponse{}
 
-				return NewNetConn(nil), nil
-			},
-		)
-		connectOptions.ReadPreloginRequest = SuccessfulReadPreloginRequest
-		connectOptions.WritePreloginResponse = SuccessfulWritePreloginResponse
-		connectOptions.ReadLoginRequest = SuccessfulReadLoginRequest
-		connectOptions.WriteLoginResponse = SuccessfulWriteLoginResponse
-		connectOptions.WriteError = SuccessfulWriteError
-		connectOptions.NewTdsBuffer = FakeTdsBufferCtor
-	}
+			return NewNetConn(nil), nil
+		},
+	)
+	connectOptions.ReadPreloginRequest = SuccessfulReadPreloginRequest
+	connectOptions.WritePreloginResponse = SuccessfulWritePreloginResponse
+	connectOptions.ReadLoginRequest = SuccessfulReadLoginRequest
+	connectOptions.WriteLoginResponse = SuccessfulWriteLoginResponse
+	connectOptions.WriteError = SuccessfulWriteError
+	connectOptions.NewTdsBuffer = FakeTdsBufferCtor
 }

--- a/internal/plugin/connectors/tcp/mssql/mock/options.go
+++ b/internal/plugin/connectors/tcp/mssql/mock/options.go
@@ -1,0 +1,103 @@
+package mock
+
+import (
+	"context"
+	"net"
+
+	logmock "github.com/cyberark/secretless-broker/pkg/secretless/log/mock"
+
+	"github.com/cyberark/secretless-broker/internal/plugin/connectors/tcp/mssql/types"
+	mssql "github.com/denisenkom/go-mssqldb"
+)
+
+// MSSQLConnectorCtorOptions represents options when creating a MSSQLConnectorCtor. This
+// makes it possible to customize some key values in a Connect double:
+// func Connect(...) (net.Conn, error)
+type MSSQLConnectorCtorOptions struct {
+	// Backend connection returned from the call to Connect
+	BackendConn net.Conn
+	// Error returned from the call to Connect
+	Err error
+	// PreloginResponse from the server passed to interceptor during Connect
+	ServerPreloginResponse map[uint8][]byte
+	// Pointer to unload client login request to, taken from interceptor during Connect
+	ClientLoginRequestPtr **mssql.LoginRequest
+	// LoginResponse from the server passed to interceptor during Connect
+	ServerLoginResponse *mssql.LoginResponse
+}
+
+// MSSQLConnectorCtorOption is the 'functional option' complement to
+// MSSQLConnectorCtorOptions.
+type MSSQLConnectorCtorOption func(*MSSQLConnectorCtorOptions)
+
+// MSSQLConnectorCtor is a 'functional option' of types.ConnectorOption. It generates
+// a customizable MSSQLConnectorCtor using MSSQLConnectorCtorOptions, then sets it on the
+// ConnectorOption passed to it.
+//
+// Empty values of MSSQLConnectorCtorOption result default:
+// ServerPreloginResponse => map[uint8][]byte{}
+// ServerLoginResponse => &mssql.LoginResponse{}
+// BackendConn => nil
+// BackendConn => nil
+// ClientLoginRequestPtr => nil (this means ClientLoginRequest is read from the channel to
+// a vacuum)
+func MSSQLConnectorCtor(setters ...MSSQLConnectorCtorOption) types.ConnectorOption {
+	args := &MSSQLConnectorCtorOptions{}
+
+	for _, setter := range setters {
+		setter(args)
+	}
+
+	return func(connectorArgs *types.ConnectorOptions) {
+		connectorArgs.NewMSSQLConnector = NewSuccessfulMSSQLConnectorCtor(
+			func(ctx context.Context) (net.Conn, error) {
+				interceptor := mssql.ConnectInterceptorFromContext(ctx)
+
+				if args.ServerPreloginResponse == nil {
+					args.ServerPreloginResponse = map[uint8][]byte{}
+				}
+				interceptor.ServerPreLoginResponse <- args.ServerPreloginResponse
+
+				if args.ClientLoginRequestPtr != nil {
+					*args.ClientLoginRequestPtr = <-interceptor.ClientLoginRequest
+				} else {
+					<-interceptor.ClientLoginRequest
+				}
+
+				if args.ServerLoginResponse == nil {
+					args.ServerLoginResponse = &mssql.LoginResponse{}
+				}
+				interceptor.ServerLoginResponse <- args.ServerLoginResponse
+
+				return args.BackendConn, args.Err
+			},
+		)
+	}
+}
+
+// DefaultConnectorOptions returns a setter that will set ConnectorOptions to
+// mocks that result in success.
+func DefaultConnectorOptions() types.ConnectorOption {
+	return func(connectOptions *types.ConnectorOptions) {
+		connectOptions.Logger = logmock.NewLogger()
+		connectOptions.NewMSSQLConnector = NewSuccessfulMSSQLConnectorCtor(
+			func(ctx context.Context) (net.Conn, error) {
+				interceptor := mssql.ConnectInterceptorFromContext(ctx)
+
+				interceptor.ServerPreLoginResponse <- map[uint8][]byte{}
+
+				<-interceptor.ClientLoginRequest
+
+				interceptor.ServerLoginResponse <- &mssql.LoginResponse{}
+
+				return NewNetConn(nil), nil
+			},
+		)
+		connectOptions.ReadPreloginRequest = SuccessfulReadPreloginRequest
+		connectOptions.WritePreloginResponse = SuccessfulWritePreloginResponse
+		connectOptions.ReadLoginRequest = SuccessfulReadLoginRequest
+		connectOptions.WriteLoginResponse = SuccessfulWriteLoginResponse
+		connectOptions.WriteError = SuccessfulWriteError
+		connectOptions.NewTdsBuffer = FakeTdsBufferCtor
+	}
+}

--- a/internal/plugin/connectors/tcp/mssql/production_options_test.go
+++ b/internal/plugin/connectors/tcp/mssql/production_options_test.go
@@ -1,0 +1,133 @@
+package mssql
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/internal/plugin/connectors/tcp/mssql/types"
+	mssql "github.com/denisenkom/go-mssqldb"
+)
+
+func TestProductionReadLoginRequest(t *testing.T) {
+	// production version of ReadLoginRequest
+	var readLoginRequest types.ReadLoginRequestFunc = mssql.ReadLoginRequest
+
+	// expected login request available from net.Conn passed to ReadLogin
+	expectedLoginRequest := &mssql.LoginRequest{}
+	expectedLoginRequest.AppName = "test-app-name"
+	expectedLoginRequest.UserName = "test-user-name"
+	expectedLoginRequest.Database = "test-database"
+	expectedLoginRequest.SSPI = []uint8{}
+
+	r, w := net.Pipe()
+	go func() {
+		_ = mssql.WriteLoginRequest(w, expectedLoginRequest)
+	}()
+
+	// login request returned from ReadLoginRequest
+	actualLoginRequest, _ := readLoginRequest(r)
+
+	assert.Equal(t, actualLoginRequest, expectedLoginRequest)
+}
+
+func TestProductionWriteLoginResponse(t *testing.T) {
+	// production version of WriteLoginResponse
+	var writeLoginResponse types.WriteLoginResponseFunc = mssql.WriteLoginResponse
+
+	// expected login request available from net.Conn passed to WriteLoginResponse
+	expectedLoginResponse := &mssql.LoginResponse{}
+	expectedLoginResponse.Interface = 23
+	expectedLoginResponse.ProgName = "test-progname"
+	expectedLoginResponse.ProgVer = 01
+	expectedLoginResponse.TDSVersion = 12
+
+	r, w := net.Pipe()
+	go func() {
+		writeLoginResponse(w, expectedLoginResponse)
+	}()
+
+	// login response returned from ReadLoginResponse
+	actualLoginResponse, err := mssql.ReadLoginResponse(r)
+	assert.Nil(t, err)
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, expectedLoginResponse, actualLoginResponse)
+}
+
+func TestProductionWritePreLoginResponse(t *testing.T) {
+	// production version of writePreLoginResponse
+	var writePreLoginResponse types.WritePreloginResponseFunc = mssql.WritePreloginResponse
+
+	// expected prelogin request available from net.Conn passed to writePreLoginResponse
+	expectedPreLoginResponse := map[uint8][]byte{
+		1: {2,3,4},
+	}
+
+	r, w := net.Pipe()
+	go func() {
+		writePreLoginResponse(w, expectedPreLoginResponse)
+	}()
+
+	// prelogin response returned from ReadPreloginResponse
+	actualPreLoginResponse, err := mssql.ReadPreloginResponse(r)
+	assert.Nil(t, err)
+	if err != nil {
+		return
+	}
+
+	assert.Equal(t, expectedPreLoginResponse, actualPreLoginResponse)
+}
+
+func TestProductionReadPreLoginRequest(t *testing.T) {
+	// production version of ReadPreLoginRequest
+	var readPreLoginRequest types.ReadPreloginRequestFunc = mssql.ReadPreloginRequest
+
+	// expected prelogin request available from net.Conn passed to ReadLogin
+	expectedPreLoginRequest := map[uint8][]byte{
+		1: {2,3,4},
+	}
+
+	r, w := net.Pipe()
+	go func() {
+		_ = mssql.WritePreloginRequest(w, expectedPreLoginRequest)
+	}()
+
+	// prelogin request returned from ReadPreLoginRequest
+	actualLoginRequest, _ := readPreLoginRequest(r)
+
+	assert.Equal(t, actualLoginRequest, expectedPreLoginRequest)
+}
+
+func TestProductionWriteErr(t *testing.T) {
+	// production version of WriteError
+	var writeError types.WriteErrorFunc = mssql.WriteError72
+
+	// expected error
+	expectedErr := mssql.Error{
+		Number:     1,
+		State:      2,
+		Class:      3,
+		Message:    "test-message",
+		ServerName: "test-server-name",
+		ProcName:   "test-proc-name",
+		LineNo:     4,
+	}
+
+	r, w := net.Pipe()
+	go func() {
+		writeError(w, expectedErr)
+	}()
+
+	// production read error
+	actualErr, err := mssql.ReadError(r)
+	assert.Nil(t, err)
+	if err != nil {
+		return
+	}
+
+	assert.Contains(t, actualErr.Error(), expectedErr.Error())
+}

--- a/internal/plugin/connectors/tcp/mssql/types/types.go
+++ b/internal/plugin/connectors/tcp/mssql/types/types.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 
+	"github.com/cyberark/secretless-broker/pkg/secretless/log"
 	mssql "github.com/denisenkom/go-mssqldb"
 )
 
@@ -51,7 +52,7 @@ type ReadLoginRequestFunc func(r io.ReadWriteCloser) (*mssql.LoginRequest, error
 // packet.  The production version is implemented by mssql.WriteLoginResponse.
 type WriteLoginResponseFunc func(
 	w io.ReadWriteCloser,
-	loginRes mssql.LoginResponse,
+	loginRes *mssql.LoginResponse,
 ) error
 
 // WriteErrorFunc defines the type of the func that writes an error packet. The production
@@ -70,3 +71,18 @@ type WriteErrorFunc func(
 // return a real TdsBuffer (which _is_ a ReadWriteCloser), and so we've chosen a
 // name that reflects the production purpose.
 type TdsBufferCtor func(transport io.ReadWriteCloser) io.ReadWriteCloser
+
+// ConnectorOptions captures all the configuration options for a SingleUseConnector
+type ConnectorOptions struct {
+	Logger                log.Logger
+	NewMSSQLConnector     MSSQLConnectorCtor
+	ReadPreloginRequest   ReadPreloginRequestFunc
+	WritePreloginResponse WritePreloginResponseFunc
+	ReadLoginRequest      ReadLoginRequestFunc
+	WriteLoginResponse    WriteLoginResponseFunc
+	WriteError            WriteErrorFunc
+	NewTdsBuffer          TdsBufferCtor
+}
+
+// ConnectorOption is the 'functional option' complement to ConnectorOptions
+type ConnectorOption func(*ConnectorOptions)


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
This PR is focused on improving the foundation of our current MsSQL tests, reducing code reuse and time needed to build new unit tests for the connector. It additionally includes a division between tests for our connector, and tests for our production options.
- NewSingleUseConnectorWithOptions allows custom injection of dependencies without needing to specify all of them
- ConnectorOptions struct captures all the configuration options for a SingleUseConnector
- ConnectorOption is the 'functional option' complement to ConnectorOptions
- Introduce tests that cover the 'production' options - dependencies we will use during production.
- Covers each option specified in the singleuseconnector
- Introduces mock options structure used for unit testing, including a function which returns default options
- Unit tests now make use of the t.Run structure, where each test can be ran from within a single connect function
- Introduces helper functions for testing around failure
- Makes use of the new functional options feature in the connector

This is a re-uploaded PR of @doodlesbykumbi's work. All credit should go to him.

#### What ticket does this PR close?
Connected to:
#1010 
#1073 

#### Where should the reviewer start?
internal/plugin/connectors/tcp/mssql/connector_test.go

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
NA

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
NA

#### Links to open issues for related automated integration and unit tests
NA

#### Links to open issues for related documentation (in READMEs, docs, etc)
NA
#### Screenshots (if appropriate)
NA