### PR TITLE
(#1163) Initial support for sslmode 

### DIFF
--- a/internal/plugin/connectors/tcp/mssql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details.go
@@ -11,6 +11,7 @@ type ConnectionDetails struct {
 	Port     uint
 	Username string
 	Password string
+	SSLMode  string
 }
 
 const defaultMSSQLPort = uint(1433)
@@ -37,6 +38,12 @@ func NewConnectionDetails(credentials map[string][]byte) *ConnectionDetails {
 
 	if credentials["password"] != nil {
 		connDetails.Password = string(credentials["password"])
+	}
+
+	if credentials["sslmode"] == nil {
+		connDetails.SSLMode = "disable"
+	} else {
+		connDetails.SSLMode = string(credentials["sslmode"])
 	}
 
 	return connDetails

--- a/internal/plugin/connectors/tcp/mssql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details.go
@@ -1,6 +1,7 @@
 package mssql
 
 import (
+	"bytes"
 	"strconv"
 )
 
@@ -40,10 +41,17 @@ func NewConnectionDetails(credentials map[string][]byte) *ConnectionDetails {
 		connDetails.Password = string(credentials["password"])
 	}
 
-	if credentials["sslmode"] == nil {
-		connDetails.SSLMode = "disable"
-	} else {
+	// More supported cases to be added
+	sslMode := credentials["sslmode"]
+	switch {
+	case bytes.Equal(sslMode, []byte("disable")):
 		connDetails.SSLMode = string(credentials["sslmode"])
+	case bytes.Equal(sslMode, []byte("enable")):
+		fallthrough
+	case bytes.Equal(sslMode, []byte("verify-ca")):
+		fallthrough
+	default:
+		connDetails.SSLMode = "disable"
 	}
 
 	return connDetails

--- a/internal/plugin/connectors/tcp/mssql/connection_details_test.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details_test.go
@@ -1,0 +1,110 @@
+package mssql
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConnectionDetails_Address(t *testing.T) {
+	type fields struct {
+		Host     string
+		Port     uint
+		Username string
+		Password string
+		SSLMode  string
+	}
+	tests := []struct {
+		description string
+		fields      fields
+		expected    string
+	}{
+		{
+			description: "default address format",
+			fields: fields{
+				Host:     "hostname",
+				Port:     5555,
+				Username: "foo",
+				Password: "bar",
+				SSLMode:  "xyz",
+			},
+			expected: "hostname:5555",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			cd := &ConnectionDetails{
+				Host:     tt.fields.Host,
+				Port:     tt.fields.Port,
+				Username: tt.fields.Username,
+				Password: tt.fields.Password,
+				SSLMode:  tt.fields.SSLMode,
+			}
+
+			assert.Equal(t, tt.expected, cd.Address())
+		})
+	}
+}
+
+func TestNewConnectionDetails(t *testing.T) {
+	type args struct {
+		credentials map[string][]byte
+	}
+	tests := []struct {
+		description string
+		args        args
+		expected    *ConnectionDetails
+	}{
+		{
+			description: "ssl mode is empty - use default",
+			args: args{
+				credentials: map[string][]byte{
+					"sslmode": nil,
+				},
+			},
+			expected: &ConnectionDetails{
+				Host:     "",
+				Port:     defaultMSSQLPort,
+				Username: "",
+				Password: "",
+				SSLMode:  "disable",
+			},
+		},
+		{
+			description: "ssl mode is disable - use value",
+			args: args{
+				credentials: map[string][]byte{
+					"sslmode": []byte("enable"),
+				},
+			},
+			expected: &ConnectionDetails{
+				Host:     "",
+				Port:     defaultMSSQLPort,
+				Username: "",
+				Password: "",
+				SSLMode:  "disable",
+			},
+		},
+		{
+			description: "ssl mode is unsupported - use default",
+			args: args{
+				credentials: map[string][]byte{
+					"sslmode": []byte("foobar"),
+				},
+			},
+			expected: &ConnectionDetails{
+				Host:     "",
+				Port:     defaultMSSQLPort,
+				Username: "",
+				Password: "",
+				SSLMode:  "disable",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			actualConnDetails := NewConnectionDetails(tt.args.credentials)
+
+			assert.Equal(t, tt.expected, actualConnDetails)
+		})
+	}
+}

--- a/internal/plugin/connectors/tcp/mssql/connector.go
+++ b/internal/plugin/connectors/tcp/mssql/connector.go
@@ -326,9 +326,10 @@ func dataSourceName(connDetails *ConnectionDetails) string {
 		// it'll be used between Secretless and the server.
 		// To disable TLS altogether we must change to
 		// "sqlserver://%s:%s@%s?encrypt=disable",
-		"sqlserver://%s:%s@%s",
+		"sqlserver://%s:%s@%s?encrypt=%s",
 		connDetails.Username,
 		connDetails.Password,
 		connDetails.Address(),
+		connDetails.SSLMode,
 	)
 }

--- a/test/connector/tcp/mssql/mssql-2017-cu1/secretless.yml
+++ b/test/connector/tcp/mssql/mssql-2017-cu1/secretless.yml
@@ -10,6 +10,7 @@ services:
       password: yourStrong()Password
       host: mssql-2017-cu1
       port: 1433
+      sslmode: disable
   fake-mssql:
     connector: mssql
     listenOn: tcp://0.0.0.0:2224
@@ -18,3 +19,4 @@ services:
       password: expected-password
       host: test
       port: 1434
+      sslmode: disable

--- a/test/connector/tcp/mssql/mssql-2019/secretless.yml
+++ b/test/connector/tcp/mssql/mssql-2019/secretless.yml
@@ -10,6 +10,7 @@ services:
       password: yourStrong()Password
       host: mssql-2019
       port: 1433
+      sslmode: disable
   fake-mssql:
     connector: mssql
     listenOn: tcp://0.0.0.0:2224
@@ -18,3 +19,4 @@ services:
       password: expected-password
       host: test
       port: 1434
+      sslmode: disable

--- a/test/connector/tcp/mssql/mssql_connector_test.go
+++ b/test/connector/tcp/mssql/mssql_connector_test.go
@@ -277,6 +277,8 @@ func propagateParams(
 	if !assert.NoError(t, err) {
 		return
 	}
+	assert.Equal(t, preloginRequest[mssql.PreloginENCRYPTION], []byte{mssql.EncryptNotSup})
+
 	// write prelogin response
 	// ensuring no TLS support
 	preloginResponse := preloginRequest

--- a/test/connector/tcp/mssql/secretless.yml
+++ b/test/connector/tcp/mssql/secretless.yml
@@ -10,6 +10,7 @@ services:
       password: yourStrong()Password
       host: mssql
       port: 1433
+      sslmode: disable
   fake-mssql:
     connector: mssql
     listenOn: tcp://0.0.0.0:2224
@@ -18,3 +19,4 @@ services:
       password: expected-password
       host: test
       port: 1434
+      sslmode: disable


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?
Adds sslmode as a param for user configuration and injecting it
into the DSN

#### What ticket does this PR close?
Connected to #1163

#### Where should the reviewer start?
internal/plugin/connectors/tcp/mssql/connector.go#dataSourceName

