### PR TITLE
HTTP Generic Connector supports URL parameter injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - MySQL and PostgreSQL connectors support SSL host name verification with
   `verify-full` SSL mode. Also adds optional `sslhost` configuration parameter
   that is compared to the server's certificate SAN. [#548](https://github.com/cyberark/secretless-broker/issues/548)
+- Generic HTTP connector now supports `queryParam` as a configurable section
+  in the secretless configuration file, under `config`. This allows the
+  construction of a query string which can have credentials injected
+  as needed. [#1290](https://github.com/cyberark/secretless-broker/issues/1290)
 
 ## [1.6.0] - 2020-05-04
 

--- a/internal/plugin/connectors/http/generic/README.md
+++ b/internal/plugin/connectors/http/generic/README.md
@@ -67,11 +67,16 @@ services:
       password:
         from: conjur
         get: somepassword
+      address:
+        from: conjur
+        get: address
     config:
       credentialValidations:
         username: '[^:]+'    # username cannot contain a colon
       headers:
         Authorization: "Basic {{ printf \"%s:%s\" .username .password | base64 }}"
+      queryParams:
+        location: "{{ .address }}"
       forceSSL: true
       authenticateURLsMatching:
         - ^http
@@ -96,6 +101,41 @@ template](https://golang.org/pkg/text/template/), as defined in the
 You can refer to your credentials in this template using the credential name
 preceded by a `.` (eg, `.username` and `.password` refer to the credentials
 `username` and `password`). At runtime, Secretless will replace these
+credential references with your real credentials.
+
+As you can see in the Basic auth example, the `text/template` package has
+powerful transformation features.  You can use `printf` for formatting and
+compose functions using pipes `|`.  See the text template package docs linked
+above for detailed information on these and other features.
+
+### `queryParams`
+
+Like `headers`, this is another key section. The `queryParams` section
+is used to generate a query string, which is appended to your existing URL
+without replacing any existing query parameters.
+
+The _keys_ of the queryParams are defined by the yaml keys.  In the examples
+above, these query parameter key is `location`.
+
+The query parameter _values_ are defined using a [Go text
+template](https://golang.org/pkg/text/template/), as defined in the
+`text/template` package.
+
+In the above example, let us say that your request URL looks like the following,
+
+```
+http://anything.com/foo?fruit=apple
+```
+
+After proxying through secretless, your request URL would look like the following,
+
+```
+http://anything.com/foo?location=valueofaddress&fruit=apple
+```
+
+You can refer to your credentials in this template using the credential name
+preceded by a `.` (eg, `.address` will refer to the credential
+`address`). At runtime, Secretless will replace these
 credential references with your real credentials.
 
 As you can see in the Basic auth example, the `text/template` package has

--- a/internal/plugin/connectors/http/generic/README.md
+++ b/internal/plugin/connectors/http/generic/README.md
@@ -140,7 +140,7 @@ credential references with your real credentials.
 
 As you can see in the Basic auth example, the `text/template` package has
 powerful transformation features.  You can use `printf` for formatting and
-compose functions using pipes `|`.  See the text template package docs linked
+you can compose functions using pipes `|`.  See the text template package docs linked
 above for detailed information on these and other features.
 
 #### `credentialValidations`

--- a/internal/plugin/connectors/http/generic/README.md
+++ b/internal/plugin/connectors/http/generic/README.md
@@ -115,7 +115,7 @@ is used to generate a query string, which is appended to your existing URL
 without replacing any existing query parameters.
 
 The _keys_ of the queryParams are defined by the yaml keys.  In the examples
-above, these query parameter key is `location`.
+above, the query parameter key is `location`.
 
 The query parameter _values_ are defined using a [Go text
 template](https://golang.org/pkg/text/template/), as defined in the

--- a/internal/plugin/connectors/http/generic/connector.go
+++ b/internal/plugin/connectors/http/generic/connector.go
@@ -30,13 +30,20 @@ func (c *Connector) Connect(
 	}
 
 	// Add configured headers to request
-	headers, err := c.config.renderedHeaders(credentialsByID)
+	headers, err := renderTemplates(c.config.Headers, credentialsByID)
 	if err != nil {
 		return fmt.Errorf("failed to render headers: %s", err)
 	}
 	for headerName, headerVal := range headers {
 		r.Header.Set(headerName, headerVal)
 	}
+
+	// Add configured params to request
+	params, err := renderTemplates(c.config.QueryParams, credentialsByID)
+	if err != nil {
+		return fmt.Errorf("failed to render query params: %s", err)
+	}
+	r.URL.RawQuery = appendQueryParams(*r.URL, params)
 
 	return nil
 }

--- a/internal/plugin/connectors/http/generic/external_api.go
+++ b/internal/plugin/connectors/http/generic/external_api.go
@@ -20,6 +20,7 @@ import (
 type ConfigYAML struct {
 	CredentialValidations map[string]string `yaml:"credentialValidations"`
 	Headers               map[string]string `yaml:"headers"`
+	QueryParams           map[string]string `yaml:"queryParams"`
 	ForceSSL              bool              `yaml:"forceSSL"`
 }
 

--- a/internal/plugin/connectors/http/proxy_service.go
+++ b/internal/plugin/connectors/http/proxy_service.go
@@ -136,20 +136,20 @@ func (proxy *proxyService) selectSubservice(r *gohttp.Request) *Subservice {
 	// No match: Warn!
 	if len(matchingSubs) == 0 {
 		msg := "No subservices matched request '%s'"
-		proxy.logger.Warnf(msg, r.URL.String())
+		proxy.logger.Warnf(msg, r.URL.Host)
 		return nil
 	}
 
 	// Multiple matches: Warn!
 	if len(matchingSubs) > 1 {
 		msg := "Multiple subservices matched request '%s': %v\n"
-		proxy.logger.Warnf(msg, r.URL.String(), matchingSubs)
+		proxy.logger.Warnf(msg, r.URL.Host, matchingSubs)
 	}
 
 	// Select first (or only) match
 	subservice := matchingSubs[0]
 	msg := "Using connector '%s' for request %s"
-	proxy.logger.Debugf(msg, subservice.ConnectorID, r.URL.String())
+	proxy.logger.Debugf(msg, subservice.ConnectorID, r.URL.Host)
 	return &subservice
 }
 
@@ -158,9 +158,8 @@ func (proxy *proxyService) ServeHTTP(w gohttp.ResponseWriter, r *gohttp.Request)
 	logger := proxy.logger
 
 	// Log request
-
 	logMsg := "Got request %v %v %v %v"
-	logger.Debugf(logMsg, r.URL.Path, r.Host, r.Method, r.URL.String())
+	logger.Debugf(logMsg, r.URL.Path, r.Host, r.Method, r.URL.Hostname())
 
 	// Validate request
 


### PR DESCRIPTION
## What does this PR do?
This PR provides support for `query params` in the config for the generic HTTP connector. This will allow the building of a query string, with any necessary credentials injected into it.

- modified 'renderHeader' function to allow rendering of multiple input fields of the same type
- Moved the validation and saving of template strings to its own function to reduce code reuse
- Added support for passing query parameters through a secretless configuration file, and appending them to the url in the http request

To manually test this, add the `queryParam` section to the `config` subsection of a `secretless.yml` file. Add a dummy key and value (ex. foo: "bar"), and then use secretless as a proxy for an http request. The key and value should be appended to your request, and your response will reflect this.

### What ticket does this PR close?
Connected to #1290 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
  - Added unit tests for parsing of query params

- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch