### PR TITLE
Adds juxtaposer persistent log and backdoor log read container

### DIFF
--- a/bin/juxtaposer/deploy/deploy_app
+++ b/bin/juxtaposer/deploy/deploy_app
@@ -8,6 +8,7 @@ CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
 AUTHENTICATOR_ID_ENCODED="$(python3 -c "import urllib.parse; print(urllib.parse.quote(input(),safe=''))" <<< "$AUTHENTICATOR_ID")"
 echo "${AUTHENTICATOR_ID_ENCODED}"
 
+mkdir -p "$CURRENT_DIR/tmp"
 sed -e "s#\${APP_NAME}#$APP_NAME#g" \
     -e "s#\${APP_SERVICE_ACCOUNT}#$APP_SERVICE_ACCOUNT#g" \
     -e "s#\${APP_NAMESPACE}#$TEST_APP_NAMESPACE_NAME#g" \

--- a/bin/juxtaposer/deploy/juxtaposer_deployment_template.yml
+++ b/bin/juxtaposer/deploy/juxtaposer_deployment_template.yml
@@ -36,6 +36,8 @@ spec:
         - name: ${APP_NAME}-sockets
           emptyDir:
             medium: Memory
+        - name: persistent-log
+          emptyDir: {}
 
       containers:
       - name: ${APP_NAME}
@@ -43,7 +45,7 @@ spec:
         imagePullPolicy: Always
         # command: [ "/bin/sleep", "999d" ]
         args: ["-c", "-t", "${TEST_DURATION}", "-f", "/etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml"]
-        # command: ["sh", "-c", "juxtaposer -t ${TEST_DURATION} -f /etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml &> /tmp/output.txt && echo 'done' && ls -la /tmp/output.txt && sleep 999d"]
+        # command: ["sh", "-c", "juxtaposer -t ${TEST_DURATION} -f /etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml >>/persistent-log/output.txt 2>&1 && echo 'done' && ls -la /persistent-log/output.txt && sleep 999d"]
         # args: ["-c", "-f", "/etc/${APP_NAME}/${APP_NAME}_${CONFIG_TEMPLATE}.yml"]
 
         volumeMounts:
@@ -52,6 +54,9 @@ spec:
             readOnly: true
           - mountPath: /sock
             name: ${APP_NAME}-sockets
+            readOnly: false
+          - mountPath: /persistent-log
+            name: persistent-log
             readOnly: false
       - name: secretless
         image: ${SECRETELESS_IMAGE}
@@ -112,3 +117,11 @@ spec:
           - mountPath: /sock
             name: ${APP_NAME}-sockets
             readOnly: false
+      - name: backdoor
+        image: alpine:3.8
+        imagePullPolicy: Always
+        command: ["tail", "-f", "/dev/null"]
+        volumeMounts:
+          - mountPath: /persistent-log
+            name: persistent-log
+            readOnly: true


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
This change adds an emptyDir volume to the Juxtaposer container
so that Juxtaposer output can be concatenated for the lifetime
of the Juxtaposer pod.

This change also adds a "backdoor" Alpine container to the
Juxtaposer deployment so that the persistent log in the emptyDir
log volume can be read even when the other two containers
(juxtaposer and secretless) may be unavailable for exec'ing
e.g. when they are in (exponential) crash loop backoff.

#### What ticket does this PR close?
Fixes Issue #1125

#### Where should the reviewer start?

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
