### PR TITLE
Add link to service connector page on quick start

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,8 @@ description: Secretless Broker
     <div class="sub-card">
       <h2>Get started with a simple example</h2>
       <p>Follow the instructions below to run through a simple example to see how Secretless works. If you don't have it already, you will need to <a href="https://docs.docker.com/install/">install Docker</a>.</p>
+      
+      <p>Interested in seeing the full list of services we support? Check out <a href="https://docs.secretless.io/Latest/en/Content/References/connectors/scl_connectors_overview.htm">our documentation</a>.</p>
       <div id="quick-start-tabs-main">
         {% include quick_start.html %}
       </div>


### PR DESCRIPTION
This ensures people know we support additional services beyond the
three that are clearly shown in the quick start.

Updated quick start on main page at secretless.io:
<img width="1026" alt="Screen Shot 2020-03-06 at 1 16 31 PM" src="https://user-images.githubusercontent.com/26872683/76110587-bee65080-5fac-11ea-8a07-d6f1e4aee7d9.png">

