### PR TITLE
1212 - Generic HTTP Config Example for Elasticsearch

### DIFF
--- a/examples/generic_connector_configs/README.md
+++ b/examples/generic_connector_configs/README.md
@@ -8,9 +8,14 @@ requires to authenticate.
 
 ## Sample Configurations
 
+> Note: The following examples use the [Keychain provider](https://docs.cyberark.com/Product-Doc/OnlineHelp/AAM-DAP/11.3/en/Content/References/providers/scl_keychain.htm?TocPath=Fundamentals%7CSecretless%20Pattern%7CSecret%20Providers%7C_____5).
+> Replace the service prefix `service#` with an appropriate service
+> or use a different provider as needed.
+
 |HTTP Service|Config File|Example Usage|
 |---|---|---|
 |[GitHub API](https://developer.github.com/v3/)|[github_secretless.yml](./github_secretless.yml)|<ul><li>Edit the supplied configuration to get your [GitHub OAuth token](https://developer.github.com/v3/#oauth2-token-sent-in-a-header) from the correct provider/path.</li><li>Run Secretless with the supplied configuration</li><li>Query the GitHub API using `http_proxy=localhost:8081 curl api.github.com/{request}`</li></ul>|
+|[Elasticsearch API](https://www.elastic.co/guide/en/elasticsearch/reference/current)|[elasticsearch_secretless.yml](./elasticsearch_secretless.yml)|<ul><li>Edit the supplied configuration to get your Elasticsearch [Api Key](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html) or [OAuth token](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html)</li><li>Run secretless with the supplied configuration(s)</li><li>Query the Elasticsearch API using `http_proxy=localhost:9020 curl <Elasticsearch Endpoint URL>/{Request}`</li></ul>
 
 ## Contributing
 

--- a/examples/generic_connector_configs/elasticsearch_secretless.yml
+++ b/examples/generic_connector_configs/elasticsearch_secretless.yml
@@ -1,0 +1,31 @@
+version: 2
+services:
+  token-service:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:9030
+    credentials:
+      token:
+        from: keychain
+        get: service#elasticsearch/access_token
+    config:
+      headers:
+        Authorization: Bearer {{ .token }}
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http[s]*\:\/\/
+  api-key-service:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:9020
+    credentials:
+      id:
+        from: keychain
+        get: service#elasticsearch/api_key_id
+      api_key:
+        from: keychain
+        get: service#elasticsearch/api_key
+    config:
+      headers:
+        Authorization: ApiKey {{ printf "%s:%s" .id .api_key | base64 }}
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http[s]*\:\/\/

--- a/examples/generic_connector_configs/github_secretless.yml
+++ b/examples/generic_connector_configs/github_secretless.yml
@@ -6,7 +6,7 @@ services:
     credentials:
       token:
         from: keychain
-        get: summon#github/api_token
+        get: service#github/api_token
     config:
       headers:
         Authorization: token {{ .token }}


### PR DESCRIPTION
- secretless yml configuration for use with elasticsearch api

- Supports both access token and api key based accesses
