### PR TITLE
Update GoSec to run only on branch builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ bench.*
 debug
 debug.*
 dist
+gosec.output
 run
 tmp
 vendor

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,6 +78,11 @@ pipeline {
         }
 
         stage('Scan For Security with Gosec') {
+          // Gosec only works on branch builds
+          when {
+            not { tag "v*" }
+          }
+
           steps {
             sh "./bin/check_golang_security -s High -c Medium -b ${env.BRANCH_NAME}"
             junit(allowEmptyResults: true, testResults: 'gosec.output')


### PR DESCRIPTION
### What does this PR do?
Update GoSec to run only on branch builds
It errors if it runs on a tag build, because it's set up to only run on branches.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
