### PR TITLE
Secretless publishes images on tag-triggered builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -169,15 +169,7 @@ pipeline {
       when { tag "v*" }
       steps {
         // The tag trigger sets TAG_NAME as an environment variable
-
-        // Clean up first
-        sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd'
-
         sh 'summon -e production ./bin/publish'
-
-        // Clean up again...
-        sh 'docker run -i --rm -v $PWD:/src -w /src alpine/git clean -fxd'
-        deleteDir()
       }
     }
 

--- a/bin/publish
+++ b/bin/publish
@@ -7,45 +7,29 @@ set -e
 readonly REGISTRY="cyberark"
 readonly VERSION="$(short_version_tag)"
 readonly FULL_VERSION_TAG="$(full_version_tag)"
-readonly INTERNAL_REGISTRY="registry.tld"
 readonly REDHAT_IMAGE="scan.connect.redhat.com/ospid-18d9f51d-9c0c-4031-9f9e-ef08aa2ff409/secretless-broker"
 readonly IMAGES=(
   "secretless-broker"
   "secretless-broker-quickstart"
 )
-
 readonly TAGS=(
   "$VERSION"
   "latest"
 )
 
-# fetching tags is required for git_description to work
-git fetch --tags
-git_description=$(git describe)
-
-for image_name in "${IMAGES[@]}"; do
-  # always push the tag with the commit hash to internal registry
-  echo "Tagging $INTERNAL_REGISTRY/$image_name:${FULL_VERSION_TAG}"
-  docker tag "$image_name:$FULL_VERSION_TAG" "$INTERNAL_REGISTRY/$image_name:$FULL_VERSION_TAG"
-  echo "Pushing $INTERNAL_REGISTRY/$image_name:${FULL_VERSION_TAG}"
-  docker push "$INTERNAL_REGISTRY/$image_name:$FULL_VERSION_TAG"
-
-  # if it’s not a tagged commit, VERSION will have extra junk (i.e. -g666c4b2), so we won’t publish that commit
-  # only when tag matches the VERSION, push VERSION and latest releases
-  # and x and x.y releases
-  if [ "$git_description" = "v${VERSION}" ]; then
-    echo "Revision $git_description matches version $VERSION exactly. Pushing to Dockerhub..."
+function main() {
+  for image_name in "${IMAGES[@]}"; do
+    image_with_tag="$image_name:$FULL_VERSION_TAG"
 
     for tag in "${TAGS[@]}" $(gen_versions "$VERSION"); do
-      echo "Tagging and pushing $REGISTRY/$image_name:$tag"
+      image_with_version_tag="${REGISTRY}/${image_name}:${tag}"
+      echo "Tagging and pushing ${image_with_version_tag}"
 
-      docker tag "$image_name:$FULL_VERSION_TAG" "$REGISTRY/$image_name:$tag"
-      docker push "$REGISTRY/$image_name:$tag"
+      docker tag "${image_with_tag}" "${image_with_version_tag}"
+      docker push "${image_with_version_tag}"
     done
-  fi
-done
+  done
 
-if [ "$git_description" = "v${VERSION}" ]; then
   # Publish only latest to Redhat Registries
   echo "Tagging and pushing ${REDHAT_IMAGE}"
 
@@ -61,4 +45,6 @@ if [ "$git_description" = "v${VERSION}" ]; then
     echo 'Failed to log in to scan.connect.redhat.com'
     exit 1
   fi
-fi
+}
+
+main

--- a/bin/publish
+++ b/bin/publish
@@ -1,13 +1,13 @@
 #!/bin/bash
 
+set -e
+
 if [[ -z "${TAG_NAME:-}" ]]; then
   echo "Please supply environment variable TAG_NAME."
   echo "If you see this error in Jenkins it means the publish script was run"
   echo "for a build that wasn't triggered by a tag - please check publish stage conditions."
   exit 1
 fi
-
-set -e
 
 . bin/build_utils
 
@@ -42,9 +42,7 @@ function main() {
 
   # Add 'latest' tag only when TAG_NAME is the highest semantic tag
   local LATEST_TAG
-  LATEST_TAG="$(
-    git for-each-ref refs/tags --sort=-refname --format='%(refname:short)' --count=1
-  )"
+  LATEST_TAG="$(git tag | sort -r --version-sort)"
   if [[ "${TAG_NAME}" == "${LATEST_TAG}" ]]; then
     TAGS+=('latest')
   fi

--- a/bin/publish
+++ b/bin/publish
@@ -12,24 +12,46 @@ readonly IMAGES=(
   "secretless-broker"
   "secretless-broker-quickstart"
 )
