### PR TITLE
Bumping base Alpine container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Secretless and secretless-redhat containers now use Alpine 3.12 as their base
+  image. [PR #1296](https://github.com/cyberark/secretless-broker/pull/1296)
 - MySQL and PostgreSQL connectors support SSL host name verification with
   `verify-full` SSL mode. Also adds optional `sslhost` configuration parameter
   that is compared to the server's certificate SAN. [#548](https://github.com/cyberark/secretless-broker/issues/548)

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN go build -ldflags="-X github.com/cyberark/secretless-broker/pkg/secretless.T
 
 
 # =================== MAIN CONTAINER ===================
-FROM alpine:3.8 as secretless-broker
+FROM alpine:3.12 as secretless-broker
 MAINTAINER CyberArk Software, Inc.
 
 RUN apk add -u shadow libc6-compat && \

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -35,7 +35,7 @@ RUN go build -ldflags="-X github.com/cyberark/secretless-broker/pkg/secretless.T
 
 
 # =================== MAIN CONTAINER ===================
-FROM alpine:3.8 as secretless-broker
+FROM alpine:3.12 as secretless-broker
 MAINTAINER CyberArk Software, Inc.
 
 RUN apk add -u shadow libc6-compat && \


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Changes the base Alpine container to 3.12 to preserve ongoing trivy scanning

### What ticket does this PR close?


### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
