### PR TITLE
fix:conjur: set POSTGRES_HOST_AUTH_METHOD=trust 

### DIFF
--- a/test/connector/http/conjur/docker-compose.yml
+++ b/test/connector/http/conjur/docker-compose.yml
@@ -2,6 +2,8 @@ version: '2'
 services:
   pg:
     image: postgres:9.4
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
 
   conjur:
     image: cyberark/conjur:latest


### PR DESCRIPTION
This is a new thing in `postgres:9.4` to allow all connections allow all connections without a password.