### PR TITLE
Added a generic HTTP config for the Stripe API

### DIFF
--- a/examples/generic_connector_configs/README.md
+++ b/examples/generic_connector_configs/README.md
@@ -7,6 +7,7 @@
   * [OAuth 2.0 API](#oauth-20-api)
   * [Slack Web API](#slack-web-api)
   * [Splunk API](#splunk-api)
+  * [Stripe API](#stripe-api)
 * [Contributing](#contributing)
 
 ## Introduction
@@ -212,6 +213,41 @@ to the backend server uses SSL.
     </code>
     <li>On another terminal window, make a request to Splunk using Secretless</li>
     <code>http_proxy=localhost:8081 curl -k -X GET SplunkServerDefaultCert:8089/services/apps/local</code>
+  </ol>
+</details>
+
+___
+
+### Stripe API
+This example can be used to interact with [Stripe's API](https://stripe.com/docs/api).
+
+The configuration file for the Stripe API can be found at [stripe_secretless.yml](./stripe_secretless.yml).
+
+This example supports several header configurations, so it is recommended to
+look at [stripe_secretless.yml](./stripe_secretless.yml) to figure out which
+one should be used.
+
+#### How to use this connector
+* Get the [Stripe API Key](https://dashboard.stripe.com/apikeys), which can be used as a Bearer token
+* Get a [connected account](https://stripe.com/docs/connect/authentication) or generate an [idempotency key](https://stripe.com/docs/api/idempotent_requests) if needed
+* Query the Striple API using `http_proxy=localhost:80*1 curl api.stripe.com/{route}`.
+
+#### Example Usage
+<details>
+  <summary><b>How to use this connector locally</b></summary>
+  <ol>
+    <li>Get the Stripe test <a href="https://dashboard.stripe.com/apikeys">API Key</a></li>
+    <li>Save the local token from Slack into the OSX keychain</li>
+    <li>Run Secretless locally</li>
+    <code>
+    ./dist/darwin/amd64/secretless-broker \
+    <br />
+    -f examples/generic_connector_configs/stripe_secretless.yml
+    </code>
+    <li>On another terminal window, make a request to Stripe using Secretless</li>
+    <code>
+    http_proxy=localhost:{secretless-server} curl api.stripe.com/v1/charges
+    </code>
   </ol>
 </details>
 

--- a/examples/generic_connector_configs/stripe_secretless.yml
+++ b/examples/generic_connector_configs/stripe_secretless.yml
@@ -1,0 +1,90 @@
+version: 2
+services:
+  # The stripe service supports connecting to Stripe's API via a Bearer token.
+  # A Bearer token can be used
+  #
+  # More information about this service can be found here:
+  # https://stripe.com/docs/api/authentication
+  stripe:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8071
+    credentials:
+      token:
+        from: keychain
+        get: service#stripe/token
+    config:
+      headers:
+        Authorization: Bearer {{ .token }}
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http[s]*\:\/\/api\.stripe\.com*
+  # The stripe-account service supports a Bearer token and a Stripe Account
+  # header. This service can be used if you want to securely connect a client's
+  # account to the Stripe API using Secretless.
+  #
+  # More information about this service can be found here:
+  # https://stripe.com/docs/api/connected_accounts
+  stripe-account:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8081
+    credentials:
+      token:
+        from: keychain
+        get: service#stripe/token
+      stripe_account:
+        from: keychain
+        get: service#stripe/account-id
+    config:
+      headers:
+        Authorization: Bearer {{ .token }}
+        Stripe-Account: "{{ .stripe_account }}"
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http[s]*\:\/\/api\.stripe\.com*
+  # The stripe-idempotency service supports a Bearer token and an
+  # Indempotency-Key header. This is useful when an API call is disrupted in
+  # transit and you do not receive a response.
+  #
+  # More information about this service can be found here:
+  # https://stripe.com/docs/api/idempotent_requests
+  stripe-idempotency:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8091
+    credentials:
+      token:
+        from: keychain
+        get: service#stripe/token
+      idempotency_key:
+        from: keychain
+        get: service#stripe/indempotency-key
+    config:
+      headers:
+        Authorization: Bearer {{ .token }}
+        Idempotency-Key: "{{ .idempotency_key }}"
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http[s]*\:\/\/api\.stripe\.com*
+  # The stripe-account-dempotency service supports a Bearer token, Stripe
+  # Account and Idempotency-Key header. This service can be used if an API call
+  # to a Stripe Account is disrupted in transit and does not receive a response.
+  stripe-account-idempotency:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:9001
+    credentials:
+      token:
+        from: keychain
+        get: service#stripe/token
+      stripe_account:
+        from: keychain
+        get: service#stripe/account-id
+      idempotency_key:
+        from: keychain
+        get: service#service/idempotency-key
+    config:
+      headers:
+        Authorization: Bearer {{ .token }}
+        Stripe-Account: "{{ .stripe_account }}"
+        Idempotency-Key: "{{ .idempotency_key }}"
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http[s]*\:\/\/api\.stripe\.com*


### PR DESCRIPTION
### What does this PR do?
- Added a generic HTTP config for the Stripe API
### What ticket does this PR close?
Connected to #1267 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
