### PR TITLE
Bump version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.0] 2020-01-29
+
+### Added
+- Added option to specify MSSQL edition in tests (#1093)
+- Added debug image that can be used with a debugger like delve (#1056)
+- Added template READMEs to connector templates (#1020)
+
+### Changed
+- Updated release instructions (#1080)
+- Improved MSSQL connector tests (#1107, #1089, #1098)
+- Improved handling of `io.EOF` errors on TCP `proxy_service`
+- Conjur authn-k8s client version bumped to v0.16.0
+- Added links to SDK docs in README (#1104)
+- Ensure external connector plugins will not override built-in connectors (#1085)
+- MSSQL connector moved to beta
+
+### Fixed
+- Updated pg connector to better validate packet length (#1095)
+- MSSQL connector faithfully propagates login response (#1106)
+- MSSQL connector faithfully propagates login request (#1107)
+
 ## [1.4.2] 2020-01-08
 
 ### Added
@@ -419,7 +440,7 @@ external plugins
 
 The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.4.2...HEAD
+[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.5.0...HEAD
 [0.2.0]: https://github.com/cyberark/secretless-broker/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/cyberark/secretless-broker/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/cyberark/secretless-broker/compare/v0.3.0...v0.4.0
@@ -441,3 +462,4 @@ The first tagged version.
 [1.4.0]: https://github.com/cyberark/secretless-broker/compare/v1.3.0...v1.4.0 
 [1.4.1]: https://github.com/cyberark/secretless-broker/compare/v1.4.0...v1.4.1 
 [1.4.2]: https://github.com/cyberark/secretless-broker/compare/v1.4.1...v1.4.2 
+[1.5.0]: https://github.com/cyberark/secretless-broker/compare/v1.4.2...v1.5.0 

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -13,7 +13,7 @@ SECTION 1: Apache License 2.0
 >>> github.com/containerd/containerd-1.3.2
 >>> github.com/CrunchyData/crunchy-proxy-0.0.0-20170717145745-c0da73ca9dde
 >>> github.com/cyberark/conjur-api-go-0.5.2
->>> github.com/cyberark/conjur-authn-k8s-client-0.15.0
+>>> github.com/cyberark/conjur-authn-k8s-client-0.16.0
 >>> github.com/docker/distribution-2.7.1
 >>> github.com/docker/docker-1.4.2-0.20191231165639-e6f6c35b7902
 >>> github.com/docker/go-connections-0.4.0
@@ -21,11 +21,9 @@ SECTION 1: Apache License 2.0
 >>> github.com/google/btree-1.0.0
 >>> github.com/googleapis/gnostic-0.3.1
 >>> github.com/heptiolabs/healthcheck-0.0.0-20180807145615-6ff867650f40
->>> github.com/modern-go/reflect2-1.0.1
 >>> github.com/opencontainers/go-digest-1.0.0-rc1
 >>> github.com/opencontainers/image-spec-1.0.1
 >>> github.com/prometheus/client_golang-1.2.1
->>> google.golang.org/appengine-1.4.0
 >>> gopkg.in/yaml.v2-2.2.2
 >>> k8s.io/api-0.0.0-20180712090710-2d6f90ab1293
 >>> k8s.io/apiextensions-apiserver-0.0.0-20180808065829-408db4a50408
@@ -164,9 +162,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
->>> github.com/cyberark/conjur-authn-k8s-client-0.15.0
+>>> github.com/cyberark/conjur-authn-k8s-client-0.16.0
 
-Copyright (c) 2019 CyberArk Software Ltd. All rights reserved.
+Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -300,23 +298,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
->>> github.com/modern-go/reflect2-1.0.1
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-
 >>> github.com/opencontainers/go-digest-1.0.0-rc1
 
 Copyright 2016 Docker, Inc.
@@ -360,23 +341,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-
->>> google.golang.org/appengine-1.4.0
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/assets/license_finder.txt
+++ b/assets/license_finder.txt
@@ -6,7 +6,7 @@ github.com/cenkalti/backoff, v2.2.1+incompatible, unknown
 github.com/codegangsta/cli, v1.20.0, unknown
 github.com/containerd/containerd, v1.3.2, unknown
 github.com/cyberark/conjur-api-go, v0.5.2, unknown
-github.com/cyberark/conjur-authn-k8s-client, v0.15.0, unknown
+github.com/cyberark/conjur-authn-k8s-client, v0.16.0, unknown
 github.com/cyberark/summon, v0.7.0, unknown
 github.com/denisenkom/go-mssqldb, v0.0.0-20191001013358-cfbb681360f0, unknown
 github.com/docker/distribution, v2.7.1+incompatible, unknown
@@ -24,7 +24,6 @@ github.com/imdario/mergo, v0.3.8, unknown
 github.com/joho/godotenv, v1.2.0, unknown
 github.com/json-iterator/go, v1.1.8, unknown
 github.com/lib/pq, v0.0.0-20180123210206-19c8e9ad0095, unknown
-github.com/modern-go/reflect2, v1.0.1, unknown
 github.com/opencontainers/go-digest, v1.0.0-rc1, unknown
 github.com/opencontainers/image-spec, v1.0.1, unknown
 github.com/pkg/errors, v0.8.1, unknown
@@ -34,7 +33,6 @@ github.com/smartystreets/goconvey, v0.0.0-20190731233626-505e41936337, unknown
 github.com/spf13/pflag, v1.0.5, unknown
 github.com/stretchr/testify, v1.3.0, unknown
 golang.org/x/crypto, v0.0.0-20190510104115-cbcb75029529, unknown
-google.golang.org/appengine, v1.4.0, unknown
 gopkg.in/yaml.v2, v2.2.2, unknown
 k8s.io/api, v0.0.0-20180712090710-2d6f90ab1293, unknown
 k8s.io/apiextensions-apiserver, v0.0.0-20180808065829-408db4a50408, unknown

--- a/internal/plugin/connectors/tcp/mssql/README.md
+++ b/internal/plugin/connectors/tcp/mssql/README.md
@@ -1,6 +1,6 @@
 # MSSQL Server Connector
 
-**NOTE: This connector is still in alpha and should not be used in production.**
+**NOTE: This connector is in beta.**
 
 The MSSQL Server Connector enables:
 
@@ -46,7 +46,7 @@ All credentials are required unless they're explicitly marked as "optional".
 
 ## Target Service SSL Support
 
-SSL is currently not supported in the alpha version, but will be coming soon.
+SSL is currently not supported in the beta version, but will be coming soon.
 
 ## Supported versions
 

--- a/pkg/secretless/version.go
+++ b/pkg/secretless/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the broker
-var Version = "1.4.2"
+var Version = "1.5.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
- Bumps the version to 1.5.0
- Updates the NOTICES
- Removes the **alpha** from the MSSQL README

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [x] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [x] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
