### PR TITLE
Bump version to 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.5.1] - 2020-02-12
+
+### Added
+- Added RedHat certified image build to pipeline (#1141)
+- Added pipeline step to validate changelog (#1138)
+- Added MSSQL support to juxtaposer perf testing tool (#1135)
+- Added SIGPIPE to signals handled by Secretless Juxtaposer (#1136)
+- Added JDBC Integration tests for Postgres (#1130)
+- Added JDBC Tests for MSSQL (#1124)
+- Added client params propagation to MSSQL integration tests (#1103)
+
 ### Changed
 - Default logging level changed from `Warn` to `Info`. Some logging message
   levels were readjusted to retain the same UX. (#1127)
+- Update `bin/prefill_changelog` to generate valid CHANGELOG / ensure current
+  CHANGELOG parses (#1138)
+- Converted integration tests to use configs.v2 (#1120)
+
+### Fixed
+- Fixed broken documentation links (#1122)
 
 ## [1.5.0] - 2020-01-29
 
@@ -429,7 +446,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.5.1...HEAD
 [0.2.0]: https://github.com/cyberark/secretless-broker/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/cyberark/secretless-broker/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/cyberark/secretless-broker/compare/v0.3.0...v0.4.0
@@ -452,3 +469,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [1.4.1]: https://github.com/cyberark/secretless-broker/compare/v1.4.0...v1.4.1
 [1.4.2]: https://github.com/cyberark/secretless-broker/compare/v1.4.1...v1.4.2
 [1.5.0]: https://github.com/cyberark/secretless-broker/compare/v1.4.2...v1.5.0
+[1.5.1]: https://github.com/cyberark/secretless-broker/compare/v1.5.0...v1.5.1

--- a/pkg/secretless/version.go
+++ b/pkg/secretless/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the broker
-var Version = "1.5.0"
+var Version = "1.5.1"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Bumps the version to 1.5.1

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [x] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [x] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
