### PR TITLE
Add Generic HTTP Config for Papertrail

### DIFF
--- a/examples/generic_connector_configs/README.md
+++ b/examples/generic_connector_configs/README.md
@@ -11,6 +11,7 @@
   * [Google Maps API](#google-maps-api)
   * [Mailchimp API](#mailchimp-api)
   * [OAuth 2.0 API](#oauth-20-api)
+  * [Papertrail API](#papertrail-api)
   * [SendGrid Web API](#sendgrid-web-api)
   * [Slack Web API](#slack-web-api)
   * [Splunk API](#splunk-api)
@@ -437,6 +438,47 @@ The configuration file for the OAuth 2.0 API can be found at
   ```
   http_proxy=localhost:8071 curl {Your OAuth2 API Endpoint URL}/{Request}
   ```
+
+___
+
+### Papertrail API
+
+This example can be used to interact with the
+[Papertrail API](https://help.papertrailapp.com/kb/how-it-works/http-api/).
+
+The configuration file for the SendGrid Web API can be found at
+[papertrail_secretless.yml](./papertrail_secretless.yml).
+
+#### How to use this connector
+
+* Edit the supplied configuration to get your
+[API Key](https://papertrailapp.com/account/profile)
+
+* Run Secretless with the supplied configuration(s)
+
+* Query the API using
+  ```
+  http_proxy=localhost:8071 curl papertrailapp.com/api/v1/{Request}
+  ```
+
+#### Example Usage
+<details>
+  <summary><b>Example setup to try this out locally...</b></summary>
+
+  1. Retrieve your API token from your Profile
+  1. Store the token from your request in your local credential manager so
+    that it may be retrieved in your `secretless.yml`
+  1. Run Secretless locally
+     ```
+     ./dist/darwin/amd64/secretless-broker \
+     -f examples/generic_connector_configs/papertrail_secretless.yml
+     ```
+  1. In another terminal window, make a request to Papertrail using Secretless
+     ```
+      http_proxy=localhost:8043 curl papertrailapp.com/api/v1/systems.json
+     ```
+
+</details>
 
 ___
 

--- a/examples/generic_connector_configs/papertrail_secretless.yml
+++ b/examples/generic_connector_configs/papertrail_secretless.yml
@@ -1,0 +1,34 @@
+version: 2
+services:
+# For authenticating with a Papertrail API Token
+  papertrail-token:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8042
+    credentials:
+      token:
+        from: keychain
+        get: service#papertrail/api-token
+    config:
+      headers:
+        X-Papertrail-Token: "{{ .token }}"
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http[s]*\:\/\/papertrailapp\.com\/api\/v1\/
+# For authenticating with Basic Auth credentials
+  papertrail-basic:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8043
+    credentials:
+        user:
+            from: keychain
+            get: service#papertrail/username
+        pass:
+            from: keychain
+            get: service#papertrail/password
+    config:
+        headers:
+            Authorization: Basic {{ printf "%s:%s" .user .pass | base64 }}
+        forceSSL: true
+        authenticateURLsMatching:
+        - ^http[s]*\:\/\/papertrailapp\.com\/api\/v1\/
+        


### PR DESCRIPTION
### What does this PR do?
Adds a new generic HTTP connector for Papertrail

### What ticket does this PR close?
Connected to #https://github.com/cyberark/secretless-broker/issues/1276

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ x ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ x ] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [ x ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

~~#### (For releases only) Manual tests~~
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
