### PR TITLE
Zeroize credentials after use

### DIFF
--- a/internal/plugin/connectors/tcp/mssql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details.go
@@ -23,6 +23,13 @@ func NewConnectionDetails(credentials map[string][]byte) *ConnectionDetails {
 
 	connDetails := &ConnectionDetails{}
 
+	// Zeroize credentials when finished
+	defer func() {
+		for key := range credentials {
+			delete(credentials, key)
+		}
+	}()
+
 	if host := credentials["host"]; host != nil {
 		connDetails.Host = string(credentials["host"])
 	}

--- a/internal/plugin/connectors/tcp/mssql/connection_details_test.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details_test.go
@@ -105,6 +105,11 @@ func TestNewConnectionDetails(t *testing.T) {
 			actualConnDetails := NewConnectionDetails(tt.args.credentials)
 
 			assert.Equal(t, tt.expected, actualConnDetails)
+
+			// Verify that credentials have been zeroed
+			for cred := range tt.args.credentials {
+				assert.Empty(t, cred)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Credentials passed in to the mssql connector
will be zeroized after being used for connection
details