### PR TITLE
Allow sslmodes in mssql juxtaposer driver

### DIFF
--- a/bin/juxtaposer/tester/db/mssql/mssql.go
+++ b/bin/juxtaposer/tester/db/mssql/mssql.go
@@ -40,10 +40,6 @@ func (tester *MssqlTester) GetQueryMarkers(length int) string {
 
 // Connect is used to initialize a testing connection to the SQL database
 func (tester *MssqlTester) Connect(options api.DbTesterOptions) error {
-	if options.SslMode != "" {
-		return fmt.Errorf("mssql driver doesn't support sslmodes")
-	}
-
 	if options.Port == "" {
 		options.Port = "1433"
 	}


### PR DESCRIPTION
Removes statement that disallows sslmodes 