### PR TITLE
Added OAuth1 functionality to the generic HTTP connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   in the secretless configuration file, under `config`. This allows the
   construction of a query string which can have credentials injected
   as needed. [#1290](https://github.com/cyberark/secretless-broker/issues/1290)
+- Generic HTTP connector now supports `oauth1` as a configurable section in the
+  secretless configuration file, under `config`. This allows the construction of
+  a header for an OAuth 1.0 request. The OAuth 1.0 feature currently only supports
+  HMAC-SHA1, but there is an [issue](https://github.com/cyberark/secretless-broker/issues/1324)
+  logged to support other hashing methods. [#1297](https://github.com/cyberark/secretless-broker/issues/1297)
 
 ## [1.6.0] - 2020-05-04
 

--- a/examples/generic_connector_configs/twitter_secretless.yml
+++ b/examples/generic_connector_configs/twitter_secretless.yml
@@ -14,3 +14,28 @@ services:
       forceSSL: true
       authenticateURLsMatching:
         - ^http[s]*\:\/\/api\.twitter\.com*
+  twitter-oauth1:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8061
+    credentials:
+      consumer_key:
+        from: keychain
+        get: service#twitter/consumer-key
+      consumer_secret:
+        from: keychain
+        get: service#twitter/consumer-secret
+      token:
+        from: keychain
+        get: service#twitter/token
+      token_secret:
+        from: keychain
+        get: service#twitter/token-secret
+    config:
+      forceSSL: true
+      oauth1:
+        consumer_key: "{{ .consumer_key }}"
+        consumer_secret: "{{ .consumer_secret }}"
+        token: "{{ .token }}"
+        token_secret: "{{ .token_secret }}"
+      authenticateURLsMatching:
+        - ^http[s]*\:\/\/api\.twitter\.com*

--- a/internal/plugin/connectors/http/generic/README.md
+++ b/internal/plugin/connectors/http/generic/README.md
@@ -34,7 +34,7 @@ services:
     connector: generic_http
     listenOn: tcp://0.0.0.0:8080
     credentials:
-      apikey: 
+      apikey:
         from: conjur
         get: my-services-api-key  # the id of your API key within conjur
     config:
@@ -61,7 +61,7 @@ services:
     connector: generic_http
     listenOn: tcp://0.0.0.0:8080
     credentials:
-      username: 
+      username:
         from: conjur
         get: someuser
       password:
@@ -123,13 +123,13 @@ template](https://golang.org/pkg/text/template/), as defined in the
 
 In the above example, let us say that your request URL looks like the following,
 
-```
+```http
 http://anything.com/foo?fruit=apple
 ```
 
 After proxying through secretless, your request URL would look like the following,
 
-```
+```http
 http://anything.com/foo?location=valueofaddress&fruit=apple
 ```
 
@@ -143,6 +143,69 @@ powerful transformation features.  You can use `printf` for formatting and
 you can compose functions using pipes `|`.  See the text template package docs linked
 above for detailed information on these and other features.
 
+### `oauth1`
+
+Like `headers` this is another key section. The `oauth1` section is used to generate
+an OAuth1 `Authorization` header.
+
+**Note: Declaring an `Authorization` header in the `config`
+ while `oauth1` is present will throw an error:
+ `authorization header already exists, cannot override header`**
+
+There are four required _keys_ for the `oauth1` section which are as follows:
+
+1. `consumer_key` - A value used by the consumer to identify itself to
+   the service provider.
+1. `consumer_secret` - A secret used by the consumer to establish ownership
+   of the consumer key.
+1. `token` - A value used by the consumer to gain access to the protected
+   resources on behalf of the user, instead of using the user’s service
+   provider credentials.
+1. `token_secret` - A secret used by the consumer to establish ownership of
+   a given token.
+
+The oauth1 _values_ are defined using a [Go text
+template](https://golang.org/pkg/text/template/), as defined in the
+`text/template` package.
+
+You can refer to your credentials in this template using the credential name
+preceded by a `.` (e.g. `.consumer_key` and `.token` refer to the credentials
+`consumer_key` and `token`). At runtime, Secretless will replace these
+credential references with your real credentials.
+
+For instance:
+
+```yaml
+
+version: 2
+services:
+  oauth1-service:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8080
+    credentials:
+      consumer_key:
+        from: conjur
+        get: somekey
+      consumer_secret:
+        from: conjur
+        get: someconsumersecret
+      token:
+        from: conjur
+        get: sometoken
+      token_secret:
+        from: conjur
+        get: sometokensecret
+    config:
+      oauth1:
+        consumer_key: "{{ .consumer_key }}"
+        consumer_secret: "{{ .consumer_secret }}"
+        token: "{{ .token }}"
+        token_secret: "{{ .token_secret }}"
+      forceSSL: true
+      authenticateURLsMatching:
+        - ^http
+```
+
 #### `credentialValidations`
 
 This section lets you use regular expressions to define validations for the
@@ -150,7 +213,7 @@ header values.
 
 For example, in the first example above, the line:
 
-```
+```yaml
 apikey: '^[A-Z0-9]+$'
 ```
 
@@ -200,7 +263,7 @@ Let's take a look at the Basic auth connector to see how this works:
 // Taken from:
 // internal/plugin/connectors/http/basicauth/plugin.go
 //
-// Also note: 
+// Also note:
 // "NewConnectorConstructor" and "ConfigYAML" are defined in:
 // /internal/plugin/connectors/http/generic/external_api.go
 
@@ -214,7 +277,7 @@ newConnector, err := generichttp.NewConnectorConstructor(
     },
   },
 )
-``` 
+```
 
 Note how this code exactly mirrors the yaml from the end-user example.  Please
 refer to those docs above for an explanation of the `CredentialValidations` and

--- a/internal/plugin/connectors/http/generic/config.go
+++ b/internal/plugin/connectors/http/generic/config.go
@@ -15,6 +15,7 @@ import (
 type config struct {
 	CredentialPatterns map[string]*regexp.Regexp
 	Headers            map[string]*template.Template
+	OAuth1Secrets      map[string]*template.Template
 	QueryParams        map[string]*template.Template
 	ForceSSL           bool
 }
@@ -89,6 +90,7 @@ func newConfig(cfgYAML *ConfigYAML) (*config, error) {
 
 	cfg.Headers, errs = stringsToTemplates(cfgYAML.Headers, errs)
 	cfg.QueryParams, errs = stringsToTemplates(cfgYAML.QueryParams, errs)
+	cfg.OAuth1Secrets, errs = stringsToTemplates(cfgYAML.OAuth1Secrets, errs)
 
 	if err := errs.Filter(); err != nil {
 		return nil, err

--- a/internal/plugin/connectors/http/generic/connector.go
+++ b/internal/plugin/connectors/http/generic/connector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	gohttp "net/http"
 
+	oauth1 "github.com/cyberark/secretless-broker/internal/plugin/connectors/http/generic/oauth/v1"
 	"github.com/cyberark/secretless-broker/pkg/secretless/log"
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
 )
@@ -12,6 +13,49 @@ import (
 type Connector struct {
 	logger log.Logger
 	config *config
+}
+
+func addOAuth1Header(c *Connector, credentialsByID connector.CredentialValuesByID, r *gohttp.Request) error {
+	// Doesn't check for error. Instead we check to see if
+	// any values exist in the oauth1 key in the config.
+	oAuth1Params, err := renderTemplates(c.config.OAuth1Secrets, credentialsByID)
+	if err != nil {
+		return fmt.Errorf("failed to render oauth1 params: %s", err)
+	}
+
+	if len(oAuth1Params) > 0 {
+		oauthHeader, err := oauth1.CreateOAuth1Header(oAuth1Params, r)
+		if err != nil {
+			return fmt.Errorf("failed to create oAuth1 'Authorization' header: %s", err)
+		}
+
+		if len(r.Header.Get("Authorization")) > 0 {
+			return fmt.Errorf("authorization header already exists, cannot override header")
+		}
+
+		r.Header.Set("Authorization", oauthHeader)
+	}
+	return nil
+}
+
+func addQueryParams(c *Connector, credentialsByID connector.CredentialValuesByID, r *gohttp.Request) error {
+	queryParams, err := renderTemplates(c.config.QueryParams, credentialsByID)
+	if err != nil {
+		return fmt.Errorf("failed to render query params: %s", err)
+	}
+	r.URL.RawQuery = appendQueryParams(*r.URL, queryParams)
+	return nil
+}
+
+func addHeaders(c *Connector, credentialsByID connector.CredentialValuesByID, r *gohttp.Request) error {
+	headers, err := renderTemplates(c.config.Headers, credentialsByID)
+	if err != nil {
+		return fmt.Errorf("failed to render headers: %s", err)
+	}
+	for headerName, headerVal := range headers {
+		r.Header.Set(headerName, headerVal)
+	}
+	return nil
 }
 
 // Connect implements the http.Connector func signature.
@@ -30,20 +74,19 @@ func (c *Connector) Connect(
 	}
 
 	// Add configured headers to request
-	headers, err := renderTemplates(c.config.Headers, credentialsByID)
-	if err != nil {
-		return fmt.Errorf("failed to render headers: %s", err)
-	}
-	for headerName, headerVal := range headers {
-		r.Header.Set(headerName, headerVal)
+	if err := addHeaders(c, credentialsByID, r); err != nil {
+		return err
 	}
 
 	// Add configured params to request
-	params, err := renderTemplates(c.config.QueryParams, credentialsByID)
-	if err != nil {
-		return fmt.Errorf("failed to render query params: %s", err)
+	if err := addQueryParams(c, credentialsByID, r); err != nil {
+		return err
 	}
-	r.URL.RawQuery = appendQueryParams(*r.URL, params)
+
+	// Add oAuth1 Authorization Header to the request
+	if err := addOAuth1Header(c, credentialsByID, r); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/internal/plugin/connectors/http/generic/external_api.go
+++ b/internal/plugin/connectors/http/generic/external_api.go
@@ -19,9 +19,10 @@ import (
 //         .yml file.  That is, we convert from .yml --> ConfigYAML --> config.
 type ConfigYAML struct {
 	CredentialValidations map[string]string `yaml:"credentialValidations"`
-	Headers               map[string]string `yaml:"headers"`
-	QueryParams           map[string]string `yaml:"queryParams"`
 	ForceSSL              bool              `yaml:"forceSSL"`
+	Headers               map[string]string `yaml:"headers"`
+	OAuth1Secrets         map[string]string `yaml:"oauth1"`
+	QueryParams           map[string]string `yaml:"queryParams"`
 }
 
 // NewConfigYAML takes the raw cfgBytes and unmarshals them into a ConfigYAML

--- a/internal/plugin/connectors/http/generic/oauth/v1/protocol.go
+++ b/internal/plugin/connectors/http/generic/oauth/v1/protocol.go
@@ -1,0 +1,262 @@
+package oauth1protocol
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	gohttp "net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+)
+
+// OAuth1 is a struct of all OAuth1 specific parameters
+type OAuth1 struct {
+	ConsumerKey     string
+	ConsumerSecret  string
+	Nonce           string
+	Signature       string
+	SignatureMethod string
+	TimeStamp       string
+	Token           string
+	TokenSecret     string
+	Version         string
+}
+
+// OAuth Header Key Names
+const (
+	oauthConsumerKey     = "oauth_consumer_key"
+	oauthNonce           = "oauth_nonce"
+	oauthSignatureMethod = "oauth_signature_method"
+	oauthTimestamp       = "oauth_timestamp"
+	oauthToken           = "oauth_token"
+	oauthVersion         = "oauth_version"
+)
+
+// OAuth Header Variables
+const (
+	// Nonce doesn't have a specified charset or length
+	// Reference: https://tools.ietf.org/html/rfc5849#section-3.3
+	nonceCharset = "abcdefghijklmnopqrstuvwxyz" +
+		"ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+		"0123456789"
+	nonceLength = 16
+	// Currently, this feature supports HMAC-SHA1, but there is an issue logged to
+	// support more methods.
+	// Reference: https://github.com/cyberark/secretless-broker/issues/1324
+	oauthSignatureMethodType = "HMAC-SHA1"
+	oauthVersionNumber       = "1.0"
+)
+
+// Required Config YAML Variables
+const (
+	consumerKey    = "consumer_key"
+	consumerSecret = "consumer_secret"
+	token          = "token"
+	tokenSecret    = "token_secret"
+)
+
+var requiredConfigParams = []string{
+	consumerKey,
+	consumerSecret,
+	token,
+	tokenSecret,
+}
+
+func generateNonce(length int, charset string) string {
+	seededRand := rand.New(
+		rand.NewSource(time.Now().UnixNano()))
+
+	randomChars := make([]byte, length)
+	for index := range randomChars {
+		randomChars[index] = charset[seededRand.Intn(len(charset))]
+	}
+	return string(randomChars)
+}
+
+// checkRequiredOAuthParams returns an error if a key from
+// "requiredConfigParams" was not included in the supplied config
+// returns the first missing key found
+func checkRequiredOAuthParams(params map[string]string) error {
+	for _, requiredParam := range requiredConfigParams {
+		if len(params[requiredParam]) < 1 {
+			return fmt.Errorf("required oAuth1 parameter '%s' not found", requiredParam)
+		}
+	}
+	return nil
+}
+
+// extractOAuthParams extracts the required oAuth1 parameters from
+// the config and assigns the other required paramters
+func extractOAuthParams(params map[string]string) OAuth1 {
+	oauth := OAuth1{
+		ConsumerKey:     params[consumerKey],
+		ConsumerSecret:  params[consumerSecret],
+		Nonce:           generateNonce(nonceLength, nonceCharset),
+		SignatureMethod: oauthSignatureMethodType,
+		Token:           params[token],
+		TokenSecret:     params[tokenSecret],
+		TimeStamp:       strconv.Itoa(int(time.Now().Unix())),
+		Version:         oauthVersionNumber,
+	}
+
+	return oauth
+}
+
+// encodeURI percent encodes a string and changes encoding of <SPACE> from "+" to "%20"
+// Reference: https://tools.ietf.org/html/rfc5849#section-3.6
+func encodeURI(stringToEncode string) string {
+	return strings.ReplaceAll(url.QueryEscape(stringToEncode), "+", "%20")
+}
+
+// collectParameters creates a map of body and query parameters by percent encoding all
+// keys and values and sorting values post-encoding
+func collectParameters(oauth1 OAuth1, r *gohttp.Request) map[string][]string {
+	// Create two copies of the request body
+	// Since r.Body is io.ReadCloser the body is empty after reading.
+	// Need to replace r.Body after r.ParseForm() dumps the body contents
+	buf, _ := ioutil.ReadAll(r.Body)
+	originalBody := ioutil.NopCloser(bytes.NewBuffer(buf))
+	copyBody := ioutil.NopCloser(bytes.NewBuffer(buf))
+	r.Body = originalBody
+
+	paramMap := make(map[string][]string, 0)
+	// get query and body params and URL encode keys and
+	// values sort values after encoding
+	r.ParseForm()
+	for paramKey, paramValues := range r.Form {
+		encodedKey := encodeURI(paramKey)
+		paramMap[encodedKey] = paramValues
+
+		// Keys with multiple values require the values
+		// to be sorted post-percent encoding
+		for valueIndex, value := range paramMap[encodedKey] {
+			encodedValue := encodeURI(value)
+			paramMap[encodedKey][valueIndex] = encodedValue
+		}
+		sort.Strings(paramMap[encodedKey])
+	}
+	r.Body = copyBody
+
+	// these keys are already URL safe and don't need sorted(1 value)
+	paramMap[oauthConsumerKey] = []string{encodeURI(oauth1.ConsumerKey)}
+	paramMap[oauthNonce] = []string{encodeURI(oauth1.Nonce)}
+	paramMap[oauthSignatureMethod] = []string{encodeURI(oauth1.SignatureMethod)}
+	paramMap[oauthTimestamp] = []string{encodeURI(oauth1.TimeStamp)}
+	paramMap[oauthToken] = []string{encodeURI(oauth1.Token)}
+	paramMap[oauthVersion] = []string{encodeURI(oauth1.Version)}
+
+	return paramMap
+}
+
+// generateParameterString creates a Parameter String from
+// sorting an encoded map of parameters and values
+// Reference: https://tools.ietf.org/html/rfc5849#section-3.5
+func generateParameterString(paramMap map[string][]string) string {
+	var parameterString strings.Builder
+
+	// make map of keys and sort to append lexicographically later
+	keys := make([]string, 0, len(paramMap))
+	for key := range paramMap {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	// create string
+	for keyIndex, key := range keys {
+		// Write keys and value pairs to `parameterString`
+		// ex: key0=value&key1=value&key2=value
+		for valueIndex, value := range paramMap[key] {
+			// Do not add '&' on first value
+			if keyIndex > 0 || valueIndex > 0 {
+				parameterString.WriteString("&")
+			}
+			parameterString.WriteString(key + "=" + value)
+		}
+	}
+
+	return parameterString.String()
+}
+
+// generateBaseString combines parameters to create the
+// pre-hash base string for the signature
+// Reference: https://tools.ietf.org/html/rfc5849#section-3.4.1
+func generateBaseString(r *gohttp.Request, paramString string) string {
+	method := strings.ToUpper(r.Method)
+	urlString := fmt.Sprintf("%s://%s%s", r.URL.Scheme, r.URL.Host, r.URL.Path)
+	return fmt.Sprintf("%s&%s&%s", method, encodeURI(urlString), encodeURI(paramString))
+}
+
+// generateSigningKey concats the consumer secret and
+// token secret with an ampersand, and encodes them
+// Reference: https://tools.ietf.org/html/rfc5849#section-3.4
+func generateSigningKey(oauth1 OAuth1) string {
+	return fmt.Sprintf("%s&%s", encodeURI(oauth1.ConsumerSecret), encodeURI(oauth1.TokenSecret))
+}
+
+// hashSignature creates a HMAC-SHA1 hash
+// Reference: https://tools.ietf.org/html/rfc5849#section-3.4.2
+func hashSignature(signingKey string, baseString string) string {
+	h := hmac.New(sha1.New, []byte(signingKey))
+	h.Write([]byte(baseString))
+	return encodeURI(base64.StdEncoding.EncodeToString(h.Sum(nil)))
+}
+
+// constructOAuthString creates the Authorization header
+// that is needed for the final request
+// Reference: https://tools.ietf.org/html/rfc5849#section-3.5.1
+func constructOAuthString(oauth1 OAuth1) (string, error) {
+	tmpl, err := template.New("oauth").Parse("OAuth " +
+		"oauth_consumer_key=\"{{.ConsumerKey}}\", " +
+		"oauth_nonce=\"{{.Nonce}}\", " +
+		"oauth_signature=\"{{.Signature}}\", " +
+		"oauth_signature_method=\"{{.SignatureMethod}}\", " +
+		"oauth_timestamp=\"{{.TimeStamp}}\", " +
+		"oauth_token=\"{{.Token}}\", " +
+		"oauth_version=\"{{.Version}}\"")
+	if err != nil {
+		return "", fmt.Errorf("could not create the OAuth template: %s", err)
+	}
+
+	var tpl bytes.Buffer
+	err = tmpl.Execute(&tpl, oauth1)
+	if err != nil {
+		return "", fmt.Errorf("could not turn the OAuth template into a string: %s", err)
+	}
+
+	return tpl.String(), nil
+}
+
+// CreateOAuth1Header calls a series of methods to construct
+// the oAuth1 'Authorization' Header String
+func CreateOAuth1Header(params map[string]string, r *gohttp.Request) (string, error) {
+
+	// check for required params
+	err := checkRequiredOAuthParams(params)
+	if err != nil {
+		return "", err
+	}
+
+	oauth1 := extractOAuthParams(params)
+
+	parameters := collectParameters(oauth1, r)
+	paramString := generateParameterString(parameters)
+	baseString := generateBaseString(r, paramString)
+	signingKey := generateSigningKey(oauth1)
+
+	oauth1.Signature = hashSignature(signingKey, baseString)
+
+	oauthString, err := constructOAuthString(oauth1)
+	if err != nil {
+		return "", err
+	}
+
+	return oauthString, nil
+}

--- a/internal/plugin/connectors/http/generic/oauth/v1/protocol_test.go
+++ b/internal/plugin/connectors/http/generic/oauth/v1/protocol_test.go
@@ -1,0 +1,397 @@
+package oauth1protocol
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	gohttp "net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_extractOAuthParams(t *testing.T) {
+	paramMap := map[string]string{
+		consumerKey:          "consumerKey",
+		consumerSecret:       "consumerSecret",
+		token:                "token",
+		tokenSecret:          "tokenSecret",
+		oauthNonce:           "oauth_nonce",
+		oauthSignatureMethod: "oauth_signature_method",
+		oauthVersion:         "oauth_version",
+		oauthTimestamp:       "oauth_timestamp",
+	}
+	result := extractOAuthParams(paramMap)
+	// Nonce and TimeStamp are generated at runtime and unknown
+	result.TimeStamp = ""
+	result.Nonce = ""
+
+	want := OAuth1{
+		ConsumerKey:     "consumerKey",
+		ConsumerSecret:  "consumerSecret",
+		Nonce:           "",
+		SignatureMethod: "HMAC-SHA1",
+		TimeStamp:       "",
+		Token:           "token",
+		TokenSecret:     "tokenSecret",
+		Version:         "1.0",
+	}
+	assert.Equal(t, want, result)
+}
+
+func createRequestBody(s string) io.ReadCloser {
+	return ioutil.NopCloser(strings.NewReader(s))
+}
+
+func Test_collectParameters(t *testing.T) {
+	type args struct {
+		oauth1 OAuth1
+		r      *gohttp.Request
+	}
+
+	params := args{
+		oauth1: OAuth1{
+			ConsumerKey:     "xvz1evFS4wEEPTGEFPHBog",
+			Nonce:           "kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg",
+			SignatureMethod: "HMAC-SHA1",
+			TimeStamp:       "1318622958",
+			Token:           "370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb",
+			Version:         "1.0",
+		},
+		r: &gohttp.Request{
+			Method: "POST",
+			URL: &url.URL{
+				Scheme:   "http",
+				Host:     "example.com",
+				Path:     "/wp-json/wp/v2/posts",
+				RawQuery: "include_entities=true",
+			},
+			Header: map[string][]string{
+				"Authorization": {"doesn't matter"},
+				"Content-Type":  {"application/x-www-form-urlencoded"},
+			},
+			Body: createRequestBody("status=Hello%20Foo%20%2B%20Bar%2C%20a%20signed%20OAuth%20request%21"),
+		},
+	}
+
+	result := collectParameters(params.oauth1, params.r)
+
+	want := map[string][]string{
+		"include_entities":       {"true"},
+		"oauth_consumer_key":     {"xvz1evFS4wEEPTGEFPHBog"},
+		"oauth_nonce":            {"kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg"},
+		"oauth_signature_method": {"HMAC-SHA1"},
+		"oauth_timestamp":        {"1318622958"},
+		"oauth_token":            {"370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb"},
+		"oauth_version":          {"1.0"},
+		"status":                 {"Hello%20Foo%20%2B%20Bar%2C%20a%20signed%20OAuth%20request%21"},
+	}
+
+	assert.Equal(t, want, result)
+}
+
+func Test_generateParameterString(t *testing.T) {
+	type args struct {
+		paramMap map[string][]string
+	}
+	tests := []struct {
+		description string
+		args        args
+		want        string
+		wantErr     bool
+	}{
+		{
+			description: "keys with single values",
+			args: args{
+				paramMap: map[string][]string{
+					"oauth_consumer_key":     {"key"},
+					"oauth_nonce":            {"nonce"},
+					"oauth_signature_method": {"HMAC-SHA1"},
+					"oauth_timestamp":        {"123456789"},
+					"oauth_token":            {"token"},
+					"oauth_version":          {"1.0"},
+				},
+			},
+			want: "oauth_consumer_key=key&oauth_nonce=nonce&oauth_signature_method=HMAC-SHA1&oauth_timestamp=123456789&oauth_token=token&oauth_version=1.0",
+		},
+		{
+			description: "key with multiple values",
+			args: args{
+				paramMap: map[string][]string{
+					"test_multi_var[]": {"multi1", "multi2"},
+					"test_single_var":  {"single"},
+				},
+			},
+			want: "test_multi_var[]=multi1&test_multi_var[]=multi2&test_single_var=single",
+		},
+		{
+			description: "sorts map values",
+			args: args{
+				paramMap: map[string][]string{
+					"c": {"3"},
+					"a": {"1"},
+					"b": {"2"},
+				},
+			},
+			want: "a=1&b=2&c=3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := generateParameterString(tt.args.paramMap)
+			assert.Equal(t, tt.want, result)
+		},
+		)
+	}
+}
+
+func Test_generateBaseString(t *testing.T) {
+	type args struct {
+		paramString string
+		r           *gohttp.Request
+	}
+	tests := []struct {
+		description string
+		args        args
+		want        string
+	}{
+		{
+			description: "all components supplied",
+			args: args{
+				paramString: "include_entities=true&oauth_consumer_key=xvz1evFS4wEEPTGEFPHBog&oauth_nonce=kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1318622958&oauth_token=370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb&oauth_version=1.0&status=Hello%20Foo%20%2B%20Bar%2C%20a%20signed%20OAuth%20request%21",
+				r: &gohttp.Request{
+					Method: "POST",
+					URL: &url.URL{
+						Scheme: "https",
+						Host:   "api.twitter.com",
+						Path:   "/1.1/statuses/update.json",
+					},
+				},
+			},
+			want: "POST&https%3A%2F%2Fapi.twitter.com%2F1.1%2Fstatuses%2Fupdate.json&include_entities%3Dtrue%26oauth_consumer_key%3Dxvz1evFS4wEEPTGEFPHBog%26oauth_nonce%3DkYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1318622958%26oauth_token%3D370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb%26oauth_version%3D1.0%26status%3DHello%2520Foo%2520%252B%2520Bar%252C%2520a%2520signed%2520OAuth%2520request%2521",
+		},
+		{
+			description: "no components supplied",
+			args: args{
+				paramString: "include_entities=true&oauth_consumer_key=xvz1evFS4wEEPTGEFPHBog&oauth_nonce=kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1318622958&oauth_token=370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb&oauth_version=1.0&status=Hello%20Foo%20%2B%20Bar%2C%20a%20signed%20OAuth%20request%21",
+				r: &gohttp.Request{
+					Method: "",
+					URL: &url.URL{
+						Scheme: "",
+						Host:   "",
+						Path:   "",
+					},
+				},
+			},
+			want: "&%3A%2F%2F&include_entities%3Dtrue%26oauth_consumer_key%3Dxvz1evFS4wEEPTGEFPHBog%26oauth_nonce%3DkYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D1318622958%26oauth_token%3D370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb%26oauth_version%3D1.0%26status%3DHello%2520Foo%2520%252B%2520Bar%252C%2520a%2520signed%2520OAuth%2520request%2521",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := generateBaseString(tt.args.r, tt.args.paramString)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func Test_generateNonce(t *testing.T) {
+	type args struct {
+		length int
+	}
+	tests := []struct {
+		description string
+		args        args
+		want        int
+	}{
+		{
+			description: "Generates a 16 length nonce",
+			args: args{
+				length: 16,
+			},
+			want: 16,
+		},
+		{
+			description: "Generates a 32 length nonce",
+			args: args{
+				length: 32,
+			},
+			want: 32,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := len(generateNonce(tt.args.length, nonceCharset))
+			assert.True(t, result == tt.args.length)
+		})
+	}
+}
+
+func Test_generateSigningKey(t *testing.T) {
+	type args struct {
+		oauth1 OAuth1
+	}
+	tests := []struct {
+		description string
+		args        args
+		want        string
+		wantErr     bool
+	}{
+		{
+			description: "both keys",
+			args: args{
+				OAuth1{
+					ConsumerSecret: "kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw",
+					TokenSecret:    "LswwdoUaIvS8ltyTt5jkRh4J50vUPVVHtR2YPi5kE",
+				},
+			},
+			want: "kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw&LswwdoUaIvS8ltyTt5jkRh4J50vUPVVHtR2YPi5kE",
+		},
+		{
+			description: "no token secret",
+			args: args{
+				OAuth1{
+					ConsumerSecret: "kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw",
+					TokenSecret:    "",
+				},
+			},
+			want: "kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw&",
+		},
+		{
+			description: "both empty",
+			args: args{
+				OAuth1{
+					ConsumerSecret: "",
+					TokenSecret:    "",
+				},
+			},
+			want: "&",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := generateSigningKey(tt.args.oauth1)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func Test_constructOAuthString(t *testing.T) {
+	t.Run("creates expected header", func(t *testing.T) {
+		oauth1 := OAuth1{
+			ConsumerKey:     "xvz1evFS4wEEPTGEFPHBog",
+			ConsumerSecret:  "kAcSOqF21Fu85e7zjz7ZN2U4ZRhfV3WpwPAoE3Z7kBw",
+			Nonce:           "kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg",
+			Signature:       "tnnArxj06cWHq44gCs1OSKk%2FjLY%3D",
+			SignatureMethod: "HMAC-SHA1",
+			TimeStamp:       "1318622958",
+			Token:           "370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb",
+			TokenSecret:     "LswwdoUaIvS8ltyTt5jkRh4J50vUPVVHtR2YPi5kE",
+			Version:         "1.0",
+		}
+
+		result, err := constructOAuthString(oauth1)
+
+		want := "OAuth oauth_consumer_key=\"xvz1evFS4wEEPTGEFPHBog\", oauth_nonce=\"kYjzVBB8Y0ZFabxSWbWovY3uYSQ2pTgmZeNu2VS4cg\", oauth_signature=\"tnnArxj06cWHq44gCs1OSKk%2FjLY%3D\", oauth_signature_method=\"HMAC-SHA1\", oauth_timestamp=\"1318622958\", oauth_token=\"370773112-GmHxMAgYyLbNEtIKZeRNFsMKPR9EyMZeS9weJAEb\", oauth_version=\"1.0\""
+
+		assert.NoError(t, err)
+		assert.Equal(t, want, result)
+	})
+}
+
+func Test_encodeURI(t *testing.T) {
+	type args struct {
+		stringToEncode string
+	}
+	tests := []struct {
+		description string
+		args        args
+		want        string
+	}{
+		{
+			description: "snowman emoji",
+			args: args{
+				stringToEncode: "☃",
+			},
+			want: "%E2%98%83",
+		},
+		{
+			description: "ALPHA",
+			args: args{
+				stringToEncode: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+			},
+			want: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+		},
+		{
+			description: "DIGIT",
+			args: args{
+				stringToEncode: "1234567890",
+			},
+			want: "1234567890",
+		},
+		{
+			description: "special characters not to encode",
+			args: args{
+				stringToEncode: "-._~",
+			},
+			want: "-._~",
+		},
+		{
+			description: "special characters to encode",
+			args: args{
+				stringToEncode: "`!@#$%^&*()+=[{]}\\|;:'\",<>/? ",
+			},
+			want: "%60%21%40%23%24%25%5E%26%2A%28%29%2B%3D%5B%7B%5D%7D%5C%7C%3B%3A%27%22%2C%3C%3E%2F%3F%20",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := encodeURI(tt.args.stringToEncode)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func Test_checkRequiredOAuthParams(t *testing.T) {
+	type args struct {
+		paramMap map[string]string
+	}
+	tests := []struct {
+		description string
+		args        args
+		want        error
+		wantErr     bool
+	}{
+		{
+			description: "all values present: no error",
+			args: args{
+				paramMap: map[string]string{
+					"consumer_key":    "conKey",
+					"consumer_secret": "conSecret",
+					"token":           "apiToken",
+					"token_secret":    "tokSecret",
+				},
+			},
+			want: nil,
+		},
+		{
+			description: "missing value: consumer_key",
+			args: args{
+				paramMap: map[string]string{
+					"consumer_secret": "conSecret",
+					"token":           "apiToken",
+					"token_secret":    "tokSecret",
+				},
+			},
+			want: fmt.Errorf("required oAuth1 parameter 'consumer_key' not found"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			result := checkRequiredOAuthParams(tt.args.paramMap)
+			assert.Equal(t, tt.want, result)
+		},
+		)
+	}
+}


### PR DESCRIPTION
### What does this PR do?
- Added OAuth1 functionaly to the generic HTTP connector

### What ticket does this PR close?
Connected to #1297 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
