### PR TITLE
Use parse-a-changelog image

### DIFF
--- a/bin/parse-changelog
+++ b/bin/parse-changelog
@@ -1,11 +1,7 @@
 #!/bin/bash -ex
 
-cd "$(dirname "$0")"
+cd "$(dirname "$0")/.."
 
 docker run --rm \
-  -v "$PWD/..:/work" \
-  -w /work \
-  ruby:2.5 bash -ec "
-    gem install -N parse_a_changelog
-    parse ./CHANGELOG.md
-  "
+  --volume "${PWD}/CHANGELOG.md:/CHANGELOG.md"  \
+  cyberark/parse-a-changelog


### PR DESCRIPTION
### What does this PR do?
parse-a-changelog has its own Docker image. We need not manually install the `gem`.
