### PR TITLE
Add option to specify MSSQL edition in tests

### DIFF
--- a/test/connector/tcp/mssql/docker-compose.yml
+++ b/test/connector/tcp/mssql/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       # This hardcoded password must match the one in secretless.yml.
       SA_PASSWORD: "yourStrong()Password"
       ACCEPT_EULA: Y
+      MSSQL_PID:
 
   secretless:
     image: secretless-broker

--- a/test/connector/tcp/mssql/mssql-2017-cu1/start
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/start
@@ -9,4 +9,4 @@ while getopts ":d" opt; do
     esac
 done
 
-../start -m $mssql_host -s $secretless_host
+../start -m $mssql_host -s $secretless_host -e Developer

--- a/test/connector/tcp/mssql/mssql-2017-cu1/test
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/test
@@ -1,12 +1,3 @@
 #!/bin/bash -e
 
-# Automatically detect if we're devmode based on the existence
-# of the secretless-dev container.  We assume that you started
-# your workflow using `./dev` if you are developing, and this
-# command will use the secretless-dev container.
-secretless_host="secretless-2017-cu1"
-if [[ ! -z $(docker-compose ps -q secretless-2017-cu1-dev) ]]; then
-  secretless_host=secretless-2017-cu1-dev
-fi
-
-../test -s $secretless_host
+../test

--- a/test/connector/tcp/mssql/mssql-2019/start
+++ b/test/connector/tcp/mssql/mssql-2019/start
@@ -9,4 +9,4 @@ while getopts ":d" opt; do
     esac
 done
 
-../start -m $mssql_host -s $secretless_host
+../start -m $mssql_host -s $secretless_host -e Developer

--- a/test/connector/tcp/mssql/mssql-2019/test
+++ b/test/connector/tcp/mssql/mssql-2019/test
@@ -1,12 +1,3 @@
 #!/bin/bash -e
 
-# Automatically detect if we're devmode based on the existence
-# of the secretless-dev container.  We assume that you started
-# your workflow using `./dev` if you are developing, and this
-# command will use the secretless-dev container.
-secretless_host="secretless-2019"
-if [[ ! -z $(docker-compose ps -q secretless-2019-dev) ]]; then
-  secretless_host=secretless-2019-dev
-fi
-
-../test -s $secretless_host
+../test

--- a/test/connector/tcp/mssql/start
+++ b/test/connector/tcp/mssql/start
@@ -1,26 +1,32 @@
 #!/bin/bash -ex
 
 mssql_host=mssql
-while getopts :dm:s: opt; do
+secretless_host=secretless
+mssql_edition=Developer # can also be Express, Standard, Enterprise, EnterpriseCore
+while getopts :dm:s:e: opt; do
     case $opt in
         d) dev_mode=true;;
         m) mssql_host=${OPTARG};;
         s) secretless_host=${OPTARG};;
+        e) mssql_edition=${OPTARG};;
        \?) echo "Unknown option -$OPTARG"; exit 1;;
     esac
 done
-# If the secretless host is not explicitly set on the command line,
-# then use one of the default names (either secretless or
-# secretless-dev, depending on whether testing is being done in
-# development mode) for the secretless host.
-if [[ -z $secretless_host ]]; then
-    secretless_host=secretless
-    if [[ "$dev_mode" = true ]]; then
-        secretless_host=secretless-dev
-    fi
+
+# the secretless host pulls from either the default value or the command line
+# input, but if dev mode is on it will be overriden by that flag to use the
+# dev container
+export SECRETLESS_HOST=$secretless_host
+
+if [[ "$dev_mode" = true ]]; then
+  echo "Using secretless-dev container"
+  export SECRETLESS_HOST=secretless-dev
 fi
 
 ./stop
+
+echo -e "\nStarting containers for the $mssql_edition edition\n"
+export MSSQL_PID=$mssql_edition
 
 docker-compose build
 
@@ -30,4 +36,27 @@ docker-compose up -d $mssql_host
 time ./wait_for_mssql -m $mssql_host
 docker-compose logs $mssql_host
 
