### PR TITLE
Adds SIGPIPE to signals handled by Secretless Juxtaposer

### DIFF
--- a/bin/juxtaposer/util/signal_listener.go
+++ b/bin/juxtaposer/util/signal_listener.go
@@ -14,9 +14,10 @@ func RegisterShutdownSignalCallback(shutdownChannel chan<- bool) {
 		syscall.SIGABRT,
 		syscall.SIGHUP,
 		syscall.SIGINT,
-		syscall.SIGUSR1,
+		syscall.SIGPIPE,
 		syscall.SIGQUIT,
 		syscall.SIGTERM,
+		syscall.SIGUSR1,
 	)
 
 	go func() {


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
This change adds the SIGPIPE signal to the list of signals that
are handled by the Secretless Juxtaposer test. The intent of the
Juxtaposer signal handler is to catch otherwise fatal signals
so that the Juxtaposer container can stay resident and running
even when fatal errors occur so that logs can be examined.

The SIGPIPE signal is being added to the list of signals being
handled because the following fatal error was observed in a
Juxatposer run after the Secretless sidecar container crashed
(because of authen issues with the Conjur follower). The error
captured was for a socket read, but the subsequent exit/crash
for the Juxtaposer could have happened on a socket write:

```
$ kubectl logs -n dane-secretless-xa juxtaposer-pg-687d4675dc-mld84 juxtaposer-pg
2020/02/04 23:18:35 Juxtaposer starting up...
2020/02/04 23:18:35 Using configuration: /etc/juxtaposer-pg/juxtaposer-pg_pg.yml
2020/02/04 23:18:35 Config loaded!
2020/02/04 23:18:35 Registering shutdown signal listener...
2020/02/04 23:18:35 Using test duration of 96h0m0s (overriding any 'rounds' from configfile)
2020/02/04 23:18:35 Driver: postgres
2020/02/04 23:18:35 Recreate connections: true
2020/02/04 23:18:35 Backends: 3
2020/02/04 23:18:35 Threads: 1
2020/02/04 23:18:35 Rounds: infinity
2020/02/04 23:18:35 Duration: 96h
2020/02/04 23:18:35 Setting up backend: pg_secretless_socket
2020/02/04 23:20:52 ERROR sql: Could not execute query!
2020/02/04 23:20:52 read unix @->/sock/.s.PGSQL.5432: read: connection reset by peer
```

#### What ticket does this PR close?
Connected to #1131

#### Where should the reviewer start?

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
