### PR TITLE
1188 - Zeroize credentials immediately after connecting

### DIFF
--- a/internal/plugin/connectors/tcp/proxy_service.go
+++ b/internal/plugin/connectors/tcp/proxy_service.go
@@ -103,6 +103,7 @@ func (proxy *proxyService) handleConnection(clientConn net.Conn) error {
 	}()
 
 	backendCredentials, err := proxy.retrieveCredentials()
+	// zeroize credentials if we exit early due to an error
 	defer internal.ZeroizeCredentials(backendCredentials)
 	if err != nil {
 		return errors.Wrap(err, "failed on retrieve credentials")
@@ -114,6 +115,9 @@ func (proxy *proxyService) handleConnection(clientConn net.Conn) error {
 	if err != nil {
 		return errors.Wrap(err, "failed on connect")
 	}
+
+	// immediately zeroize credentials after connecting
+	internal.ZeroizeCredentials(backendCredentials)
 
 	logger.Debugf("Connection opened on %v to %v.\n", clientConn.LocalAddr(), targetConn.RemoteAddr())
 

--- a/internal/plugin/connectors/tcp/proxy_service_test.go
+++ b/internal/plugin/connectors/tcp/proxy_service_test.go
@@ -72,8 +72,8 @@ func TestNewProxyService(t *testing.T) {
 		}
 		assert.Equal(
 			t,
-			string(creds["credName"]),
 			strings.Repeat("\x00", len([]byte("credValue"))),
+			string(creds["credName"]),
 		)
 	})
 }


### PR DESCRIPTION
In addition to a defer statement, called if we return
an error or panic after retreiving credentials, we
also call the zeroizing function immediately after
the connection is made and the credentials are no
longer needed.