-docker-compose up -d $secretless_host
+docker-compose up -d $SECRETLESS_HOST test
+
+echo "Waiting for '$SECRETLESS_HOST' service to start"
+
+# single quotes are intentional:
+# shellcheck disable=SC2016
+# SECRETLESS_HOST has to be set on the container for this run, so that the test
+# container can be used to query the correct Secretless instance
+docker-compose exec -T test bash -ec '
+counter=0
+while ! wget --quiet --output-document - http://'$SECRETLESS_HOST':5335/ready > /dev/null 2>&1; do
+    if expr $counter = 5 > /dev/null; then
+      echo ""
+      echo "Timed out waiting for Secretless"
+      exit 1
+    fi
+    let "counter=$counter+1"
+    >&2 printf ". "
+    sleep 1
+done
+printf "\n"
+'
+
+echo -e "\n'$SECRETLESS_HOST' service is up\n"

--- a/test/connector/tcp/mssql/test
+++ b/test/connector/tcp/mssql/test
@@ -1,55 +1,6 @@
 #!/bin/bash -e
 
-while getopts :s: opt; do
-    case $opt in
-        s) SECRETLESS_HOST=${OPTARG};;
-       \?) echo "Unknown option -$OPTARG"; exit 1;;
-    esac
-done
-# If the secretless host is not explicitly set on the command line,
-# then use the default names (either secretless or secretless-dev)
-# for the secretless host. Automatically detect if we're devmode
-# based on the existence of the secretless-dev container.  We assume
-# that you started your workflow using `./dev` if you are developing,
-# and this command will use the secretless-dev container.
-if [[ -z $SECRETLESS_HOST ]]; then
-  export SECRETLESS_HOST=secretless
-  if [[ ! -z $(docker-compose ps -q secretless-dev) ]]; then
-    SECRETLESS_HOST=secretless-dev
-  fi
-fi
+echo -e "\nRunning tests\n"
 
-echo "Waiting for '$SECRETLESS_HOST' service to start"
-
-# single quotes are intentional:
-# shellcheck disable=SC2016
-docker-compose run --rm --no-deps test bash -ec '
-counter=0
-while ! wget --quiet --output-document - http://'$SECRETLESS_HOST':5335/ready > /dev/null 2>&1; do
-    if expr $counter = 5 > /dev/null; then
-      echo ""
-      echo "Timed out waiting for Secretless"
-      exit 1
-    fi
-    let "counter=$counter+1"
-    >&2 printf ". "
-    sleep 1
-done
-printf "\n"
-'
-
-echo "'$SECRETLESS_HOST' service is up - continuing "
-echo ""
-echo "Running tests"
-echo ""
-
-docker-compose run \
-  -e SECRETLESS_HOST="$SECRETLESS_HOST" \
-  --rm \
-  --no-deps \
+docker-compose exec -T \
   test bash -c "go test -v ./test/connector/tcp/mssql"
-
-# print secretless logs after tests run
-ret=$?
-docker-compose logs $SECRETLESS_HOST
-exit $ret


### PR DESCRIPTION
- Add MSSQL_PID env var option to MSSQL server container (defaults to Developer)
- Removed need for Secretless host from test script - this makes it easier to
  run the test scripts, bc you only have to supply config to the `start`
  script. All it took was leaving the `test` container up in the `start`
  script and verifying the `secretless` container was up in `start`, which
  logically is reasonable anyway.
- Updated 2017-cu1 and 2019 tests to not send Secretless host to test script


If interested in trying this out, a reviewer can run `./bin/build` from the project root and from the [mssql dir](https://github.com/cyberark/secretless-broker/tree/test-mssql-editions/test/connector/tcp/mssql) run `./start -e Enterprise` to start the containers and `./test` to run the tests.

You can validate that the MSSQL container is running the Enterprise edition by running
```
$ docker exec -it {MSSQL_CONTAINER_ID} /opt/mssql-tools/bin/sqlcmd -S localhost -U SA -P 'yourStrong()Password' -Q 'SELECT @@VERSION'
                                                                                                                                                                                                                                                                                                            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Microsoft SQL Server 2017 (RTM-CU18) (KB4527377) - 14.0.3257.3 (X64) 
	Nov 16 2019 01:14:50 
	Copyright (C) 2017 Microsoft Corporation
	Enterprise Edition (64-bit) on Linux (Ubuntu 16.04.6 LTS)   
```

I have used this to validate that our test cases pass against all server editions (Developer, Express, Standard, Enterprise, EnterpriseCore).