### PR TITLE
fix(version_test.go): Use assert.NotEmpty instead of assert.NotNil for strings

### DIFF
--- a/pkg/secretless/version_test.go
+++ b/pkg/secretless/version_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 func TestVersionIsPresent(t *testing.T) {
-	assert.NotNil(t, Version, "Expected Version to be non-empty but got an empty value")
+	assert.NotEmpty(t, Version, "Expected Version to be non-empty but got an empty value")
 }
 
 func TestTagIsPresent(t *testing.T) {
-	assert.NotNil(t, Tag, "Expected Tag to be non-empty but got an empty value")
+	assert.NotEmpty(t, Tag, "Expected Tag to be non-empty but got an empty value")
 }
 
 func TestVersionIsCorrectFormat(t *testing.T) {


### PR DESCRIPTION
assert.NotNil always returns true for values that can't be nil e.g. string values. Assert.NotEmpty is more comprehensive and caters to empty strings, slice and nil values.
