### PR TITLE
Update mssql driver to support verify-ca and verify-full

### DIFF
--- a/internal/plugin/connectors/tcp/mssql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details.go
@@ -36,9 +36,9 @@ var sslModeToBaseParams = map[string]map[string]string{
 }
 
 const (
-	sslModeDisable  = "disable"
-	sslModeRequire  = "require"
-	sslModeVerifyCA = "verify-ca"
+	sslModeDisable    = "disable"
+	sslModeRequire    = "require"
+	sslModeVerifyCA   = "verify-ca"
 	sslModeVerifyFull = "verify-full"
 )
 
@@ -84,12 +84,17 @@ func newSSLParams(credentials map[string][]byte) map[string]string {
 		return newSSLParams(credentials)
 	}
 
-	if sslMode == sslModeVerifyCA  {
+	if sslMode == sslModeVerifyCA {
 		params["rawcertificate"] = string(credentials["sslrootcert"])
 	}
 
-	if sslMode == sslModeVerifyFull  {
+	if sslMode == sslModeVerifyFull {
 		params["rawcertificate"] = string(credentials["sslrootcert"])
+
+		// Ability to override hostname for verification
+		if len(credentials["sslhost"]) > 0 {
+			params["hostnameincertificate"] = string(credentials["sslhost"])
+		}
 	}
 
 	return params

--- a/internal/plugin/connectors/tcp/mssql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details.go
@@ -26,6 +26,7 @@ var sslModeToBaseParams = map[string]map[string]string{
 	sslModeVerifyCA: {
 		"encrypt":                "true",
 		"trustservercertificate": "false",
+		"disableverifyhostname":  "true",
 	},
 }
 

--- a/internal/plugin/connectors/tcp/mssql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details.go
@@ -28,12 +28,18 @@ var sslModeToBaseParams = map[string]map[string]string{
 		"trustservercertificate": "false",
 		"disableverifyhostname":  "true",
 	},
+	sslModeVerifyFull: {
+		"encrypt":                "true",
+		"trustservercertificate": "false",
+		"disableverifyhostname":  "false",
+	},
 }
 
 const (
 	sslModeDisable  = "disable"
 	sslModeRequire  = "require"
 	sslModeVerifyCA = "verify-ca"
+	sslModeVerifyFull = "verify-full"
 )
 
 var defaultSSLMode = []byte(sslModeRequire)
@@ -78,7 +84,11 @@ func newSSLParams(credentials map[string][]byte) map[string]string {
 		return newSSLParams(credentials)
 	}
 
-	if sslMode == "verify-ca" {
+	if sslMode == sslModeVerifyCA  {
+		params["rawcertificate"] = string(credentials["sslrootcert"])
+	}
+
+	if sslMode == sslModeVerifyFull  {
 		params["rawcertificate"] = string(credentials["sslrootcert"])
 	}
 

--- a/internal/plugin/connectors/tcp/mssql/connection_details_test.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details_test.go
@@ -158,6 +158,7 @@ func TestConnectionDetails_NewSSLOptions(t *testing.T) {
 			expected: map[string]string{
 				"encrypt":                "true",
 				"trustservercertificate": "false",
+				"disableverifyhostname":  "true",
 				"rawcertificate":         "foo",
 			},
 		},

--- a/internal/plugin/connectors/tcp/mssql/connection_details_test.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details_test.go
@@ -162,6 +162,21 @@ func TestConnectionDetails_NewSSLOptions(t *testing.T) {
 				"rawcertificate":         "foo",
 			},
 		},
+		{
+			description: "sslmode:verify-full",
+			args: args{
+				credentials: map[string][]byte{
+					"sslmode":     []byte("verify-full"),
+					"sslrootcert": []byte("foo"),
+				},
+			},
+			expected: map[string]string{
+				"encrypt":                "true",
+				"trustservercertificate": "false",
+				"disableverifyhostname":  "false",
+				"rawcertificate":         "foo",
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/internal/plugin/connectors/tcp/mssql/connection_details_test.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details_test.go
@@ -177,6 +177,23 @@ func TestConnectionDetails_NewSSLOptions(t *testing.T) {
 				"rawcertificate":         "foo",
 			},
 		},
+		{
+			description: "sslmode:verify-full with sslhost",
+			args: args{
+				credentials: map[string][]byte{
+					"sslmode":     []byte("verify-full"),
+					"sslhost":     []byte("foo.bar"),
+					"sslrootcert": []byte("foo"),
+				},
+			},
+			expected: map[string]string{
+				"encrypt":                "true",
+				"trustservercertificate": "false",
+				"disableverifyhostname":  "false",
+				"rawcertificate":         "foo",
+				"hostnameincertificate":  "foo.bar",
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Closes https://github.com/cyberark/secretless-broker/issues/1165
Closes https://github.com/cyberark/secretless-broker/issues/1199

mssql driver only supported full verification out of the box, which corresponds to sslmode=verify-full.

1. sslmode=verify-full has been added, with addition parameter sslhost that overrides the host used for verification.
2. sslmode=verify-ca has been fixed. custom verification logic has been added to ignore hostname verification.

Checklist before merge:

- [x] Ensure the [PR on the mssql driver](https://github.com/cyberark/go-mssqldb/pull/25) is merged before merging this.
