### PR TITLE
WIP: Juxtaposer start script does not error on tmp/juxtaposer_deployment.yml

### DIFF
--- a/bin/juxtaposer/deploy/deploy_app
+++ b/bin/juxtaposer/deploy/deploy_app
@@ -8,6 +8,7 @@ CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 AUTHENTICATOR_ID_ENCODED="$(python3 -c "import urllib.parse; print(urllib.parse.quote(input(),safe=''))" <<< "$AUTHENTICATOR_ID")"
 echo "${AUTHENTICATOR_ID_ENCODED}"
 
+mkdir -p "$CURRENT_DIR/tmp"
 sed -e "s#\${APP_NAME}#$APP_NAME#g" \
     -e "s#\${APP_SERVICE_ACCOUNT}#$APP_SERVICE_ACCOUNT#g" \
     -e "s#\${APP_NAMESPACE}#$TEST_APP_NAMESPACE_NAME#g" \


### PR DESCRIPTION
WIP: I haven't tested this out yet... I'm waiting for the current 4-day
juxtaposer testing on OpenShift to complete first, so that I don't
accidentally kill that running test!

#### What does this PR do (include background context, if relevant)?
Currently, if the `bin/juxtaposer/deploy/start` script is run, e.g.
to deploy on OpenShift, the script errors out with a file error trying
to open `deploy/tmp/juxtaposer_deployment.yml`, unless the directory
`deploy/tmp` is manually created beforehand.

This change adds the creation of the `deploy/tmp` dir to the script
before the juxtaposer_deployment.yml is rendered.

#### What ticket does this PR close?

#### Where should the reviewer start?

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
