### PR TITLE
Add production env to Summon publish step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -123,7 +123,7 @@ pipeline {
       }
 
       steps {
-        sh 'summon ./bin/publish'
+        sh 'summon -e production ./bin/publish'
       }
     }
 


### PR DESCRIPTION
Updates the Jenkinsfile to specify the `production` environment when invoking `bin/publish` using Summon