### PR TITLE
Update Redhat image dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,8 @@ LABEL description="Secretless Broker is a connection broker which relieves clien
 applications of the need to directly handle secrets to target services"
 
     # Add Limited user
-RUN groupadd -r secretless \
+RUN yum update dbus && \
+    groupadd -r secretless \
              -g 777 && \
     useradd -c "secretless runner account" \
             -g secretless \


### PR DESCRIPTION
### What does this PR do?
The `dbus` dependency in our Redhat image
requires updating for security reasons

### What ticket does this PR close?
None

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [X] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
