### PR TITLE
WIP: Automate notices file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,6 @@ docker-compose.yml
 
 # We don't want Docker cache to break on Jenkinsfile changes
 Jenkinsfile
+
+# Ignore temp files directory (e.g. licenses)
+tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ results.json
 # Ignore test coverage files
 c.out
 coverage.xml
+
+# Ignore temp files directory (e.g. licenses)
+tmp/

--- a/assets/NOTICES.tmpl
+++ b/assets/NOTICES.tmpl
@@ -1,0 +1,19 @@
+============================ TABLE OF CONTENTS =============================
+
+The following is a listing of the Secretless Broker open source components detailed
+in this document. This list is provided for your convenience; please read
+further if you wish to review the copyright notice(s) and the full text
+of the license associated with each component.
+
+{{ range .Modules }}
+  {{ .Name }} - {{ .LicenseType -}}
+{{ end }}
+{{ range .Modules }}
+
+
+========== START '{{ .Name }}' LICENSE ==========
+
+{{ .LicenseContent }}
+
+========== END '{{ .Name }}' LICENSE ==========
+{{ end }}

--- a/bin/Dockerfile.notices
+++ b/bin/Dockerfile.notices
@@ -1,0 +1,8 @@
+FROM golang:1.13
+
+WORKDIR /secretless
+
+RUN apt-get update && \
+    apt-get install -y mercurial
+
+RUN go get github.com/google/go-licenses

--- a/bin/build_notices_file
+++ b/bin/build_notices_file
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+
+current_dir=$("$(dirname "$0")"/abspath)
+toplevel_dir=$current_dir/..
+
+PROJECT_NAME="secretless"
+MAIN_PKG="$PROJECT_NAME/cmd/secretless-broker"
+OUTPUT_DIR="tmp/licenses"
+
+echo "Building the go-licenses image..."
+docker build -f $toplevel_dir/bin/Dockerfile.notices \
+             -t secretless-broker-notices-updater \
+             $toplevel_dir
+
+echo "Cleaning up the output folder..."
+rm -rf $OUTPUT_DIR
+
+echo "Running the license checker container..."
+docker run --rm \
+  -v "$toplevel_dir":"/$PROJECT_NAME" \
+  secretless-broker-notices-updater \
+  /bin/bash -ec "
+    echo \"Finding license files (this may take a while)...\"
+    go-licenses save \
+                --save_path=/$PROJECT_NAME/$OUTPUT_DIR \
+                /$MAIN_PKG
+
+    # We need to make sure this folder can be deleted on host
+    chmod -R 777 /$PROJECT_NAME/$OUTPUT_DIR
+
+    echo \"Finding license types (this may take a while)...\"
+    go-licenses csv /$MAIN_PKG > $OUTPUT_DIR/packages.txt
+
+    echo \"Generating new NOTICES file...\"
+    go run bin/combine_licenses.go $OUTPUT_DIR
+
+    echo \"Cleaning up...\"
+    rm -rf $OUTPUT_DIR
+
+    echo \"Completed generating NOTICES file!\"
+  "

