### PR TITLE
Add PG int test exception to gitleaks

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -198,7 +198,8 @@ files = [
 ]
 regexes = [
   "AKIAJC5FABNOFVBKRWHA", # sample AWS key in AWS HTTP connector comments
-  "AKIAJADDJE4Q4JVX3HAA" # since-removed sample AWS key
+  "AKIAJADDJE4Q4JVX3HAA", # since-removed sample AWS key
+  "SuperSecure", # dummy password used in conjur integration test docker-compose
 ]
 commits = [
   "21c8edd1766c146dccdbf9fc4752c0588f8b00b6", # old commit with disabled API key


### PR DESCRIPTION
Adds gitleaks exception to a PG
docker-compose file that uses a dummy
password