### PR TITLE
WIP - 1205 - Create and implement connectiondetails module within TCP module

### DIFF
--- a/internal/plugin/connectors/tcp/connectiondetails/connection_details.go
+++ b/internal/plugin/connectors/tcp/connectiondetails/connection_details.go
@@ -1,0 +1,82 @@
+package connectiondetails
+
+import (
+	"net"
+)
+
+// ConnectionDetails stores the connection info to the real backend database.
+// These values are pulled from the SingleUseConnector credentials config
+//
+// Any named parameter besides Options is assumed to be required.
+type ConnectionDetails struct {
+	Host       string
+	Port       string
+	Username   string
+	Password   string
+	Options    map[string]string
+}
+
+// Handler defines custom functions for handling parameters that are
+// not shared by all connectors
+type Handler func(credentials map[string][]byte) (map[string]string, error)
+
+// NewConnectionDetails is a constructor of ConnectionDetails structure from a
+// map of credentials.
+func NewConnectionDetails(credentials map[string][]byte,
+	defaultPort string,
+	customHandlers ...Handler) (
+	*ConnectionDetails, error) {
+
+	connDetails := &ConnectionDetails{
+		Options: make(map[string]string),
+	}
+
+	// Required Credentials
+	if len(credentials["host"]) > 0 {
+		connDetails.Host = string(credentials["host"])
+	}
+
+	connDetails.Port = defaultPort
+	if len(credentials["port"]) > 0 {
+		connDetails.Port = string(credentials["port"])
+	}
+
+	if len(credentials["username"]) > 0 {
+		connDetails.Username = string(credentials["username"])
+	}
+
+	if len(credentials["password"]) > 0 {
+		connDetails.Password = string(credentials["password"])
+	}
+
+	// Remove required credentials before continuing
+	delete(credentials, "host")
+	delete(credentials, "port")
+	delete(credentials, "username")
+	delete(credentials, "password")
+
+	// Add any non-required options to Options
+	for key, value := range credentials {
+		connDetails.Options[key] = string(value)
+	}
+
+	// Perform custom logic using any given handlers
+	for _, handler := range customHandlers {
+		customOptions, err := handler(credentials)
+		if err != nil {
+			return nil, err
+		}
+		for key, value := range customOptions {
+			connDetails.Options[key] = value
+		}
+	}
+
+	return connDetails, nil
+}
+
+// Address returns a string representing the network location (host and port)
+// of a server.  This is the string you would would typically use to
+// connect to the database -- eg, in cmd line tools.
+func (cd *ConnectionDetails) Address() string {
+	return net.JoinHostPort(cd.Host, cd.Port)
+}

--- a/internal/plugin/connectors/tcp/connectiondetails/connection_details_test.go
+++ b/internal/plugin/connectors/tcp/connectiondetails/connection_details_test.go
@@ -1,0 +1,97 @@
+package connectiondetails
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type args struct {
+	credentials map[string][]byte
+}
+
+var defaultTestPort = "1234"
+
+var defaultConnectionDetails = &ConnectionDetails{
+	Username: "herp",
+	Password: "derp",
+	Host:     "0.0.0.0",
+	Port:     "1234",
+	Options: map[string]string{
+		"sslmode":"require",
+		"sslrootcert":"foo",
+	},
+}
+
+var emptyConnectionDetails = &ConnectionDetails{
+	Port: defaultTestPort,
+	Options: map[string]string{},
+}
+
+func TestConnectionDetails_Address(t *testing.T) {
+	testCases := []struct {
+		description string
+		fields      *ConnectionDetails
+		expected    string
+	}{
+		{
+			description: "expected valid input",
+			fields:      defaultConnectionDetails,
+			expected:    "0.0.0.0:1234",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			cd := &ConnectionDetails{
+				Host:      tc.fields.Host,
+				Port:      tc.fields.Port,
+				Username:  tc.fields.Username,
+				Password:  tc.fields.Password,
+				Options: tc.fields.Options,
+			}
+
+			assert.Equal(t, tc.expected, cd.Address())
+		})
+	}
+}
+
+func TestNewConnectionDetails(t *testing.T) {
+	testCases := []struct {
+		description string
+		args        args
+		expected    *ConnectionDetails
+	}{
+		{
+			description: "expected valid credentials",
+			args: args{
+				credentials: map[string][]byte{
+					"username":    []byte("herp"),
+					"password":    []byte("derp"),
+					"host":        []byte("0.0.0.0"),
+					"port":        []byte("1234"),
+					"sslmode":     []byte("require"),
+					"sslrootcert": []byte("foo"),
+				},
+			},
+			expected: defaultConnectionDetails,
+		},
+		{
+			description: "nil credentials",
+			args: args{
+				credentials: map[string][]byte{
+				},
+			},
+			expected: emptyConnectionDetails,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			actualConnDetails, _ := NewConnectionDetails(
+				tc.args.credentials,
+				defaultTestPort,
+				)
+
+			assert.Equal(t, tc.expected, actualConnDetails)
+		})
+	}
+}

--- a/internal/plugin/connectors/tcp/mssql/connector.go
+++ b/internal/plugin/connectors/tcp/mssql/connector.go
@@ -190,7 +190,7 @@ func (connector *SingleUseConnector) Connect(
 	// Prepare connection details from the client, formatted for MSSQL
 	// TODO: find out if it is possible to send errors during prelogin-phase
 	// TODO: send error to client on failed credential validation
-	connDetails := NewConnectionDetails(credentialValuesByID)
+	connDetails, _ := NewConnectionDetails(credentialValuesByID)
 
 	// Create a new MSSQL connector
 	// Using DSN (Data Source Name) string because gomssql forces us to.
@@ -198,7 +198,7 @@ func (connector *SingleUseConnector) Connect(
 	// NOTE: Secretless has some unfortunate naming collisions with the
 	// go-mssqldb driver package.  The driver package has its own concept of a
 	// "connector", and its connectors also have a "Connect" method.
-	driverConnector, err := connector.NewMSSQLConnector(connDetails.URL())
+	driverConnector, err := connector.NewMSSQLConnector(URL(connDetails))
 	if err != nil {
 		wrappedError := errors.Wrap(err, "failed to create a go-mssqldb connector")
 		connector.writeErrorToClient(wrappedError)


### PR DESCRIPTION
- Created connectiondetails module with functionality matching existing
best practices and implementations across the three TCP connectors

- Relocated tests for the top level constructor in connectiondetails

- Modified mssql connector to use abstracted connection details

Todo:
- Add tests in the mssql connector for NewConnectionDetails
- Implement connectiondetails in mysql and pg adapters
