### PR TITLE
Fix issues with ssh_agent tests breaking the build

### DIFF
--- a/test/connector/ssh_agent/Dockerfile.ssh_host
+++ b/test/connector/ssh_agent/Dockerfile.ssh_host
@@ -1,4 +1,4 @@
-FROM phusion/baseimage
+FROM phusion/baseimage:master-amd64
 
 COPY ./id_insecure.pub /tmp/id_insecure.pub
 


### PR DESCRIPTION
This was due to phusion/baseimage changing their tags to support
multiple build architectures which broke our integration tests. We now
properly select master-amd64 tag for this.

### What ticket does this PR close?
Fixes #1322 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
