### PR TITLE
Turning on trivy scanning for other containers built in pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,21 @@ pipeline {
           }
         }
 
+        stage('Scan Secretless Quickstart') {
+          steps {
+            scanAndReport("secretless-broker-quickstart:latest", "CRITICAL")
+          }
+        }
+
+        stage('Scan Secretless RedHat') {
+          steps {
+            script {
+              TAG = sh(returnStdout: true, script: '. bin/build_utils && full_version_tag')
+            }
+            scanAndReport("secretless-broker-redhat:${TAG}", "NONE")
+          }
+        }
+
         stage('Scan For Security with Gosec') {
           steps {
             sh "./bin/check_golang_security -s High -c Medium -b ${env.BRANCH_NAME}"


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

#### What does this PR do (include background context, if relevant)?
Adds scanning for the secretless-broker-quickstart and secretless-broker-redhat containers that are built as part of the pipeline.

#### What ticket does this PR close?
N/A
#### Where should the reviewer start?

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
