### PR TITLE
Remove the ability to override an internal plugin with external one

### DIFF
--- a/pkg/secretless/log/mock/logger.go
+++ b/pkg/secretless/log/mock/logger.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"fmt"
+
 	"github.com/stretchr/testify/mock"
 
 	"github.com/cyberark/secretless-broker/pkg/secretless/log"
@@ -11,12 +13,16 @@ type LoggerMock struct {
 	mock.Mock
 	log.Logger
 	ReceivedCall chan struct{}
+	Warns        []string
+	Errors       []string
+	Panics       []string
 }
 
 // Errorf mocks the method of the same name on the log.Logger interface
 func (l *LoggerMock) Errorf(format string, args ...interface{}) {
 	l.Called()
 	l.ReceivedCall <- struct{}{}
+	l.Errors = append(l.Errors, fmt.Sprintf(format, args...))
 
 	return
 }
@@ -51,28 +57,44 @@ func (l *LoggerMock) Infof(string, ...interface{}) {}
 func (l *LoggerMock) Infoln(...interface{}) {}
 
 // Warn mocks the method of the same name on the log.Logger interface
-func (l *LoggerMock) Warn(...interface{}) {}
+func (l *LoggerMock) Warn(args ...interface{}) {
+	l.Warns = append(l.Warns, fmt.Sprint(args...))
+}
 
 // Warnf mocks the method of the same name on the log.Logger interface
-func (l *LoggerMock) Warnf(string, ...interface{}) {}
+func (l *LoggerMock) Warnf(format string, args ...interface{}) {
+	l.Warns = append(l.Warns, fmt.Sprintf(format, args...))
+}
 
 // Warnln mocks the method of the same name on the log.Logger interface
-func (l *LoggerMock) Warnln(...interface{}) {}
+func (l *LoggerMock) Warnln(args ...interface{}) {
+	l.Warns = append(l.Warns, fmt.Sprintln(args...))
+}
 
 // Error mocks the method of the same name on the log.Logger interface
-func (l *LoggerMock) Error(...interface{}) {}
+func (l *LoggerMock) Error(args ...interface{}) {
+	l.Errors = append(l.Errors, fmt.Sprint(args...))
+}
 
 // Errorln mocks the method of the same name on the log.Logger interface
-func (l *LoggerMock) Errorln(...interface{}) {}
+func (l *LoggerMock) Errorln(args ...interface{}) {
+	l.Errors = append(l.Errors, fmt.Sprintln(args...))
+}
 
 // Panic mocks the method of the same name on the log.Logger interface
-func (l *LoggerMock) Panic(...interface{}) {}
+func (l *LoggerMock) Panic(args ...interface{}) {
+	l.Panics = append(l.Panics, fmt.Sprint(args...))
+}
 
 // Panicf mocks the method of the same name on the log.Logger interface
-func (l *LoggerMock) Panicf(string, ...interface{}) {}
+func (l *LoggerMock) Panicf(format string, args ...interface{}) {
+	l.Panics = append(l.Panics, fmt.Sprintf(format, args...))
+}
 
 // Panicln mocks the method of the same name on the log.Logger interface
-func (l *LoggerMock) Panicln(...interface{}) {}
+func (l *LoggerMock) Panicln(args ...interface{}) {
+	l.Panics = append(l.Panics, fmt.Sprintln(args...))
+}
 
 // NewLogger creates a mock that conforms to the Secretless Logger interface
 func NewLogger() *LoggerMock {

--- a/pkg/secretless/plugin/sharedobj/available_plugins.go
+++ b/pkg/secretless/plugin/sharedobj/available_plugins.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/tcp"
 )
 
+const pluginConflictMessage = "%s plugin ID '%s' conflicts with an existing internal plugin"
+
 // CompatiblePluginAPIVersion indicates what matching API version an external plugin
 // must have so that Secretless is capable of loading it.
 var CompatiblePluginAPIVersion = "0.1.0"
@@ -39,6 +41,24 @@ func AllAvailablePlugins(
 	)
 }
 
