### PR TITLE
Add SDK to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,26 @@ Secretless Broker is currently licensed under [ASL 2.0](#license)
 
 ## Currently supported services
 
+Secretless supports several target services out of the box, and these include:
+
 - MySQL (Socket and TCP)
 - PostgreSQL (Socket and TCP)
 - SSH / SSH-Agent (Beta)
 - HTTP with Basic auth, Conjur, and AWS authorization strategies (Beta)
 
-With many others in the planning stages!
+Support for these services is provided via internal plugins (also referred to as "Service Connectors") that are part of the
+Secretless binary distribution.
 
-If there is a specific target service that you would like to be included in this project, please open a [GitHub issue](https://github.com/cyberark/secretless-broker/issues) with your request.
+If you want to use Secretless with a target service that is not currently supported, you can use the [Secretless Plugin
+Interface](pkg/secretless/plugin) to create [Connector Plugins](pkg/secretless/plugin/connector) to extend Secretless to
+support virtually any target service. These external plugins can be integrated in environments using a standard Secretless
+Broker implementation.
+
+For more information on building a Secretless Connector Plugin please see our [documentation](https://docs.secretless.io/Latest/en/Content/References/Secretless%20Plugin%20Interface/Secretless_Plugin_Interface_Intro.htm), which will walk
+you through creating a new Connector Plugin using our templates.
+
+Are we missing an internal service connector that you think is important? Are you curious if anyone else has thought of
+building the service connector you're interested in? Please open a [GitHub issue](https://github.com/cyberark/secretless-broker/issues) with more information on the connector you'd like to create, and start the conversation.
 
 For specific guidelines about using a particular service, please see our [documentation](https://docs.secretless.io/Latest/en/Content/References/connectors/overview.htm).
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For more information on building a Secretless Connector Plugin please see our [d
 which will walk you through creating a new Connector Plugin using our templates.
 
 Are we missing an internal service connector that you think is important? Are you curious if anyone else has thought of
-building the service connector you're interested in? Please open a [GitHub issue](https://github.com/cyberark/secretless-broker/issues) with more information on the connector you'd like to create, and start the conversation.
+building the service connector you're interested in? Please open a [GitHub issue](https://github.com/cyberark/secretless-broker/issues) with more information on the connector you'd like, and start the conversation.
 
 For specific guidelines about using a particular service, please see our [documentation](https://docs.secretless.io/Latest/en/Content/References/connectors/overview.htm).
 

--- a/README.md
+++ b/README.md
@@ -53,16 +53,16 @@ Secretless supports several target services out of the box, and these include:
 - SSH / SSH-Agent (Beta)
 - HTTP with Basic auth, Conjur, and AWS authorization strategies (Beta)
 
-Support for these services is provided via internal plugins (also referred to as "Service Connectors") that are part of the
-Secretless binary distribution.
+Support for these services is provided via internal plugins (also referred to as "Service Connectors") that are part
+of the Secretless binary distribution.
 
 If you want to use Secretless with a target service that is not currently supported, you can use the [Secretless Plugin
-Interface](pkg/secretless/plugin) to create [Connector Plugins](pkg/secretless/plugin/connector) to extend Secretless to
-support virtually any target service. These external plugins can be integrated in environments using a standard Secretless
-Broker implementation.
+Interface](pkg/secretless/plugin) to create [Connector Plugins](pkg/secretless/plugin/connector) to extend Secretless
+to support virtually any target service. These external plugins can be integrated in environments using a standard
+Secretless Broker implementation.
 
-For more information on building a Secretless Connector Plugin please see our [documentation](https://docs.secretless.io/Latest/en/Content/References/Secretless%20Plugin%20Interface/Secretless_Plugin_Interface_Intro.htm), which will walk
-you through creating a new Connector Plugin using our templates.
+For more information on building a Secretless Connector Plugin please see our [documentation](https://docs.secretless.io/Latest/en/Content/References/Secretless%20Plugin%20Interface/Secretless_Plugin_Interface_Intro.htm),
+which will walk you through creating a new Connector Plugin using our templates.
 
 Are we missing an internal service connector that you think is important? Are you curious if anyone else has thought of
 building the service connector you're interested in? Please open a [GitHub issue](https://github.com/cyberark/secretless-broker/issues) with more information on the connector you'd like to create, and start the conversation.


### PR DESCRIPTION
In the "currently supported services" section, add a reference to our SDK
so that it's clear it's possible (and easy!) to add support for a new service.

Connected to #1096 