### PR TITLE
Adds Splunk example generic HTTP config

### DIFF
--- a/examples/generic_connector_configs/README.md
+++ b/examples/generic_connector_configs/README.md
@@ -6,6 +6,10 @@ having to write new Secretless connectors_. Instead, you can modify your
 Secretless configuration to specify the header structure the HTTP service
 requires to authenticate.
 
+If your target uses self-signed certs you will need to follow the
+[documented instructions](https://docs.secretless.io/Latest/en/Content/References/connectors/scl_handlers-https.htm#Manageservercertificates)
+for adding the target’s CA to Secretless’ trusted certificate pool.
+
 ## Sample Configurations
 
 > Note: The following examples use the [Keychain provider](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/11.3/en/Content/References/providers/scl_keychain.htm?TocPath=Fundamentals%7CSecretless%20Pattern%7CSecret%20Providers%7C_____5).
@@ -18,6 +22,7 @@ requires to authenticate.
 |[GitHub API](https://developer.github.com/v3/)|[github_secretless.yml](./github_secretless.yml)|<ul><li>Edit the supplied configuration to get your [GitHub OAuth token](https://developer.github.com/v3/#oauth2-token-sent-in-a-header) from the correct provider/path.</li><li>Run Secretless with the supplied configuration</li><li>Query the GitHub API using `http_proxy=localhost:8081 curl api.github.com/{request}`</li></ul>|
 |OAuth 2.0 APIs|[oauth2_secretless.yml](./oauth2_secretless.yml)|This configuration acts as a generic OAuth2 connector. It can be used with any service that requires a Bearer token Authorization header.<ul><li>Edit the supplied service configuration to get your OAuth token</li><li>Run secretless with the supplied configuration(s)</li><li>Query the API using `http_proxy=localhost:8071 curl <Your OAuth2 API Endpoint URL>/{Request}`</li></ul>
 |[Slack Web API](https://api.slack.com/apis)|[slack_secretless.yml](./slack_secretless.yml)|<ul><li>Edit the supplied configuration to get your Slack [OAuth token](https://api.slack.com/legacy/oauth#flow)</li><li>Run secretless with the supplied configuration(s)</li><li>Query the Slack API using `http_proxy=localhost:9030 curl -d {data} <Slack Endpoint URL>` or `http_proxy=localhost:9040 curl -d {data} <Slack Endpoint URL>` depending on if your endpoint requires JSON or URL encoded requests</li></ul>
+|[Splunk API](https://docs.splunk.com/Documentation/Splunk/8.0.2/Security/UseAuthTokens)|[splunk_secretless.yml](./splunk_secretless.yml)|<ul><li>Edit the supplied configuration to get your [Splunk authentication token](https://docs.splunk.com/Documentation/Splunk/8.0.2/Security/EnableTokenAuth) from the correct provider/path</li><li>Create a Splunk [certficate](https://docs.splunk.com/Documentation/Splunk/8.0.2/Security/Howtoself-signcertificates) and add the certificate to [Secretless's trusted certificate pool](https://docs.secretless.io/Latest/en/Content/References/connectors/scl_handlers-https.htm#Manageservercertificates) </li><li>Run Secretless with the supplied configuration</li><li>Query the Splunk API using `http_proxy=localhost:8081 curl {instance host name or IP address}:{management port}/{route}` - note that you do not preface your instance host name with `https://`; Secretless will ensure the final connection to the backend server uses SSL.</li></ul>|
 
 ## Contributing
 

--- a/examples/generic_connector_configs/splunk_secretless.yml
+++ b/examples/generic_connector_configs/splunk_secretless.yml
@@ -1,0 +1,15 @@
+version: 2
+services:
+  splunk:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8081
+    credentials:
+      token:
+        from: keychain
+        get: service#splunk/temp-token
+    config:
+      headers:
+        Authorization: Bearer {{ .token }}
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http[s]*


### PR DESCRIPTION
Connected to #1172

To test this out:
- I ran Splunk locally:
   ```
   docker run \
     -d \
     -p 8000:8000 \
     -p 8089:8089 \
     -e "SPLUNK_START_ARGS=--accept-license" \
     -e "SPLUNK_PASSWORD=specialpass" \
     --name splunk \
     splunk/splunk:latest
   ```
- I followed the instructions [here](https://docs.splunk.com/Documentation/Splunk/8.0.2/Security/EnableTokenAuth) for enabling and configuring a token using the Splunk UI at localhost:8000

- I added the token to my OSX keychain

- I verified API access by running the following command and getting a result:
   ```
   summon -p keyring.py \
     --yaml 'TOKEN: !var splunk/temp-token' \
     bash -c 'curl -H "Authorization: Bearer $TOKEN" -X GET -i -k https://localhost:8089/services/apps/local'
   ```

- I ran Secretless locally by running `./bin/build_darwin` and then
   ```
   ./dist/darwin/amd64/secretless-broker \
     -f examples/generic_connector_configs/splunk_secretless.yml
   ```

- I attempted to connect to Splunk via Secretless, but got an error:
   ```
   $ http_proxy=localhost:8081 curl -k -X GET localhost:8089/services/apps/local
   x509: certificate is valid for SplunkServerDefaultCert, not localhost
   ```