### PR TITLE
Add openshift registry support for secretless-broker

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -30,6 +30,7 @@ echo "Building secretless-broker:$FULL_VERSION_TAG Docker image"
 # shellcheck disable=SC2086
 docker build --tag "secretless-broker:${FULL_VERSION_TAG}" \
              --tag "secretless-broker:latest" \
+             --target "secretless-broker" \
              $DOCKER_FLAGS \
              --file "$TOPLEVEL_DIR/Dockerfile" \
              "$TOPLEVEL_DIR"
@@ -53,3 +54,13 @@ docker build --tag "secretless-broker-quickstart:${FULL_VERSION_TAG}" \
              $DOCKER_FLAGS \
              --file "$QUICK_START_DIR/Dockerfile" \
              "$QUICK_START_DIR"
+
+echo "Building secretless-broker-redhat:$FULL_VERSION_TAG Docker image"
+# (we want the flags to be word split here)
+# shellcheck disable=SC2086
+docker build --tag "secretless-broker-redhat:${FULL_VERSION_TAG}" \
+             --target "secretless-broker-redhat" \
+             --build-arg VERSION="${FULL_VERSION_TAG}" \
+             $DOCKER_FLAGS \
+              --file "$TOPLEVEL_DIR/Dockerfile" \
+             "$TOPLEVEL_DIR"

--- a/bin/publish
+++ b/bin/publish
@@ -8,7 +8,7 @@ readonly REGISTRY="cyberark"
 readonly VERSION="$(short_version_tag)"
 readonly FULL_VERSION_TAG="$(full_version_tag)"
 readonly INTERNAL_REGISTRY="registry.tld"
-
+readonly REDHAT_IMAGE="scan.connect.redhat.com/ospid-18d9f51d-9c0c-4031-9f9e-ef08aa2ff409/secretless-broker"
 readonly IMAGES=(
   "secretless-broker"
   "secretless-broker-quickstart"
@@ -44,3 +44,15 @@ for image_name in "${IMAGES[@]}"; do
     done
   fi
 done
+
+if [ "$git_description" = "v${VERSION}" ]; then
+  # Publish only latest to Redhat Registries
+  echo "Tagging and pushing ${REDHAT_IMAGE}"
+
+  docker tag "secretless-broker-redhat:${FULL_VERSION_TAG}" "${REDHAT_IMAGE}:${VERSION}"
+  # you can't push the same tag twice to redhat registry, so ignore errors
+  if ! docker push "${REDHAT_IMAGE}:${VERSION}"; then
+    echo 'RedHat push FAILED! (Maybe the image was pushed already?)'
+    exit 0
+  fi
+fi


### PR DESCRIPTION
- Added an additional stage for building an openshift container
compliant image for secretless while making use of the build stage
- Added a stage to publishing for tagging and submitting the latest
version of the redhat compliant image
- Updated our build script to use stage targets, and since both
stages require different parameters, there would be a failure if
these target parameters would be left out, rather than overriding
an image with a different name