-readonly TAGS=(
-  "$VERSION"
-  "latest"
-)
 
 function main() {
   TAG_NAME="${TAG_NAME:-}"
 
-  # Compare TAG_NAME (without v prefix) to project version
+  # Ensure TAG_NAME version matches project version
   if [[ "${TAG_NAME#"v"}" != "${VERSION}" ]]; then
-    echo "TAG_NAME envvar must match project version";
+    echo "TAG_NAME envvar version was '${TAG_NAME#"v"}', expected '${VERSION}'";
+    echo "TAG_NAME envvar version must match project version";
     exit 1;
   fi
 
+  # Accumulate TAGS
+  #
+
+  local TAGS=(
+    "$VERSION"
+  )
+
+  # Add less specific version tags, eg. given 1.2.3, add 1.2 and 1
+  for tag in $(gen_versions "$VERSION"); do
+    TAGS+=("${tag}")
+  done
+
+  # Add 'latest' tag only when TAG_NAME is the highest semantic tag
+  local LATEST_TAG
+  LATEST_TAG="$(
+    git for-each-ref refs/tags --sort=-refname --format='%(refname:short)' --count=1
+  )"
+  if [[ "${TAG_NAME}" == "${LATEST_TAG}" ]]; then
+    TAGS+=('latest')
+  fi
+
+  # Publish
+  #
+
+  # Publish combinations of images and tags
   for image_name in "${IMAGES[@]}"; do
     image_with_tag="$image_name:$FULL_VERSION_TAG"
 
-    for tag in "${TAGS[@]}" $(gen_versions "$VERSION"); do
+    for tag in "${TAGS[@]}"; do
       image_with_version_tag="${REGISTRY}/${image_name}:${tag}"
       echo "Tagging and pushing ${image_with_version_tag}"
 

--- a/bin/publish
+++ b/bin/publish
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [[ -z "${TAG_NAME:-}" ]]; then
+  echo "Please supply environment variable TAG_NAME."
+  echo "If you see this error in Jenkins it means the publish script was run"
+  echo "for a build that wasn't triggered by a tag - please check publish stage conditions."
+  exit 1
+fi
+
 set -e
 
 . bin/build_utils
@@ -14,8 +21,6 @@ readonly IMAGES=(
 )
 
 function main() {
-  TAG_NAME="${TAG_NAME:-}"
-
   # Ensure TAG_NAME version matches project version
   if [[ "${TAG_NAME#"v"}" != "${VERSION}" ]]; then
     echo "TAG_NAME envvar version was '${TAG_NAME#"v"}', expected '${VERSION}'";

--- a/bin/publish
+++ b/bin/publish
@@ -18,6 +18,14 @@ readonly TAGS=(
 )
 
 function main() {
+  TAG_NAME="${TAG_NAME:-}"
+
+  # Compare TAG_NAME (without v prefix) to project version
+  if [[ "${TAG_NAME#"v"}" != "${VERSION}" ]]; then
+    echo "TAG_NAME envvar must match project version";
+    exit 1;
+  fi
+
   for image_name in "${IMAGES[@]}"; do
     image_with_tag="$image_name:$FULL_VERSION_TAG"
 

--- a/bin/publish_internal
+++ b/bin/publish_internal
@@ -4,7 +4,6 @@ set -e
 
 . bin/build_utils
 
-readonly REGISTRY="cyberark"
 readonly FULL_VERSION_TAG="$(full_version_tag)"
 readonly INTERNAL_REGISTRY="registry.tld"
 readonly IMAGES=(

--- a/bin/publish_internal
+++ b/bin/publish_internal
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+. bin/build_utils
+
+readonly REGISTRY="cyberark"
+readonly FULL_VERSION_TAG="$(full_version_tag)"
+readonly INTERNAL_REGISTRY="registry.tld"
+readonly IMAGES=(
+  "secretless-broker"
+  "secretless-broker-quickstart"
+)
+
+function main() {
+  for image_name in "${IMAGES[@]}"; do
+    image_with_tag="${image_name}:${FULL_VERSION_TAG}"
+    image_with_registry_and_tag="${INTERNAL_REGISTRY}/${image_with_tag}"
+
+    echo "Tagging ${image_with_registry_and_tag}"
+    docker tag "${image_with_tag}" "${image_with_registry_and_tag}"
+    echo "Pushing ${image_with_registry_and_tag}"
+    docker push "${image_with_registry_and_tag}"
+  done
+}
+
+main


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_
Non-internal images are published on tag-triggered builds
- _How should the reviewer approach this PR, especially if manual tests are required?_
The Jenkinsfile is the entrypoint to the change. The publishing steps have been split in 2. 
  1. An internal publish which happens only on master.
  2. A non-internal publish which happens only on tags.

  ~~**TODO** The non-internal publish happens to also publish latest. This isn't great because if there's a retagging then latest will represent some older version.~~
  ~~**TODO** Should we use the TAG_NAME env var from Jenkins or should we use the VERSION in the Go file. Most of the time they should be the same. What do we do when they're not!?~~

- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to https://github.com/cyberark/secretless-broker/issues/1233

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
