### PR TITLE
Bump authn-k8s client to v0.16.1

### DIFF
--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -13,7 +13,7 @@ SECTION 1: Apache License 2.0
 >>> github.com/containerd/containerd-1.3.2
 >>> github.com/CrunchyData/crunchy-proxy-0.0.0-20170717145745-c0da73ca9dde
 >>> github.com/cyberark/conjur-api-go-0.5.2
->>> github.com/cyberark/conjur-authn-k8s-client-0.16.0
+>>> github.com/cyberark/conjur-authn-k8s-client-0.16.1
 >>> github.com/docker/distribution-2.7.1
 >>> github.com/docker/docker-1.4.2-0.20191231165639-e6f6c35b7902
 >>> github.com/docker/go-connections-0.4.0
@@ -162,7 +162,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
->>> github.com/cyberark/conjur-authn-k8s-client-0.16.0
+>>> github.com/cyberark/conjur-authn-k8s-client-0.16.1
 
 Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 

--- a/assets/license_finder.txt
+++ b/assets/license_finder.txt
@@ -6,7 +6,7 @@ github.com/cenkalti/backoff, v2.2.1+incompatible, unknown
 github.com/codegangsta/cli, v1.20.0, unknown
 github.com/containerd/containerd, v1.3.2, unknown
 github.com/cyberark/conjur-api-go, v0.5.2, unknown
-github.com/cyberark/conjur-authn-k8s-client, v0.16.0, unknown
+github.com/cyberark/conjur-authn-k8s-client, v0.16.1, unknown
 github.com/cyberark/summon, v0.7.0, unknown
 github.com/denisenkom/go-mssqldb, v0.0.0-20191001013358-cfbb681360f0, unknown
 github.com/docker/distribution, v2.7.1+incompatible, unknown

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/codegangsta/cli v1.20.0
 	github.com/containerd/containerd v1.3.2 // indirect
 	github.com/cyberark/conjur-api-go v0.5.2
-	github.com/cyberark/conjur-authn-k8s-client v0.16.0
+	github.com/cyberark/conjur-authn-k8s-client v0.16.1
 	github.com/cyberark/summon v0.7.0
 	github.com/denisenkom/go-mssqldb v0.0.0-20191001013358-cfbb681360f0
 	github.com/docker/distribution v2.7.1+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,9 +28,8 @@ github.com/containerd/containerd v1.3.2 h1:ForxmXkA6tPIvffbrDAcPUIB32QgXkt2XFj+F
 github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/cyberark/conjur-api-go v0.5.2 h1:8ntk07YNRz5bBwjNXkDEAPR70Yr+J2MN8NGlkhaMC3k=
 github.com/cyberark/conjur-api-go v0.5.2/go.mod h1:hwaReWirzgKor+JtH6vbwZaASDXulvd0SzGCloC5uOc=
-github.com/cyberark/conjur-authn-k8s-client v0.13.0/go.mod h1:JTeGIeRO59J7mMEc5yF6FPtk1QnaAzs4GyZa4WldqZc=
-github.com/cyberark/conjur-authn-k8s-client v0.16.0 h1:qQEpaa3Yq+wao0tj+mk6jMG/XX6sM8cOyzq3GBQplPg=
-github.com/cyberark/conjur-authn-k8s-client v0.16.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
+github.com/cyberark/conjur-authn-k8s-client v0.16.1 h1:tiYIUYuBr578BCYlx+mbPiE4dWi+NsCu6Dy9cSRv4/M=
+github.com/cyberark/conjur-authn-k8s-client v0.16.1/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
 github.com/cyberark/secretless-broker v1.4.1-0.20191211191712-251c5ec034af/go.mod h1:+GueI3WCJL5gDYaYa38ZokAR8ceEyCVet7MkuZyjf80=
 github.com/cyberark/summon v0.7.0/go.mod h1:S7grcxHeUxfL1vRTQUyq9jGK8yG6V/tSlLPQ6tHRO4k=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Bumps the version of conjur-authn-k8s-client to v0.16.1

#### What ticket does this PR close?
Partially resolves cyberark/conjur-authn-k8s-client#70