### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,25 @@
-#### What does this PR do (include background context, if relevant)?
+### What does this PR do?
+- _What's changed? Why were these changes made?_
+- _How should the reviewer approach this PR, especially if manual tests are required?_
+- _Are there relevant screenshots you can add to the PR description?_
 
-#### What ticket does this PR close?
+### What ticket does this PR close?
 Connected to #[relevant GitHub issues, eg 76]
 
-#### Where should the reviewer start?
+### Checklists
 
-#### What is the status of the manual tests?
-Have you run the following manual tests to verify existing functionality continues to function as expected?
+#### Change log
+- [ ] The CHANGELOG has been updated, or
+- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update
+
+#### Test coverage
+- [ ] This PR includes new unit and integration tests to go with the code changes, or
+- [ ] The changes in this PR do not require tests
+
+#### Documentation
+- [ ] This PR does not require updating any documentation, or
+- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
+
+#### (For releases only) Manual tests
 - [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
 - [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
-
-If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
-- [ ] An updated README with instructions on how to manually test this feature
-- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
-- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)
-
-#### Links to open issues for related automated integration and unit tests
-
-#### Links to open issues for related documentation (in READMEs, docs, etc)
-
-#### Screenshots (if appropriate)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,34 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.6.0] - 2020-05-04
+
 ### Added
-- Introduce `SECRETLESS_HTTP_CA_BUNDLE` environment variable, which provides a
-  path to a bundle of CA certificates to append to the certificate pool used 
-  for verification by all http service connectors
-  [#1180](https://github.com/cyberark/secretless-broker/pull/1180)
+- Support for a `SECRETLESS_HTTP_CA_BUNDLE` environment variable that specifies
+  the path to a CA cert bundle and enables users to configure Secretless with
+  additional CA certificates for server cert verification when using HTTP
+  connectors.
+  [PR #1180](https://github.com/cyberark/secretless-broker/pull/1180)
+- TLS support for the Secretless-to-server connections of the MSSQL connector.
+  This is the recommended way to secure this connection and achieves feature
+  parity with other TLS connectors.
+  [#1163](https://github.com/cyberark/secretless-broker/issues/1163),
+  [#1164](https://github.com/cyberark/secretless-broker/issues/1164),
+  [#1165](https://github.com/cyberark/secretless-broker/issues/1165)
+- MSSQL connector supports SSL host name verification with `verify-full` SSL
+  mode. Also adds optional `sslhost` configuration parameter that is compared to
+  the server's certificate SAN.
+  [#1199](https://github.com/cyberark/secretless-broker/issues/1199)
+
+### Fixed
+- PostgreSQL connector log messages were updated to improve formatting, fixing
+  a previous issue where the log messages were improperly formatted and were
+  garbled in the logs. [PR #1192](https://github.com/cyberark/secretless-broker/pull/1192)
+
+### Security
+- TCP connectors all automatically zeroize the connection credentials in memory
+  after successfully opening a connection; previously, credentials were only
+  zeroized in memory on error. [#1188](https://github.com/cyberark/secretless-broker/issues/1188)
 
 ## [1.5.2] - 2020-02-24
 
@@ -463,7 +486,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.5.2...HEAD
+[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.6.0...HEAD
 [0.2.0]: https://github.com/cyberark/secretless-broker/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/cyberark/secretless-broker/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/cyberark/secretless-broker/compare/v0.3.0...v0.4.0
@@ -488,3 +511,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [1.5.0]: https://github.com/cyberark/secretless-broker/compare/v1.4.2...v1.5.0
 [1.5.1]: https://github.com/cyberark/secretless-broker/compare/v1.5.0...v1.5.1
 [1.5.2]: https://github.com/cyberark/secretless-broker/compare/v1.5.1...v1.5.2
+[1.6.0]: https://github.com/cyberark/secretless-broker/compare/v1.5.2...v1.6.0

--- a/pkg/secretless/version.go
+++ b/pkg/secretless/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the broker
-var Version = "1.5.2"
+var Version = "1.6.0"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
#### What does this PR do (include background context, if relevant)?

Bumps the project version to 1.6.0 in preparation for a new Secretless pre-release.

#### What ticket does this PR close?
n/a

#### Where should the reviewer start?

#### What is the status of the manual tests?
Have you run the following manual tests to verify existing functionality continues to function as expected?
- [x] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [x] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

If this feature does not have any/sufficent automated tests, have you created/updated a folder in `test/manual` that includes:
- [ ] An updated README with instructions on how to manually test this feature
- [ ] Utility `start` and `stop` scripts to spin up and tear down the test environments
- [ ] A `test` script to run some basic manual tests (optional; if does not exist, the README should have detailed instructions)

#### Links to open issues for related automated integration and unit tests

#### Links to open issues for related documentation (in READMEs, docs, etc)

#### Screenshots (if appropriate)
