### PR TITLE
Added a generic oauth2 http connector

### DIFF
--- a/examples/generic_connector_configs/README.md
+++ b/examples/generic_connector_configs/README.md
@@ -14,6 +14,7 @@ requires to authenticate.
 
 |HTTP Service|Config File|Example Usage|
 |---|---|---|
+|OAuth 2.0 APIs|[oauth2_secretless.yml](./oauth2_secretless.yml)|This configuration acts as a generic OAuth2 connector. It can be used with any service that requires a Bearer token Authorization header.<ul><li>Edit the supplied service configuration to get your OAuth token</li><li>Run secretless with the supplied configuration(s)</li><li>Query the API using `http_proxy=localhost:8071 curl <Your OAuth2 API Endpoint URL>/{Request}`</li></ul>
 |[GitHub API](https://developer.github.com/v3/)|[github_secretless.yml](./github_secretless.yml)|<ul><li>Edit the supplied configuration to get your [GitHub OAuth token](https://developer.github.com/v3/#oauth2-token-sent-in-a-header) from the correct provider/path.</li><li>Run Secretless with the supplied configuration</li><li>Query the GitHub API using `http_proxy=localhost:8081 curl api.github.com/{request}`</li></ul>|
 |[Elasticsearch API](https://www.elastic.co/guide/en/elasticsearch/reference/current)|[elasticsearch_secretless.yml](./elasticsearch_secretless.yml)|<ul><li>Edit the supplied configuration to get your Elasticsearch [Api Key](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-create-api-key.html) or [OAuth token](https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-token.html)</li><li>Run secretless with the supplied configuration(s)</li><li>Query the Elasticsearch API using `http_proxy=localhost:9020 curl <Elasticsearch Endpoint URL>/{Request}`</li></ul>
 

--- a/examples/generic_connector_configs/oauth2_secretless.yml
+++ b/examples/generic_connector_configs/oauth2_secretless.yml
@@ -1,0 +1,15 @@
+version: 2
+services:
+  generic-oauth2:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8071
+    credentials:
+      token:
+        from: keychain
+        get: service#generic/temp-token
+    config:
+      headers:
+        Authorization: Bearer {{ .token }}
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http[s]*


### PR DESCRIPTION
### What does this PR do?
- Added a generic OAuth2 HTTP Connector for Secreless Broker

### What ticket does this PR close?
Connected to #328 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