+// checkPluginIDConflicts asserts that a given plugin ID is not used
+// by any internal HTTP or TCP plugin.
+func checkPluginIDConflicts(
+	pluginType string, // "HTTP" or "TCP"
+	pluginID string,
+	internalPlugins plugin.AvailablePlugins,
+	logger log.Logger) {
+
+	httpPlugins := internalPlugins.HTTPPlugins()
+	if _, ok := httpPlugins[pluginID]; ok {
+		logger.Panicf(pluginConflictMessage, pluginType, pluginID)
+	}
+	tcpPlugins := internalPlugins.TCPPlugins()
+	if _, ok := tcpPlugins[pluginID]; ok {
+		logger.Panicf(pluginConflictMessage, pluginType, pluginID)
+	}
+}
+
 // AllAvailablePluginsWithOptions returns the full list of internal and external
 // plugins available to the broker using explicitly-defined lookup functions.
 func AllAvailablePluginsWithOptions(
@@ -49,52 +69,42 @@ func AllAvailablePluginsWithOptions(
 	logger log.Logger,
 ) (plugin.AvailablePlugins, error) {
 
+	allHTTPPlugins := map[string]http.Plugin{}
+	allTCPPlugins := map[string]tcp.Plugin{}
+
+	// Assemble internal plugins. Plugin IDs for internal plugins are
+	// assumed to be unique because their definitions are hardcoded.
 	internalPlugins, err := InternalPlugins(internalLookupFunc)
 	if err != nil {
 		return nil, err
 	}
+	for pluginID, httpPlugin := range internalPlugins.HTTPPlugins() {
+		allHTTPPlugins[pluginID] = httpPlugin
+	}
+	for pluginID, tcpPlugin := range internalPlugins.TCPPlugins() {
+		allTCPPlugins[pluginID] = tcpPlugin
+	}
 
+	// Assemble external plugins. Check whether the plugin ID for each
+	// external plugin conflicts with any plugin IDs of internal plugins.
+	// (Checks for uniqueness among external HTTP and TCP plugins is
+	// done elsewhere, i.e. as external plugins are discovered.)
 	externalPlugins, err := externalLookupfunc(pluginDir, checksumsFile, logger)
 	if err != nil {
 		return nil, err
 	}
-
-	httpPlugins := map[string]http.Plugin{}
-
-	for name, httpPlugin := range internalPlugins.HTTPPlugins() {
-		if _, ok := httpPlugins[name]; ok {
-			// TODO: Should this ever happen?  Do we need this check?  Should it panic?
-			logger.Warnf("Internal plugin '%s' replaced by internal plugin", name)
-		}
-		httpPlugins[name] = httpPlugin
+	for pluginID, httpPlugin := range externalPlugins.HTTPPlugins() {
+		checkPluginIDConflicts("HTTP", pluginID, internalPlugins, logger)
+		allHTTPPlugins[pluginID] = httpPlugin
 	}
-
-	for name, httpPlugin := range externalPlugins.HTTPPlugins() {
-		if _, ok := httpPlugins[name]; ok {
-			logger.Warnf("Internal plugin '%s' replaced by external plugin", name)
-		}
-		httpPlugins[name] = httpPlugin
-	}
-
-	tcpPlugins := map[string]tcp.Plugin{}
-
-	for name, tcpPlugin := range internalPlugins.TCPPlugins() {
-		if _, ok := tcpPlugins[name]; ok {
-			logger.Warnf("Internal plugin '%s' replaced by internal plugin", name)
-		}
-		tcpPlugins[name] = tcpPlugin
-	}
-
-	for name, tcpPlugin := range externalPlugins.TCPPlugins() {
-		if _, ok := tcpPlugins[name]; ok {
-			logger.Warnf("Internal plugin '%s' replaced by external plugin", name)
-		}
-		tcpPlugins[name] = tcpPlugin
+	for pluginID, tcpPlugin := range externalPlugins.TCPPlugins() {
+		checkPluginIDConflicts("TCP", pluginID, internalPlugins, logger)
+		allTCPPlugins[pluginID] = tcpPlugin
 	}
 
 	return &Plugins{
-		HTTPPluginsByID: httpPlugins,
-		TCPPluginsByID:  tcpPlugins,
+		HTTPPluginsByID: allHTTPPlugins,
+		TCPPluginsByID:  allTCPPlugins,
 	}, nil
 }
 

--- a/pkg/secretless/plugin/sharedobj/external_plugins_test.go
+++ b/pkg/secretless/plugin/sharedobj/external_plugins_test.go
@@ -1,0 +1,155 @@
+package sharedobj
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/pkg/secretless/log"
+	loggerMock "github.com/cyberark/secretless-broker/pkg/secretless/log/mock"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/sharedobj/mock"
+)
+
+func TestParsePluginMetadata(t *testing.T) {
+	t.Run("Correctly parses plugin metadata", func(t *testing.T) {
+		// Set up for test
+		rawPlugin := mock.RawPlugins["http1"]
+		rawPluginName := "mock_plugin"
+
+		// Run test
+		pluginType, pluginID, err := parsePluginMetadata(rawPlugin, rawPluginName)
+
+		// Check results
+		expType := "connector.http"
+		expID := "extHTTP1"
+
+		assert.NoError(t, err)
+		if err != nil {
+			return
+		}
+		assert.Equal(t, expType, pluginType)
+		assert.Equal(t, expID, pluginID)
+	})
+}
+
+// directoryPluginLookup implements an external DirectoryPluginLookupFunc
+// for testing.
+func directoryPluginLookup(mockPlugins map[string]mock.RawPlugin) DirectoryPluginLookupFunc {
+	return func(
+		pluginDir string,
+		checksumfile string,
+		logger log.Logger,
+	) (map[string]rawPlugin, error) {
+		rawPlugins := map[string]rawPlugin{}
+		for name, plugin := range mockPlugins {
+			rawPlugins[name] = plugin
+		}
+		return rawPlugins, nil
+	}
+}
+
+func TestExternalPlugins(t *testing.T) {
+	t.Run("Assembles external plugins", func(t *testing.T) {
+		externalPlugins, err := ExternalPluginsWithOptions(
+			"",
+			"",
+			directoryPluginLookup(mock.RawPlugins),
+			mock.NewLogger(),
+		)
+		assert.NoError(t, err)
+		if err != nil {
+			return
+		}
+
+		expExternalPlugins := mock.ExternalPlugins()
+		assert.EqualValues(t, expExternalPlugins.HTTPPlugins(), externalPlugins.HTTPPlugins())
+		assert.EqualValues(t, expExternalPlugins.TCPPlugins(), externalPlugins.TCPPlugins())
+	})
+
+	// Test detection of conflicting external plugin names.
+	TestCases := []struct {
+		description   string
+		addPluginName string
+		addPluginType string // "connector.http" or "connector.tcp"
+		addPluginID   string
+		expectPanic   bool
+	}{
+		{
+			description: "There are no panics without duplicate plugin names",
+		},
+		{
+			description:   "Two external HTTP plugins use same plugin ID",
+			addPluginName: "new_http_plugin",
+			addPluginType: "connector.http",
+			addPluginID:   "extHTTP1",
+			expectPanic:   true,
+		},
+		{
+			description:   "Two external TCP plugins use same plugin ID",
+			addPluginName: "new_tcp_plugin",
+			addPluginType: "connector.tcp",
+			addPluginID:   "extTCP2",
+			expectPanic:   true,
+		},
+		{
+			description:   "An HTTP and a TCP external plugin use same plugin ID",
+			addPluginName: "new_tcp_plugin",
+			addPluginType: "connector.tcp",
+			addPluginID:   "extHTTP2",
+			expectPanic:   true,
+		},
+	}
+
+	for _, tc := range TestCases {
+		t.Run(tc.description, func(t *testing.T) {
+			// Set up baseline test plugins
+			testPlugins := map[string]mock.RawPlugin{}
+			for name, rawPlugin := range mock.RawPlugins {
+				testPlugins[name] = rawPlugin
+			}
+			expHTTPPlugins := mock.HTTPExternalPluginsByID()
+			expTCPPlugins := mock.TCPExternalPluginsByID()
+
+			// Add external plugin for this test case, if necessary
+			if tc.addPluginName != "" {
+				testPlugins[tc.addPluginName] = mock.RawPlugin{
+					PluginAPIVersion: "0.1.0",
+					PluginType:       tc.addPluginType,
+					PluginID:         tc.addPluginID,
+				}
+				switch tc.addPluginType {
+				case "connector.http":
+					expHTTPPlugins[tc.addPluginName] = mock.NewHTTPPlugin(tc.addPluginID)
+				case "connector.tcp":
+					expTCPPlugins[tc.addPluginName] = mock.NewTCPPlugin(tc.addPluginID)
+				}
+			}
+
+			// Run the test subject
+			mockLogger := loggerMock.NewLogger()
+			availablePlugins, err := ExternalPluginsWithOptions(
+				"",
+				"",
+				directoryPluginLookup(testPlugins),
+				mockLogger,
+			)
+
+			// Check test results
+			if tc.expectPanic {
+				expectedPanic := "conflicts with external plugin"
+				panic := mockLogger.Panics[0]
+				assert.Contains(t, panic, expectedPanic)
+			} else {
+				assert.NoError(t, err)
+				if err != nil {
+					return
+				}
+				// Confirm expected HTTP plugins have been discovered
+				assert.Equal(t, expHTTPPlugins, availablePlugins.HTTPPlugins())
+
+				// Confirm expected TCP plugins have been discovered
+				assert.Equal(t, expTCPPlugins, availablePlugins.TCPPlugins())
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Currently, an external http or tcp connector plugin is allowed to replace an
internal connector plugin that has the same plugin ID.

This change removes this capability, and forces all external plugins to
use plugin IDs that are unique among all other plugin IDs.
If there is a plugin ID conflict between an external plugin and any other
plugin, then a panic occurs.

Note that there is no need to check for duplicate plugin IDs among `internal`
plugins at run time because these plugins are
hardcoded,  so that the only way that duplicate plugin IDs could occur is if the
same ID  was used twice erroneously.

The checks for uniqueness of external plugin IDs is done in 2 places:

- Right after the external plugin file content is read in and parsed. Here, each external plugin ID is compared against all other external plugins (either HTTP or TCP) that have been loaded so far.
- When available plugins are assembled. Here, each external plugin ID is compared against all internal plugin IDs (either HTTP or TCP). 

This change also adds UT for the external_plugins.go file (which was previously
non-existent), and adds some mocks for parsing go plugins.

This change also adds history to the Secretless mock logger for log calls
for errors, warns, and panics. This will allow unit tests to check that the
appropriate errors, warnings, or panics are being logged for each test
case. History is maintained as a slice of strings for each log type
(errors/warn/panic).

#### What ticket does this PR close?
Addresses Issue #1085

#### Where should the reviewer start?

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
