### PR TITLE
1165 - MSSQL support exists for sslmodes verify-ca & require

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/containerd/containerd v1.3.2 h1:ForxmXkA6tPIvffbrDAcPUIB32QgXkt2XFj+F
 github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/cyberark/conjur-api-go v0.5.2 h1:8ntk07YNRz5bBwjNXkDEAPR70Yr+J2MN8NGlkhaMC3k=
 github.com/cyberark/conjur-api-go v0.5.2/go.mod h1:hwaReWirzgKor+JtH6vbwZaASDXulvd0SzGCloC5uOc=
+github.com/cyberark/conjur-authn-k8s-client v0.13.0/go.mod h1:JTeGIeRO59J7mMEc5yF6FPtk1QnaAzs4GyZa4WldqZc=
 github.com/cyberark/conjur-authn-k8s-client v0.16.1 h1:tiYIUYuBr578BCYlx+mbPiE4dWi+NsCu6Dy9cSRv4/M=
 github.com/cyberark/conjur-authn-k8s-client v0.16.1/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
 github.com/cyberark/secretless-broker v1.4.1-0.20191211191712-251c5ec034af/go.mod h1:+GueI3WCJL5gDYaYa38ZokAR8ceEyCVet7MkuZyjf80=

--- a/internal/plugin/connectors/tcp/mssql/connector.go
+++ b/internal/plugin/connectors/tcp/mssql/connector.go
@@ -2,7 +2,6 @@ package mssql
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net"
 
@@ -199,7 +198,7 @@ func (connector *SingleUseConnector) Connect(
 	// NOTE: Secretless has some unfortunate naming collisions with the
 	// go-mssqldb driver package.  The driver package has its own concept of a
 	// "connector", and its connectors also have a "Connect" method.
-	driverConnector, err := connector.NewMSSQLConnector(dataSourceName(connDetails))
+	driverConnector, err := connector.NewMSSQLConnector(connDetails.URL())
 	if err != nil {
 		wrappedError := errors.Wrap(err, "failed to create a go-mssqldb connector")
 		connector.writeErrorToClient(wrappedError)
@@ -318,18 +317,4 @@ func (connector *SingleUseConnector) waitForServerConnection(
 
 func (connector *SingleUseConnector) writeErrorToClient(err error) {
 	_ = connector.WriteError(connector.clientBuff, protocolError(err))
-}
-
-func dataSourceName(connDetails *ConnectionDetails) string {
-	return fmt.Sprintf(
-		// NOTE: as things stand the resulting DSN here means that if TLS is available
-		// it'll be used between Secretless and the server.
-		// To disable TLS altogether we must change to
-		// "sqlserver://%s:%s@%s?encrypt=disable",
-		"sqlserver://%s:%s@%s?encrypt=%s",
-		connDetails.Username,
-		connDetails.Password,
-		connDetails.Address(),
-		connDetails.SSLMode,
-	)
 }


### PR DESCRIPTION
sslmodes require and verify-ca dictate that TLS must
be used between secretless and the target mssql
service.

- Added support for verify-ca and building
the associated DSN
- Added support for require and building the
associated DSN

- created a map of sslmodes and their associated
params for building DSNs easily and consistently
- Modified and added tests, as needed, for the
changes and additions to connection_details.go

Todo: Add more thorough testing to verify 
parameter propagation per story #1193 