### PR TITLE
Increase default logging level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Default logging level changed from `Warn` to `Info`. Some logging message
+  levels were readjusted to retain the same UX. (#1127)
+
 ## [1.5.0] - 2020-01-29
 
 ### Added

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -69,10 +69,7 @@ func NewWithOptions(outputBuffer io.Writer, prefix string, isDebug bool) log_api
 }
 
 func (logger *Logger) shouldPrint(severityLevel severity) bool {
-	debugOnlySeverity := severityLevel == DebugSeverity ||
-		severityLevel == InfoSeverity
-
-	return !debugOnlySeverity || logger.IsDebug
+	return logger.IsDebug || (severityLevel != DebugSeverity)
 }
 
 func prependString(prependString string, args ...interface{}) []interface{} {

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -223,6 +223,5 @@ func (name methodName) requiresFormatString() bool {
 // debugOnly identifies methods that produce output only when the Logger is in
 // debug mode.
 func (name methodName) debugOnly() bool {
-	return strings.HasPrefix(string(name), "Debug") ||
-		strings.HasPrefix(string(name), "Info")
+	return strings.HasPrefix(string(name), "Debug")
 }

--- a/internal/plugin/connectors/http/aws/connector.go
+++ b/internal/plugin/connectors/http/aws/connector.go
@@ -38,7 +38,7 @@ func (c *Connector) Connect(
 	}
 
 	// Use metadata and credentials to sign request
-	c.logger.Infof(
+	c.logger.Debugf(
 		"Signing for service=%s region=%s",
 		reqMeta.serviceName,
 		reqMeta.region,

--- a/internal/plugin/connectors/http/proxy_service.go
+++ b/internal/plugin/connectors/http/proxy_service.go
@@ -145,7 +145,7 @@ func (proxy *proxyService) ServeHTTP(w gohttp.ResponseWriter, r *gohttp.Request)
 	// Log request
 
 	logMsg := "Got request %v %v %v %v"
-	logger.Infof(logMsg, r.URL.Path, r.Host, r.Method, r.URL.String())
+	logger.Debugf(logMsg, r.URL.Path, r.Host, r.Method, r.URL.String())
 
 	// Validate request
 

--- a/internal/plugin/connectors/ssh/proxy_service.go
+++ b/internal/plugin/connectors/ssh/proxy_service.go
@@ -152,7 +152,7 @@ func (proxy *proxyService) Start() error {
 					return
 				}
 
-				logger.Infof("Connection closed on %v", conn.LocalAddr())
+				logger.Debugf("Connection closed on %v", conn.LocalAddr())
 			}()
 		}
 	}()

--- a/internal/plugin/connectors/sshagent/proxy_service.go
+++ b/internal/plugin/connectors/sshagent/proxy_service.go
@@ -154,14 +154,14 @@ func (proxy *proxyService) Start() error {
 			}
 
 			go func() {
-				proxy.logger.Infof("Serving connection on %v", conn.LocalAddr())
+				proxy.logger.Debugf("Serving SSH Agent connection on %v", conn.LocalAddr())
 				err := agent.ServeAgent(proxy.keyring, conn)
 				if err != nil && err != io.EOF {
 					logger.Errorf("Failed on handle connection: %s", err)
 					return
 				}
 
-				logger.Infof("Connection closed on %v", conn.LocalAddr())
+				logger.Debugf("Connection closed on %v", conn.LocalAddr())
 			}()
 		}
 	}()

--- a/internal/plugin/connectors/tcp/mysql/connector.go
+++ b/internal/plugin/connectors/tcp/mysql/connector.go
@@ -32,7 +32,7 @@ func (connector *SingleUseConnector) sendErrorToClient(err error) {
 
 	if e := connector.mySQLClientConn.write(mysqlErrorContainer.GetPacket()); e != nil {
 		msg := "Attempted to write error %s to MySQL client but failed"
-		connector.logger.Infof(msg, e)
+		connector.logger.Warnf(msg, e)
 	}
 }
 

--- a/internal/plugin/connectors/tcp/proxy_service.go
+++ b/internal/plugin/connectors/tcp/proxy_service.go
@@ -108,14 +108,14 @@ func (proxy *proxyService) handleConnection(clientConn net.Conn) error {
 		return errors.Wrap(err, "failed on retrieve credentials")
 	}
 
-	logger.Infof("New connection on %v.\n", clientConn.LocalAddr())
+	logger.Debugf("New connection on %v.\n", clientConn.LocalAddr())
 
 	targetConn, err = proxy.connector.Connect(clientConn, backendCredentials)
 	if err != nil {
 		return errors.Wrap(err, "failed on connect")
 	}
 
-	logger.Infof("Connection opened on %v to %v.\n", clientConn.LocalAddr(), targetConn.RemoteAddr())
+	logger.Debugf("Connection opened on %v to %v.\n", clientConn.LocalAddr(), targetConn.RemoteAddr())
 
 	clientErrChan, destErrChan := duplexStream(clientConn, targetConn)
 
@@ -138,7 +138,7 @@ func (proxy *proxyService) handleConnection(clientConn net.Conn) error {
 		)
 	}
 
