### PR TITLE
Use the mssql proxy service for E2E tests

### DIFF
--- a/internal/plugin/connectors/tcp/mssql/connector.go
+++ b/internal/plugin/connectors/tcp/mssql/connector.go
@@ -191,6 +191,7 @@ func (connector *SingleUseConnector) Connect(
 	// Prepare connection details from the client, formatted for MSSQL
 	// TODO: find out if it is possible to send errors during prelogin-phase
 	// TODO: send error to client on failed credential validation
+	connector.Logger.Debug("Constructing connection details")
 	connDetails := NewConnectionDetails(credentialValuesByID)
 
 	// Create a new MSSQL connector
@@ -199,6 +200,7 @@ func (connector *SingleUseConnector) Connect(
 	// NOTE: Secretless has some unfortunate naming collisions with the
 	// go-mssqldb driver package.  The driver package has its own concept of a
 	// "connector", and its connectors also have a "Connect" method.
+	connector.Logger.Debug("Constructing MSSQL connector")
 	driverConnector, err := connector.NewMSSQLConnector(dataSourceName(connDetails))
 	if err != nil {
 		wrappedError := errors.Wrap(err, "failed to create a go-mssqldb connector")
@@ -225,6 +227,7 @@ func (connector *SingleUseConnector) Connect(
 		}
 	}()
 
+	connector.Logger.Debug("Waiting for server connection")
 	backendConn, err := connector.waitForServerConnection(
 		connInterceptor,
 		connectionResultChan)
@@ -234,6 +237,7 @@ func (connector *SingleUseConnector) Connect(
 		return nil, err
 	}
 
+	connector.Logger.Debug("Off to the races")
 	return backendConn, nil
 }
 

--- a/test/connector/tcp/mssql/connector_e2e_test.go
+++ b/test/connector/tcp/mssql/connector_e2e_test.go
@@ -1,0 +1,187 @@
+package mssqltest
+
+import (
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cyberark/secretless-broker/internal/log"
+	"github.com/cyberark/secretless-broker/internal/plugin/connectors/tcp"
+	secretlessMssql "github.com/cyberark/secretless-broker/internal/plugin/connectors/tcp/mssql"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
+	mssql "github.com/denisenkom/go-mssqldb"
+)
+
+func randomPortListener() (listener net.Listener, err error) {
+	listener, err = net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return
+	}
+
+	// We don't want to wait forever for a connection to come in
+	err = listener.(*net.TCPListener).SetDeadline(time.Now().Add(5 * time.Second))
+
+	return
+}
+
+func exampleRun() (*TargetCapture, error) {
+	logger := log.New(true)
+	testLogger := logger.CopyWith("[TEST]", true)
+
+	targetSvcListener, err := randomPortListener()
+	if err != nil {
+		return nil, err
+	}
+	targetSvcHost, targetSvcPort, err := net.SplitHostPort(
+		targetSvcListener.Addr().String(),
+		)
+	if err != nil {
+		return nil, err
+	}
+
+	secretlessSvcListener, err := randomPortListener()
+	if err != nil {
+		return nil, err
+	}
+	secretlessSvcHost, secretlessSvcPort, err := net.SplitHostPort(
+		secretlessSvcListener.Addr().String(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	secretlessSvcPortInt, err := strconv.Atoi(secretlessSvcPort)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = targetSvcListener.Close()
+	}()
+
+	credentials := map[string][]byte{
+		"sslmode": []byte("disable"),
+		"host": []byte(targetSvcHost),
+		"port": []byte(targetSvcPort),
+	}
+
+	defer func() {
+		_ = secretlessSvcListener.Close()
+	}()
+
+
+	proxySvc, err := tcp.NewProxyService(
+		secretlessMssql.NewConnector(
+			connector.NewResources(nil, logger),
+		),
+		secretlessSvcListener,
+		logger,
+		func() (bytes map[string][]byte, e error) {
+			return credentials, nil
+		},
+		)
+	defer func() {
+		_ = proxySvc.Stop()
+	}()
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		_ = proxySvc.Start()
+	}()
+
+	go func() {
+		testLogger.Info("Client connecting to ", secretlessSvcHost, secretlessSvcPort)
+
+		// we don't actually care about the response
+		_, err = sqlcmdExec(
+			dbConfig{
+				Host:     secretlessSvcHost,
+				Port:     secretlessSvcPortInt ,
+				Username: "dummy",
+				Password: "dummy",
+				Database: "test-db",
+				ReadOnly: true,
+			},
+			"",
+		)
+		if err != nil {
+			testLogger.Infof("Failed to start client", err)
+		}
+	}()
+
+	 capture, err := runMockTarget(targetSvcListener)
+	 testLogger.Info("Captured: %v", capture)
+
+	return capture, err
+}
+
+
+type TargetCapture struct {
+	preloginRequest map[uint8][]byte
+	loginRequest mssql.LoginRequest
+}
+
+func runMockTarget(listener net.Listener) (*TargetCapture, error) {
+	targetCapture := &TargetCapture{}
+
+	clientConnection, err := listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	// Set a deadline so that if things hang then they fail fast
+	readWriteDeadline := time.Now().Add(5 * time.Second)
+	err = clientConnection.SetDeadline(readWriteDeadline)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		_ = clientConnection.Close()
+	}()
+
+	// Read prelogin request
+	preloginRequest, err := mssql.ReadPreloginRequest(clientConnection)
+	if err != nil {
+		return targetCapture, err
+	}
+
+	targetCapture.preloginRequest = preloginRequest
+
+	// Write prelogin response
+	// ensuring no TLS support for now
+	// TODO: add TLS handshake logic lol
+	preloginResponse := preloginRequest
+	preloginResponse[mssql.PreloginVERSION] = []byte{0x0e, 0x00, 0x0c, 0xa6, 0x00, 0x00}
+	preloginResponse[mssql.PreloginENCRYPTION] = []byte{mssql.EncryptNotSup}
+	err = mssql.WritePreloginResponse(clientConnection, preloginResponse)
+	if err != nil {
+		return targetCapture, err
+	}
+
+	// read login request
+	loginRequest, err := mssql.ReadLoginRequest(clientConnection)
+	if err != nil {
+		return targetCapture, err
+	}
+
+	targetCapture.loginRequest = *loginRequest
+
+	// write a dummy successful login response
+	loginResponse := &mssql.LoginResponse{}
+	loginResponse.ProgName = "test"
+	loginResponse.TDSVersion = 0x730A0003
+	loginResponse.Interface = 27
+	err = mssql.WriteLoginResponse(clientConnection, loginResponse)
+	if err != nil {
+		return targetCapture, err
+	}
+
+	return targetCapture, nil
+}
+
+func TestConnectorE2E(t *testing.T) {
+	_, _ = exampleRun()
+}

