### PR TITLE
Fix incorrect variable usage in MsSQL Connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Updated RH image push to ensure we're logged into the RH container registry
   appropriately before pushing (#1149)
+- Fixed a stack overflow issue when running multiple multiple connections to an MsSQL
+  server consecutively
 
 ## [1.5.1] - 2020-02-12
 

--- a/internal/plugin/connectors/tcp/mssql/connection_details.go
+++ b/internal/plugin/connectors/tcp/mssql/connection_details.go
@@ -42,7 +42,7 @@ const (
 	sslModeVerifyFull = "verify-full"
 )
 
-var defaultSSLMode = []byte(sslModeRequire)
+const defaultSSLMode = sslModeRequire
 
 const defaultMSSQLPort = uint(1433)
 
@@ -80,7 +80,7 @@ func newSSLParams(credentials map[string][]byte) map[string]string {
 	params, ok := sslModeToBaseParams[sslMode]
 
 	if !ok {
-		credentials["sslmode"] = defaultSSLMode
+		credentials["sslmode"] = []byte(defaultSSLMode)
 		return newSSLParams(credentials)
 	}
 


### PR DESCRIPTION
By passing a variable into the credentials map,
we open ourselves up to an infinite loop. The variable
will be zeroed at the end of the usage for the
credentials map, which will break functionality.