-	logger.Infof("Connection on %v closed by %s.\n", clientConn.LocalAddr(), closer)
+	logger.Debugf("Connection on %v closed by %s.\n", clientConn.LocalAddr(), closer)
 	return nil
 }
 

--- a/internal/proxyservice/proxy_service.go
+++ b/internal/proxyservice/proxy_service.go
@@ -52,7 +52,7 @@ func (s *proxyServices) Start() error {
 func (s *proxyServices) Stop() error {
 	var stopFailures []string
 
-	s.logger.Infoln("Stopping services...")
+	s.logger.Infoln("Stopping all services...")
 	for _, svc := range s.runningServices {
 		err := svc.Stop()
 		if err != nil {
@@ -166,7 +166,7 @@ func (s *proxyServices) createHTTPService(
 		return nil, err
 	}
 
-	s.logger.Warnf("Starting HTTP listener on %s...", netAddr.Address())
+	s.logger.Infof("Starting HTTP listener on %s...", netAddr.Address())
 
 	// Create the subservices
 
@@ -185,7 +185,7 @@ func (s *proxyServices) createHTTPService(
 			return nil, err
 		}
 
-		s.logger.Warnf("Starting HTTP subservice %s...", subCfg.Connector)
+		s.logger.Infof("Starting HTTP subservice %s...", subCfg.Connector)
 
 		subservices = append(subservices, httpproxy.Subservice{
 			ConnectorID:              subCfg.Connector, // TODO: Rename connectorID
@@ -223,7 +223,7 @@ func (s *proxyServices) createSSHService(
 		return nil, err
 	}
 
-	s.logger.Warnf("Starting SSH listener on %s...", netAddr.Address())
+	s.logger.Infof("Starting SSH listener on %s...", netAddr.Address())
 
 	connResources := s.connectorResources(config)
 	credsRetriever := s.credsRetriever(config.Credentials)
@@ -256,7 +256,7 @@ func (s *proxyServices) createSSHAgentService(
 		return nil, err
 	}
 
-	s.logger.Warnf("Starting SSH Agent listener on %s...", netAddr.Address())
+	s.logger.Infof("Starting SSH Agent listener on %s...", netAddr.Address())
 
 	connResources := s.connectorResources(config)
 	credsRetriever := s.credsRetriever(config.Credentials)
@@ -290,7 +290,7 @@ func (s *proxyServices) createTCPService(
 		return nil, err
 	}
 
-	s.logger.Warnf("Starting TCP listener on %s...", netAddr.Address())
+	s.logger.Infof("Starting TCP listener on %s...", netAddr.Address())
 
 	connResources := s.connectorResources(config)
 	svcConnector := pluginInst.NewConnector(connResources)

--- a/pkg/secretless/entrypoint/entrypoint.go
+++ b/pkg/secretless/entrypoint/entrypoint.go
@@ -131,7 +131,7 @@ func StartSecretless(params *SecretlessOptions) {
 		// TODO: This loop should probably be cleaned up rather than
 		//       rely on os.Exit() to end it.
 		for {
-			logger.Info("Waiting for new configuration...")
+			logger.Debug("Waiting for new configuration...")
 			cfg := <-configChangedChan
 
 			if allServices != nil {
@@ -142,7 +142,7 @@ func StartSecretless(params *SecretlessOptions) {
 				}
 			}
 
-			logger.Debug("Got new configuration")
+			logger.Info("Configuration found. Loading...")
 			reloadConfig(cfg)
 		}
 	}()

--- a/pkg/secretless/plugin/sharedobj/external_plugins.go
+++ b/pkg/secretless/plugin/sharedobj/external_plugins.go
@@ -118,7 +118,7 @@ func loadPluginFiles(
 			continue
 		}
 
-		logger.Infof("Adding '%s' as a plugin...", fileName)
+		logger.Debugf("Adding '%s' as a plugin...", fileName)
 
 		rawPlugins[fileName[:len(fileName)-3]] = pluginObj
 	}
@@ -180,7 +180,7 @@ func ExternalPluginsWithOptions(
 	plugins := NewPlugins()
 
 	for rawPluginName, rawPlugin := range rawPlugins {
-		logger.Infof("Loading plugin '%s'...", rawPluginName)
+		logger.Debugf("Loading plugin '%s'...", rawPluginName)
 
 		logPluginLoadError := func(err error) {
 			logger.Errorf("failed to load plugin '%s': %s", rawPluginName, err)
@@ -228,7 +228,7 @@ func ExternalPluginsWithOptions(
 			logPluginLoadError(err)
 			continue
 		}
-		logger.Warnf("Plugin %s/%s loaded", pluginType, pluginID)
+		logger.Infof("Plugin %s/%s loaded", pluginType, pluginID)
 	}
 	return &plugins, nil
 }


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
This PR increases logging by including `Info` messages in the default logging output.
Some message levels were adjusted to accommodate the change while retaining the expected
UX.

#### What ticket does this PR close?
Parent: #1127 

#### Where should the reviewer start?
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--secretless-broker/job/increase-default-logging-level/)

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
