### PR TITLE
Add mssql DB backend to Juxtaposer

### DIFF
--- a/bin/juxtaposer/README.md
+++ b/bin/juxtaposer/README.md
@@ -11,10 +11,12 @@ alongside Secretless to compare the following scenarios:
 
 | Backend       | Baseline          | Compare With                       | Connection Type |
 | ---           |---                | ---                                |---              |
+| MSSQL         | Direct connection | Secretless (persistent connection) | TCP port        |
 | MySQL         | Direct connection | Secretless (persistent connection) | Unix socket     |
 | MySQL         | Direct connection | Secretless (persistent connection) | TCP port        |
 | Postgres      | Direct connection | Secretless (persistent connection) | Unix socket     |
 | Postgres      | Direct connection | Secretless (persistent connection) | TCP port        |
+| MSSQL         | Direct connection | Secretless (recreated connection)  | TCP port        |
 | MySQL         | Direct connection | Secretless (recreated connection)  | Unix socket     |
 | MySQL         | Direct connection | Secretless (recreated connection)  | TCP port        |
 | Postgres      | Direct connection | Secretless (recreated connection)  | Unix socket     |
@@ -80,6 +82,17 @@ docker run --name mysql-test-db \
            mysql:5
 ```
 
+#### MSSQL
+
+```
+docker run --name mssql-test-db \
+           -p 1434:1433 \
+           -e ACCEPT_EULA=Y \
+           -e SA_PASSWORD="MYp4ssword1" \
+           -d \
+           mcr.microsoft.com/mssql/server:2017-latest
+```
+
 ### Run Secretless Broker
 
 _Note: This step is optional but it is required for this specific example since it tests the broker's
@@ -113,6 +126,15 @@ services:
       host: 127.0.0.1
       port: 5433
       sslmode: disable
+
+  mssql-tcp:
+    connector: mssql
+    listenOn: tcp://0.0.0.0:1433
+    credentials:
+      username: sa
+      password: MYp4ssword1
+      host: 127.0.0.1
+      port: 1434
 ```
 
   </p>
@@ -137,12 +159,14 @@ database backend you want to test:
     
 ```yaml
 ---
+#driver: mssql
 #driver: mysql-5.7
 driver: postgres
 
 comparison:
   baselineBackend: pg_direct
 #  baselineBackend: mysql_direct
+#  baselineBackend: mssql_direct
 #  recreateConnections: true
 #  sqlStatementType: select
 #  rounds: 1000
@@ -179,6 +203,17 @@ backends:
     password: mypassword
     sslmode: disable
     debug: false
+    ignore: true
+
+  mssql_secretless:
+    host: 127.0.0.1
+    ignore: true
+
+  mssql_direct:
+    host: 127.0.0.1
+    port: 1434
+    username: sa
+    password: MYp4ssword1
     ignore: true
 ```
 
@@ -321,6 +356,7 @@ backends:
 
 ## Supported Drivers:
 
+- `mssql`
 - `mysql-5.7`
 - `postgres`
 

--- a/bin/juxtaposer/deploy/juxtaposer_deployment_template.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_deployment_template.yml
@@ -58,7 +58,9 @@ spec:
         imagePullPolicy: Always
         args: ["-f", "/etc/secretless/secretless.yml"]
         ports:
-        - containerPort: 5432
+        - containerPort: 15432   # for PostgreSQL TCP
+        - containerPort: 13306   # for MySQL TCP
+        - containerPort: 11433   # for MSSQL TCP
         livenessProbe:
           httpGet:
             path: /live

--- a/bin/juxtaposer/deploy/juxtaposer_mssql.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_mssql.yml
@@ -1,0 +1,27 @@
+---
+driver: mysql-5.7
+
+comparison:
+  baselineBackend: mssql_direct
+#  recreateConnections: true
+  rounds: 10000
+  threads: 1
+  silent: false
+
+formatters:
+  json:
+    outputFile: ./results.json
+  stdout:
+
+backends:
+  mssql_direct:
+    host: REPLACEME
+    port: 1433
+    username: REPLACEME
+    password: REPLACEME
+    database: secretless_xa
+
+  mssql_secretless_tcp:
+    host: 127.0.0.1
+    port: 11433
+    database: secretless

