### PR TITLE
Fixed garbled logging messages in PG connector

### DIFF
--- a/internal/plugin/connectors/tcp/pg/backend.go
+++ b/internal/plugin/connectors/tcp/pg/backend.go
@@ -105,7 +105,7 @@ func (s *SingleUseConnector) ConnectToBackend() error {
 		return err
 	}
 
-	s.logger.Debugln(
+	s.logger.Debugf(
 		"Successfully connected to '%s:%s'",
 		s.connectionDetails.Host,
 		s.connectionDetails.Port,

--- a/internal/plugin/connectors/tcp/pg/startup.go
+++ b/internal/plugin/connectors/tcp/pg/startup.go
@@ -9,7 +9,7 @@ import (
 // Startup performs the startup handshake with the client and parses the client
 // options to extract the database name.
 func (s *SingleUseConnector) Startup() error {
-	s.logger.Debugln("Handling connection %v", s.clientConn)
+	s.logger.Debugf("Handling connection %+v -> %+v", s.clientConn.RemoteAddr(), s.clientConn.LocalAddr())
 
 	messageBytes, err := protocol.ReadStartupMessage(s.clientConn)
 	if err != nil {
@@ -21,8 +21,8 @@ func (s *SingleUseConnector) Startup() error {
 		return err
 	}
 
-	s.logger.Debugln(
-		"s.Client version : %v, (SSL mode: %v)",
+	s.logger.Debugf(
+		"s.Client version: %v, (SSL mode: %v)",
 		version,
 		version == protocol.SSLRequestCode)
 


### PR DESCRIPTION
Some of the messages were using the non-formatted output with a
formatting string which was creating pretty unreadable logging output so
these have been fixed now.

#### What ticket does this PR close?
N/A

#### Where should the reviewer start?


#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests
N/A

#### Links to open issues for related documentation (in READMEs, docs, etc)
N/A

#### Screenshots (if appropriate)