--- a/test/connector/tcp/mssql/mssql_connector_test.go
+++ b/test/connector/tcp/mssql/mssql_connector_test.go
@@ -114,6 +114,7 @@ func RunConnectivityTests(t *testing.T, queryExec dbQueryExecutor) {
 }
 
 const mockServerSecretlessPort = 2224
+const mockServerPort = 1434
 type testClientParams struct {
 	queryExec dbQueryExecutor
 	applicationName string
@@ -122,7 +123,7 @@ type testClientParams struct {
 
 func TestClientParams(t *testing.T) {
 	// Setup mock-server listener
-	_ln, err := net.Listen("tcp", ":1434")
+	_ln, err := net.Listen("tcp", fmt.Sprintf(":%d", mockServerPort))
 	ln := _ln.(*net.TCPListener)
 	defer func() {
 		_ = ln.Close()

--- a/test/connector/tcp/mssql/mssql_defaults.go.go
+++ b/test/connector/tcp/mssql/mssql_defaults.go.go
@@ -1,0 +1,12 @@
+package mssqltest
+
+import "github.com/cyberark/secretless-broker/test/util/testutil"
+
+func defaultSecretlessDbConfig() dbConfig {
+	return dbConfig{
+		Host:     testutil.SecretlessHost,
+		Port:     testutil.SecretlessPort,
+		Username: "dummy",
+		Password: "dummy",
+	}
+}

--- a/test/connector/tcp/mssql/mssql_query.go
+++ b/test/connector/tcp/mssql/mssql_query.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"os/exec"
 	"text/tabwriter"
-
-	"github.com/cyberark/secretless-broker/test/util/testutil"
 )
 
 type dbConfig struct {
@@ -26,15 +24,6 @@ type dbConfig struct {
 type dbQueryExecutor func(cfg dbConfig, query string) (string, error)
 
 const jdbcJARPath = "/secretless/test/util/jdbc/jdbc.jar"
-
-func defaultSecretlessDbConfig() dbConfig {
-	return dbConfig{
-		Host:     testutil.SecretlessHost,
-		Port:     testutil.SecretlessPort,
-		Username: "dummy",
-		Password: "dummy",
-	}
-}
 
 // runs queries using sqlcmd
 func sqlcmdExec(


### PR DESCRIPTION
Invoking the proxy service, as opposed to the Secretless binary, makes it possible to avoid the perils of static configuration. It gives the E2E tester more flexibility in exercising a variety of test cases, all generated in-process.

I added a test cases that uses this method `TestConnectorE2E`. The logs for it are presented below. There's also a mock MSSQL server that captures incoming packets.

Perhaps the mock MSSQL server could be removed and instead we can use `tshark` while talking to an actual server. This is one of the benefits of this approach of invoking the proxy service, both the Secretless and server can be configured at runtime.

```
=== RUN   TestConnectorE2E
2020/04/09 14:38:03 [INFO]  Starting service
2020/04/09 14:38:03 [INFO]  [TEST]: Client connecting to  127.0.0.1 56295
2020/04/09 14:38:03 [DEBUG] New connection on 127.0.0.1:56295.
2020/04/09 14:38:03 [DEBUG] Constructing connection details
2020/04/09 14:38:03 [DEBUG] Constructing MSSQL connector
2020/04/09 14:38:03 [DEBUG] Waiting for server connection
2020/04/09 14:38:03 [DEBUG] Off to the races
2020/04/09 14:38:03 [DEBUG] Proxying connection on 127.0.0.1:56295 to 127.0.0.1:56294.
2020/04/09 14:38:03 [DEBUG] Connection on 127.0.0.1:56295 closed by target.
2020/04/09 14:38:03 [INFO]  [TEST]: Captured: %v &{map[0:[14 0 12 166 0 0] 1:[2] 2:[0] 3:[0 0 0 0] 4:[0]] {{1946157060 4096 117440512 44179 0 224 3 32 16 -60 1033 kumbirai-t   SQLCMD 127.0.0.1,56295 [182 0 0 0] [9 1 0 0 0 1 10 1 0 0 0 1 1 0 0 0 0 255] ODBC  test-db [255 255 255 255 255 255] []  }}}
2020/04/09 14:38:03 [INFO]  Stopping service
2020/04/09 14:38:03 [INFO]  Listener closed
--- PASS: TestConnectorE2E (0.06s)
PASS
ok      command-line-arguments  0.072s
```