--- a/bin/combine_licenses.go
+++ b/bin/combine_licenses.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"html/template"
+	"io/ioutil"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var ModuleListFilename = "packages.txt"
+var NoticesPath = "NOTICES.txt"
+var NoticesTemplatePath = "assets/NOTICES.tmpl"
+
+type Module struct {
+	Name           string
+	LicenseType    string
+	LicenseContent string
+}
+
+type ModuleData struct {
+	Modules []Module
+}
+
+func findLicenses(targetDir string, debug bool) (map[string]string, error) {
+	licenseFileRegex, _ := regexp.Compile("LICENSE.*")
+	licenseFileMap := map[string]string{}
+
+	err := filepath.Walk(targetDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Printf("Failure accessing a path %q: %v", path, err)
+			return err
+		}
+
+		// Skip directories
+		if info.IsDir() {
+			return nil
+		}
+
+		// Skip things that aren't license files
+		if !licenseFileRegex.MatchString(info.Name()) {
+			return nil
+		}
+
+		if debug {
+			log.Printf("Found: %q", path)
+		}
+
+		// Turn full path into a module name
+		moduleName := strings.TrimPrefix(path, targetDir+"/")
+		moduleName = strings.TrimSuffix(moduleName, "/"+info.Name())
+
+		licenseContent, err := ioutil.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		licenseFileMap[moduleName] = string(licenseContent)
+
+		return nil
+	})
+
+	return licenseFileMap, err
+}
+
+func getModules(moduleListPath string, debug bool) ([]Module, error) {
+	moduleRawData, err := ioutil.ReadFile(moduleListPath)
+	if err != nil {
+		return nil, err
+	}
+
+	moduleData := string(moduleRawData)
+	moduleInfoLines := strings.Split(moduleData, "\n")
+
+	modules := []Module{}
+	for _, moduleInfoLine := range moduleInfoLines {
+		if debug {
+			log.Println(moduleInfoLine)
+		}
+
+		splitModulesInfoLine := strings.Split(moduleInfoLine, ",")
+
+		if len(splitModulesInfoLine) < 3 {
+			log.Printf("WARN: Found unparseable line: '%s'", moduleInfoLine)
+			continue
+		}
+		moduleName, licenseType := splitModulesInfoLine[0], splitModulesInfoLine[2]
+
+		module := Module{
+			LicenseType: licenseType,
+			Name:        moduleName,
+		}
+
+		modules = append(modules, module)
+	}
+
+	// Sort the output
+	sort.Slice(modules[:], func(i, j int) bool {
+		return modules[i].Name < modules[j].Name
+	})
+
+	return modules, nil
+}
+
+func main() {
+	targetDir := os.Args[1]
+	log.Printf("Combining licenses in '%s'...", targetDir)
+
+	// Get a list of modules and their generic license names
+	moduleListPath := path.Join(targetDir, ModuleListFilename)
+	modules, err := getModules(moduleListPath, false)
+	if err != nil {
+		log.Printf(
+			"Error reading package list file '%s': %v",
+			moduleListPath,
+			err,
+		)
+		os.Exit(1)
+	}
+
+	// Initialize our template data object
+	moduleData := ModuleData{
+		Modules: modules,
+	}
+
+	// Collect all license files
+	licenseFiles, err := findLicenses(targetDir, false)
+	if err != nil {
+		log.Printf("Error walking the path %q: %v", targetDir, err)
+		os.Exit(1)
+	}
+	log.Printf("Found %d license files", len(licenseFiles))
+
+	// Append license texts to our module objects
+	for index, module := range moduleData.Modules {
+		if _, ok := licenseFiles[module.Name]; !ok {
+			log.Printf("WARN! Could not find license for module '%s'!", module.Name)
+		}
+
+		moduleData.Modules[index].LicenseContent = licenseFiles[module.Name]
+	}
+
+	// Open the NOTICES file
+	log.Printf("Opening '%s'...", NoticesPath)
+	noticesFile, err := os.Create(NoticesPath)
+	if err != nil {
+		log.Printf("Error creating %s: %v", NoticesPath, err)
+		os.Exit(1)
+	}
+	defer noticesFile.Close()
+
+	// Generate and write the license data to it
+	log.Printf("Generating '%s' file from template '%s'...", NoticesPath, NoticesTemplatePath)
+	tmpl := template.Must(template.ParseFiles(NoticesTemplatePath))
+	err = tmpl.Execute(noticesFile, moduleData)
+	if err != nil {
+		log.Printf("Error running template '%s': %v", NoticesTemplatePath, err)
+		os.Exit(1)
+	}
+
+	log.Println("Done!")
+}


### PR DESCRIPTION
Adds automatic generation capability of NOTICES file

#### What ticket does this PR close?
Connected to https://github.com/cyberark/community/issues/15

#### Where should the reviewer start?

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