--- a/bin/juxtaposer/deploy/secretless.yml
+++ b/bin/juxtaposer/deploy/secretless.yml
@@ -68,3 +68,20 @@ services:
       port:
         from: conjur
         get: conjur/xa-secretless-db/postgresql/port
+
+  mssql-tcp:
+    connector: mssql
+    listenOn: tcp://0.0.0.0:11433
+    credentials:
+      username:
+        from: conjur
+        get: conjur/xa-secretless-db/mssql/username
+      password:
+        from: conjur
+        get: conjur/xa-secretless-db/mssql/password
+      host:
+        from: conjur
+        get: conjur/xa-secretless-db/mssql/hostname
+      port:
+        from: conjur
+        get: conjur/xa-secretless-db/mssql/port

--- a/bin/juxtaposer/go.mod
+++ b/bin/juxtaposer/go.mod
@@ -3,6 +3,7 @@ module github.com/cyberark/secretless-broker/bin/juxtaposer
 go 1.12
 
 require (
+	github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73
 	github.com/go-sql-driver/mysql v1.4.1
 	github.com/lib/pq v1.1.1
 	github.com/stretchr/testify v1.3.0

--- a/bin/juxtaposer/go.sum
+++ b/bin/juxtaposer/go.sum
@@ -1,7 +1,11 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73 h1:OGNva6WhsKst5OZf7eZOklDztV3hwtTHovdrLHV+MsA=
+github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/lib/pq v1.1.1 h1:sJZmqHoEaY7f+NPP8pgLB/WxulyR3fewgCM2qaSlBb4=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -9,6 +13,9 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0FNOmBrHfq7vN4btdGoDZgI=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae h1:ehhBuCxzgQEGk38YjhFv/97fMIc2JGHZAhAWMmEjmu0=

--- a/bin/juxtaposer/juxtaposer.yml
+++ b/bin/juxtaposer/juxtaposer.yml
@@ -1,10 +1,12 @@
 ---
 #driver: mysql-5.7
 driver: postgres
+#driver: mssql
 
 comparison:
   baselineBackend: pg_direct
 #  baselineBackend: mysql_direct
+#  baselineBackend: mssql_direct
 #  recreateConnections: true
 #  sqlStatementType: select
 #  rounds: 1000
@@ -40,5 +42,18 @@ backends:
     username: myuser
     password: mypassword
     sslmode: disable
+    debug: false
+    ignore: true
+
+  mssql_secretless:
+    host: 127.0.0.1
+    port: 2433
+    ignore: true
+
+  mssql_direct:
+    host: 127.0.0.1
+    port: 1433
+    username: sa
+    password: MYp4ssword1
     debug: false
     ignore: true

--- a/bin/juxtaposer/tester/db/db.go
+++ b/bin/juxtaposer/tester/db/db.go
@@ -36,12 +36,12 @@ const CreateTableStatement = `
     id           INTEGER,
     birth_date   DATE,
     result       DECIMAL,
-    passed       BOOLEAN
+    passed       BIT
 `
 
 var QueryTypes = map[string]string{
 	"dropTable": fmt.Sprintf("DROP TABLE IF EXISTS %s;", DefaultTableName),
-	"createTable": fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (%s);",
+	"createTable": fmt.Sprintf("CREATE TABLE %s (%s);",
 		DefaultTableName,
 		CreateTableStatement),
 	"insertItem": fmt.Sprintf(`INSERT INTO %s (name, id, birth_date, result, passed)
@@ -80,7 +80,8 @@ func (manager *DriverManager) ensureWantedDbDataState() error {
 			itemIndex,
 			time.Now().AddDate(0, 0, itemIndex),
 			float32(itemIndex)*10,
-			rand.Int31()&(1<<30) == 0)
+			rand.Int31()&0x1,
+		)
 
 		if err != nil {
 			log.Printf("ERROR! Could not insert canned values into DB!")

--- a/bin/juxtaposer/tester/db/db.go
+++ b/bin/juxtaposer/tester/db/db.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cyberark/secretless-broker/bin/juxtaposer/tester/api"
+	mssql "github.com/cyberark/secretless-broker/bin/juxtaposer/tester/db/mssql"
 	mysql "github.com/cyberark/secretless-broker/bin/juxtaposer/tester/db/mysql"
 	postgres "github.com/cyberark/secretless-broker/bin/juxtaposer/tester/db/postgres"
 	"github.com/cyberark/secretless-broker/bin/juxtaposer/timing"
@@ -21,6 +22,7 @@ type DriverManager struct {
 }
 
 var DbTesterImplementatons = map[string]func() (api.DbTester, error){
+	"mssql":     mssql.NewTester,
 	"mysql-5.7": mysql.NewTester,
 	"postgres":  postgres.NewTester,
 }

--- a/bin/juxtaposer/tester/db/mssql/mssql.go
+++ b/bin/juxtaposer/tester/db/mssql/mssql.go
@@ -1,0 +1,102 @@
+package mssql
+
+import (
+	"database/sql"
+	"fmt"
+	"log"
+	"net/url"
+	"strings"
+
+	_ "github.com/denisenkom/go-mssqldb"
+
+	"github.com/cyberark/secretless-broker/bin/juxtaposer/tester/api"
+	sql_db_tester "github.com/cyberark/secretless-broker/bin/juxtaposer/tester/db/sql"
+)
+
+// MssqlTester is a wrapping struct around the basic SQL tester
+type MssqlTester struct {
+	sql_db_tester.SqlDatabaseTester
+}
+
+// NewTester creates a new instance of the MSSQL DB tester
+func NewTester() (api.DbTester, error) {
+	tester := &MssqlTester{}
+
+	return tester, nil
+}
+
+// sqlserver://username:password@host:port?database=master&param2=value
+
+// GetQueryMarkers returns part of the query string that will be paramerized as it's
+// different between databases. In this case, the params are defined using `@p<num>`.
+func (tester *MssqlTester) GetQueryMarkers(length int) string {
+	markers := []string{}
+	for markerIndex := 1; markerIndex <= length; markerIndex++ {
+		markers = append(markers, fmt.Sprintf("@p%d", markerIndex))
+	}
+	return strings.Join(markers, ", ")
+}
+
+// Connect is used to initialize a testing connection to the SQL database
+func (tester *MssqlTester) Connect(options api.DbTesterOptions) error {
+	if options.SslMode != "" {
+		return fmt.Errorf("mssql driver doesn't support sslmodes!")
+	}
+
+	if options.Port == "" {
+		options.Port = "1433"
+	}
+
+	if options.Socket != "" {
+		return fmt.Errorf("mssql driver doesn't support socket files!")
+	}
+
+	query := url.Values{}
+	query.Add("app name", "Juxtaposer")
+
+	connStringURL := &url.URL{
+		Scheme:   "sqlserver",
+		User:     url.UserPassword(options.Username, options.Password),
+		Host:     fmt.Sprintf("%s:%s", options.Host, options.Port),
+		RawQuery: query.Encode(),
+	}
+
+	connectionString := connStringURL.String()
+
+	if options.Debug {
+		log.Printf("Connection string: %s", connectionString)
+	}
+
+	db, err := sql.Open("sqlserver", connectionString)
+	if err != nil {
+		return err
+	}
+
+	if options.Debug {
+		log.Printf("Connected to DB")
+	}
+
+	log.Printf("Creating database (if it doesn't exist)...")
+	createDbStmt := fmt.Sprintf(`
+		IF NOT EXISTS (SELECT name FROM master.dbo.sysdatabases WHERE name = N'%s')
+			CREATE DATABASE %s`,
+		options.DatabaseName,
+		options.DatabaseName)
+
+	_, err = db.Exec(createDbStmt)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("Switching database...")
+	switchDbStmt := fmt.Sprintf("USE %s", options.DatabaseName)
+	_, err = db.Exec(switchDbStmt)
+	if err != nil {
+		return err
+	}
+
+	tester.Database = db
+	tester.Debug = options.Debug
+
+	return nil
+}

--- a/bin/juxtaposer/tester/db/mysql/mysql.go
+++ b/bin/juxtaposer/tester/db/mysql/mysql.go
@@ -1,4 +1,4 @@
-package db
+package mysql
 
 import (
 	"database/sql"

--- a/bin/juxtaposer/tester/db/postgres/postgres.go
+++ b/bin/juxtaposer/tester/db/postgres/postgres.go
@@ -1,4 +1,4 @@
-package db
+package postgres
 
 import (
 	"database/sql"


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?

This PR adds `mssql` as a supported DB backend to Juxtaposer

_Note: XA deployment env config was unable to be tested yet_

#### What ticket does this PR close?
N/A

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
