### PR TITLE
fix: Do not specify summon provider on draft release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,7 +187,7 @@ pipeline {
         }
         stage('Create draft release') {
           steps {
-            sh "summon --provider summon-conjur --yaml 'GITHUB_TOKEN: !var github/users/conjur-jenkins/api-token' ./bin/build_release"
+            sh "summon --yaml 'GITHUB_TOKEN: !var github/users/conjur-jenkins/api-token' ./bin/build_release"
             archiveArtifacts 'dist/goreleaser/'
           }
         }


### PR DESCRIPTION
This seems to be a Jenkins specific issue. Specifying `--provider summon-conjur` on `summon` results in `stat /usr/local/lib/summon/summon-conjur: no such file or directory`.


