### PR TITLE
Support Vault KV v2 backend. Connected to #1331.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- The `vault` provider now supports loading secrets from the KV Version 2 secret
+  engine. Reference a secret in Vault using the right path and a field
+  navigation in the Secretless configuration.
+  [#1331](https://github.com/cyberark/secretless-broker/issues/1331)
+
 ## [1.7.0] - 2020-09-11
 
 ### Added

--- a/internal/providers/vault/README.md
+++ b/internal/providers/vault/README.md
@@ -1,0 +1,98 @@
+# Vault Provider
+
+The Vault provider for Secretless can fetch secrets from configured secret
+engines in [HashiCorp Vault](https://www.vaultproject.io). The provider is based
+on the [Vault API client](https://pkg.go.dev/github.com/hashicorp/vault/api) in
+Go. It reads the secret object from the configured path and returns the value
+navigated to by the configured fields (or default field otherwise).
+
+## Usage Documentation
+
+The Vault provider is configured in the `secretless.yml` using:
+
+```yaml
+from: vault
+get: /path/to/secret/in/vault
+```
+
+Or with explicit fields navigating to the value in the secret returned at path:
+
+```yaml
+from: vault
+get: /path/to/secret/in/vault#navigate.to.this.field
+```
+
+The provider will read a secret (object) at a given path and returns the value
+of field `value` (by default). By appending `#data.fieldName` to the path, the
+provider will instead read the value at the field `fieldName` in the object
+`data` in the secret (object) instead.
+
+Below are some examples showing how to configure the provider for secrets.
+
+### Example: API key from KV backends (v1 and v2)
+
+Below is an excerpt of an example configuration for a fictional "Example
+Service" that requires an API key, e.g. used in a request header. It gets the
+API key from Vault's KV version 1 backend at path `kv/example-service` under the
+secret's `value` field.
+
+```yaml
+version: 2
+services:
+  my_example_service:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8080
+    credentials:
+      apikey:
+        from: vault
+        get: kv/example-service
+        # gets path to API key in Vault, field 'value' holds the API key
+    ...
+```
+
+A slightly different configuration explicitly sets the field `api-key` (instead
+of the default `value`) to hold the API key.
+
+```yaml
+version: 2
+services:
+  my_example_service:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8080
+    credentials:
+      apikey:
+        from: vault
+        get: kv/example-service#api-key
+        # gets path to API key in Vault, field 'api-key' holds the API key
+    ...
+```
+
+If the secret is stored in a KV v2 backend (mounted at `secret` by default), the
+configuration must use the use the `data` segment in the path and the
+`#data.api-key` suffix. This is behavior specific to KV v2 in Vault, see Vault
+API docs.
+
+```yaml
+version: 2
+services:
+  my_example_service:
+    connector: generic_http
+    listenOn: tcp://0.0.0.0:8080
+    credentials:
+      apikey:
+        from: vault
+        get: secret/data/example-service#data.api-key
+        # gets path to API key in Vault stored in the KV v2 secret engine
+    ...
+```
+
+## Limitations
+
+- Only token-based login to Vault supported at the moment.
+- Only secrets that are "read" in Vault are supported at the moment. Backends
+  that require "writes" to obtain the secret (e.g. PKI, dynamic database
+  credentials) are not supported at the moment.
+- Backends that have multiple values change simultaneously (e.g. client id and
+  secret, database username and password) are not supported at the moment.
+- Limited support for KV v2 secret engine, only latest version of a secret can
+  be retrieved.

--- a/test/providers/vault/start
+++ b/test/providers/vault/start
@@ -49,7 +49,13 @@ VAULT_ADDR=http://localhost:$vault_port
 VAULT_TOKEN=$root_token
 ENV
 
-vault_cmd secrets enable kv
+# cubbyhole enabled by default, mounted at /cubbyhole
+vault_cmd write cubbyhole/first-secret 'some-key=one'
+vault_cmd write cubbyhole/second-secret 'value=two'
+
+# KV v2 enabled by default, mounted at /secret
+vault_cmd secrets enable -version=1 kv
 vault_cmd kv put kv/db/password 'password=db-secret'
 vault_cmd kv put kv/frontend/admin-password 'password=frontend-secret'
 vault_cmd kv put kv/web/password 'value=web-secret'
+vault_cmd kv put secret/service 'api-key=service-api-key'

--- a/test/providers/vault/vault_summon_test.go
+++ b/test/providers/vault/vault_summon_test.go
@@ -14,8 +14,11 @@ import (
 
 func TestVault_Summon(t *testing.T) {
 	secretsDescriptor := `
+FIRST_SECRET: !var cubbyhole/first-secret#some-key
+SECOND_SECRET: !var cubbyhole/second-secret
 DB_PASSWORD: !var kv/db/password#password
 WEB_PASSWORD: !var kv/web/password
+SVC_API_KEY: !var secret/data/service#data.api-key
 `
 	defaultArgs := []string{"summon2", "-p", "vault", "--yaml", secretsDescriptor, "env"}
 
@@ -36,7 +39,10 @@ WEB_PASSWORD: !var kv/web/password
 		lines, err := runCommand(defaultArgs)
 
 		So(err, ShouldBeNil)
+		So(lines, ShouldContain, "FIRST_SECRET=one")
+		So(lines, ShouldContain, "SECOND_SECRET=two")
 		So(lines, ShouldContain, "DB_PASSWORD=db-secret")
 		So(lines, ShouldContain, "WEB_PASSWORD=web-secret")
+		So(lines, ShouldContain, "SVC_API_KEY=service-api-key")
 	})
 }


### PR DESCRIPTION
Signed-off-by: Meijer <michaelmeijer@outlook.com>

### What does this PR do?
- Support secrets of Vault's KV v2 backend which is incompatible with the current implementation in secretless-broker.
- New behavior is implemented with backwards compatability to current (old) behavior.

### What ticket does this PR close?
Connected to #1331 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
