### PR TITLE
Stale: Change GetValue to GetValues for Providers to allow batch retrieval

### DIFF
--- a/design/proposal-zeroization.md
+++ b/design/proposal-zeroization.md
@@ -13,7 +13,7 @@ Ideally, 2 would happen in a centralized fashion to avoid the need for repeated 
 It is worth noting the journey of Secrets in Secretless.
 
 ```
-Resolver.#Resolve -> Provider.#GetValue |-> Handler -> Listener -> Target Backend
+Resolver.#Resolve -> Provider.#GetValues |-> Handler -> Listener -> Target Backend
                                         |
 					|-> EventNotifier.#ResolveSecret
 ```
@@ -87,5 +87,5 @@ The recommendation per Secret usage session is as follows:
 ## Further consideration
 
 1. Audit `Listener -> Target Backend`
-1. Audit `Provider.#GetValue`
+1. Audit `Provider.#GetValues`
 1. Reconsider `EventNotifier.#ResolveSecret`, why do we need this ?

--- a/go.sum
+++ b/go.sum
@@ -29,7 +29,6 @@ github.com/containerd/containerd v1.3.2 h1:ForxmXkA6tPIvffbrDAcPUIB32QgXkt2XFj+F
 github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/cyberark/conjur-api-go v0.5.2 h1:8ntk07YNRz5bBwjNXkDEAPR70Yr+J2MN8NGlkhaMC3k=
 github.com/cyberark/conjur-api-go v0.5.2/go.mod h1:hwaReWirzgKor+JtH6vbwZaASDXulvd0SzGCloC5uOc=
-github.com/cyberark/conjur-authn-k8s-client v0.13.0/go.mod h1:JTeGIeRO59J7mMEc5yF6FPtk1QnaAzs4GyZa4WldqZc=
 github.com/cyberark/conjur-authn-k8s-client v0.19.0 h1:zHjdKyZ8bu4cRyV3iYMh1/XfIVtTugoiU/CflnboP9Q=
 github.com/cyberark/conjur-authn-k8s-client v0.19.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
 github.com/cyberark/secretless-broker v1.4.1-0.20191211191712-251c5ec034af/go.mod h1:+GueI3WCJL5gDYaYa38ZokAR8ceEyCVet7MkuZyjf80=
@@ -246,7 +245,6 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-go.mongodb.org/mongo-driver v1.4.2 h1:WlnEglfTg/PfPq4WXs2Vkl/5ICC6hoG8+r+LraPmGk4=
 golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/containerd/containerd v1.3.2 h1:ForxmXkA6tPIvffbrDAcPUIB32QgXkt2XFj+F
 github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/cyberark/conjur-api-go v0.5.2 h1:8ntk07YNRz5bBwjNXkDEAPR70Yr+J2MN8NGlkhaMC3k=
 github.com/cyberark/conjur-api-go v0.5.2/go.mod h1:hwaReWirzgKor+JtH6vbwZaASDXulvd0SzGCloC5uOc=
+github.com/cyberark/conjur-authn-k8s-client v0.13.0/go.mod h1:JTeGIeRO59J7mMEc5yF6FPtk1QnaAzs4GyZa4WldqZc=
+github.com/cyberark/conjur-authn-k8s-client v0.19.0 h1:zHjdKyZ8bu4cRyV3iYMh1/XfIVtTugoiU/CflnboP9Q=
 github.com/cyberark/conjur-authn-k8s-client v0.19.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
 github.com/cyberark/secretless-broker v1.4.1-0.20191211191712-251c5ec034af/go.mod h1:+GueI3WCJL5gDYaYa38ZokAR8ceEyCVet7MkuZyjf80=
 github.com/cyberark/summon v0.7.0 h1:eBjyNzpJEeFb7BFcOgidM6S/UbEsN7LGSFeQE7szPsk=
@@ -244,6 +246,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+go.mongodb.org/mongo-driver v1.4.2 h1:WlnEglfTg/PfPq4WXs2Vkl/5ICC6hoG8+r+LraPmGk4=
 golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/plugin/resolver.go
+++ b/internal/plugin/resolver.go
@@ -124,7 +124,7 @@ func (resolver *Resolver) resolveForProvider(
 	return provider, providerResponses, ""
 }
 
-// Resolve accepts an list of Providers and a list of Credentials and
+// Resolve accepts n list of Providers and a list of Credentials and
 // attempts to obtain the value of each Credential from the appropriate Provider.
 func (resolver *Resolver) Resolve(credentials []*config_v2.Credential) (map[string][]byte, error) {
 	if len(credentials) == 0 {
@@ -174,7 +174,7 @@ func (resolver *Resolver) Resolve(credentials []*config_v2.Credential) (map[stri
 		// Sort the error strings to provide deterministic output
 		sort.Strings(errorStrings)
 
-		err = fmt.Errorf(strings.Join(errorStrings, "; "))
+		err = fmt.Errorf(strings.Join(errorStrings, "\n"))
 	}
 
 	return result, err

--- a/internal/plugin/resolver_test.go
+++ b/internal/plugin/resolver_test.go
@@ -83,7 +83,7 @@ func Test_Resolver(t *testing.T) {
 			credentialValues, err := resolver.Resolve(credentials)
 			So(len(credentialValues), ShouldEqual, 0)
 			So(err, ShouldNotBeNil)
-			errorMsg := "ERROR: Resolving credential 'something-not-in-env' from provider 'env' failed: env cannot find environment variable 'something-not-in-env'"
+			errorMsg := "ERROR: Resolving credentials from provider 'env' failed: env cannot find environment variable 'something-not-in-env'"
 			So(err.Error(), ShouldEqual, errorMsg)
 
 		})

--- a/internal/plugin/resolver_test.go
+++ b/internal/plugin/resolver_test.go
@@ -63,7 +63,7 @@ func Test_Resolver(t *testing.T) {
 			So(err.Error(), ShouldEqual,
 				"ERROR: Resolving credentials from provider 'env' failed: "+
 					"env cannot find environment variable 'something-also-not-in-env', "+
-					"env cannot find environment variable 'something-not-in-env'; "+
+					"env cannot find environment variable 'something-not-in-env'\n"+
 					"ERROR: Resolving credentials from provider 'file' failed: "+
 					"open something-not-on-file: no such file or directory")
 		})

--- a/internal/plugin/v1/provider.go
+++ b/internal/plugin/v1/provider.go
@@ -28,7 +28,7 @@ type singleValueProvider interface {
 }
 
 // GetValues takes in variable ids and returns their resolved values by making sequential
-// calls to a singleValueProvider.
+// getValueCallArgs to a singleValueProvider.
 // This is a convenience function since most providers with batch retrieval capabilities
 // will have need the exact same code. Note: most internal providers simply use this
 // function in their implementation of the Provider interface's GetValues method.

--- a/internal/plugin/v1/provider.go
+++ b/internal/plugin/v1/provider.go
@@ -43,7 +43,7 @@ func GetValues(
 			continue
 		}
 
-		var pr ProviderResponse
+		pr := ProviderResponse{}
 		pr.Value, pr.Error = p.GetValue(id)
 
 		responses[id] = pr

--- a/internal/plugin/v1/provider.go
+++ b/internal/plugin/v1/provider.go
@@ -12,6 +12,33 @@ type Provider interface {
 	// GetName returns the name that the Provider was instantiated with
 	GetName() string
 
+	// GetValues takes in variable ids and returns their resolved values
+	GetValues(ids ...string) ([][]byte, error)
+}
+
+type singleValueProvider interface {
 	// GetValue takes in an id of a variable and returns its resolved value
 	GetValue(id string) ([]byte, error)
+}
+
+// GetValues takes in variable ids and returns their resolved values by making sequential
+// calls to a singleValueProvider.
+// This is a convenience function since most providers with batch retrieval capabilities
+// will have need the exact same code. Note: most internal providers simply use this
+// function in their implementation of the Provider interface's GetValues method.
+func GetValues(
+	p singleValueProvider,
+	ids ...string,
+) ([][]byte, error) {
+	var err error
+	var res = make([][]byte, len(ids))
+
+	for idx, id := range ids {
+		res[idx], err = p.GetValue(id)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return res, nil
 }

--- a/internal/plugin/v1/provider.go
+++ b/internal/plugin/v1/provider.go
@@ -7,13 +7,19 @@ type ProviderOptions struct {
 	Name string
 }
 
+// ProviderResponse is the response from the provider for a given secret request
+type ProviderResponse struct {
+	Value []byte
+	Error error
+}
+
 // Provider is the interface used to obtain values from a secret vault backend.
 type Provider interface {
 	// GetName returns the name that the Provider was instantiated with
 	GetName() string
 
 	// GetValues takes in variable ids and returns their resolved values
-	GetValues(ids ...string) ([][]byte, error)
+	GetValues(ids ...string) (map[string]ProviderResponse, error)
 }
 
 type singleValueProvider interface {
@@ -29,16 +35,19 @@ type singleValueProvider interface {
 func GetValues(
 	p singleValueProvider,
 	ids ...string,
-) ([][]byte, error) {
-	var err error
-	var res = make([][]byte, len(ids))
+) (map[string]ProviderResponse, error) {
+	responses := map[string]ProviderResponse{}
 
-	for idx, id := range ids {
-		res[idx], err = p.GetValue(id)
-		if err != nil {
-			return nil, err
+	for _, id := range ids {
+		if _, ok := responses[id]; ok {
+			continue
 		}
+
+		var pr ProviderResponse
+		pr.Value, pr.Error = p.GetValue(id)
+
+		responses[id] = pr
 	}
 
-	return res, nil
+	return responses, nil
 }

--- a/internal/plugin/v1/provider_mock.go
+++ b/internal/plugin/v1/provider_mock.go
@@ -1,0 +1,57 @@
+package v1
+
+import (
+	"errors"
+	"strings"
+)
+
+// MockProvider conforms to, and allows testing of, both the singleValueProvider and
+// Provider interfaces
+type MockProvider struct {
+	GetValueCallArgs []string // keeps track of args for each call to getValue
+}
+
+// GetValue returns
+// 0. If [id] has prefix 'err_', returns (nil, errors.New(id + "_value"))
+// 1. Otherwise, returns ([]byte(id + "_value"), nil)
+func (p *MockProvider) GetValue(id string) ([]byte, error) {
+	p.GetValueCallArgs = append(p.GetValueCallArgs, id)
+
+	if strings.HasPrefix(id, "err_") {
+		return nil, errors.New(id + "_value")
+	}
+	return []byte(id + "_value"), nil
+}
+
+// GetValues sequentially get values for unique ids by calling GetValue
+//
+// If there exists any id with the prefix 'global_err_', the function will return
+// (nil, errors.New(id + "_value"))
+func (p *MockProvider) GetValues(ids ...string) (
+	map[string]ProviderResponse,
+	error,
+) {
+	responses := map[string]ProviderResponse{}
+
+	for _, id := range ids {
+		if _, ok := responses[id]; ok {
+			continue
+		}
+
+		if strings.HasPrefix(id, "global_err_") {
+			return nil, errors.New(id + "_value")
+		}
+
+		pr := ProviderResponse{}
+		pr.Value, pr.Error = p.GetValue(id)
+
+		responses[id] = pr
+	}
+
+	return responses, nil
+}
+
+// GetName simply returns "mock-provider"
+func (p *MockProvider) GetName() string {
+	return "mock-provider"
+}

--- a/internal/plugin/v1/provider_mock_test.go
+++ b/internal/plugin/v1/provider_mock_test.go
@@ -1,0 +1,48 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockProvider_GetName(t *testing.T) {
+	p := &MockProvider{}
+
+	assert.Equal(t, p.GetName(), "mock-provider")
+}
+
+func TestMockProvider_GetValue(t *testing.T) {
+	p := &MockProvider{}
+
+	t.Run("Get value", func(t *testing.T) {
+		val, err := p.GetValue("foo")
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, string(val), "foo_value")
+	})
+
+	t.Run("Reports error", func(t *testing.T) {
+		val, err := p.GetValue("err_foo")
+		assert.EqualError(t, err, "err_foo_value")
+		assert.Nil(t, val)
+	})
+}
+
+func TestMockProvider_GetValues(t *testing.T) {
+	p := &MockProvider{}
+
+	t.Run("Sequentially calls GetValue", func(t *testing.T) {
+		_, _ = p.GetValues("a", "b", "c")
+
+		assert.Equal(t, []string{"a", "b", "c"}, p.GetValueCallArgs)
+	})
+
+	t.Run("Returns global error", func(t *testing.T) {
+		res, err := p.GetValues("a", "b", "global_err_example", "c")
+		assert.EqualError(t, err, "global_err_example_value")
+		assert.Nil(t, res)
+	})
+}

--- a/internal/plugin/v1/provider_test.go
+++ b/internal/plugin/v1/provider_test.go
@@ -1,0 +1,76 @@
+package v1
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+// mockProvider conforms to the singleValueProvider interface and allows testing the
+// singleValueProvider interface
+type mockProvider struct {
+	getValueCallArgs []string // keeps track of args for each call to getValue
+}
+
+// GetValue returns
+// 0. If [id] has prefix 'err_', returns (nil, errors.New(id))
+// 1. Otherwise, returns ([]byte(id), nil)
+func (p *mockProvider) GetValue(id string) ([]byte, error) {
+	p.getValueCallArgs = append(p.getValueCallArgs, id)
+
+	if strings.HasPrefix(id, "err_") {
+		return nil, errors.New(id)
+	}
+	return []byte(id), nil
+}
+
+func TestGetValues(t *testing.T) {
+	Convey("GetValues", t, func() {
+		// ids, 4 of which are unique
+		ids := []string{"foo", "err_meow", "bar", "bar", "err_meow", "err_baz"}
+
+		Convey("Sequentially call GetValue on unique ids", func() {
+			p := &mockProvider{}
+			_, _ = GetValues(
+				p,
+				ids...,
+			)
+
+			So(p.getValueCallArgs, ShouldResemble, []string{"foo", "err_meow", "bar", "err_baz"})
+		})
+
+		Convey("Returns good or bad responses depending on unique ids", func() {
+			providerResponses, err := GetValues(
+				&mockProvider{},
+				ids...,
+			)
+			So(err, ShouldBeNil)
+			So(len(providerResponses), ShouldEqual, 4)
+
+			ensureGoodResponse(providerResponses, "foo")
+			ensureGoodResponse(providerResponses, "bar")
+			ensureErrResponse(providerResponses, "err_baz")
+			ensureErrResponse(providerResponses, "err_meow")
+		})
+	})
+}
+
+// ensureGoodResponse ensures [key] exists within a provider-responses map, and that the
+// entry has no error and the value is []byte(key), in line with how
+// mockProvider#GetValue works
+func ensureGoodResponse(responses map[string]ProviderResponse, key string) {
+	So(responses, ShouldContainKey, key)
+	So(responses[key].Error, ShouldBeNil)
+	So(responses[key].Value, ShouldResemble, []byte(key))
+}
+
+// ensureErrResponse ensures [key] exists within a provider-responses map, and that the
+// entry has no value and the error string is equal to [key], in line with how
+// mockProvider#GetValue works
+func ensureErrResponse(responses map[string]ProviderResponse, key string) {
+	So(responses, ShouldContainKey, key)
+	So(responses[key].Value, ShouldBeNil)
+	So(responses[key].Error.Error(), ShouldEqual, key)
+}

--- a/internal/plugin/v1/provider_test.go
+++ b/internal/plugin/v1/provider_test.go
@@ -1,30 +1,10 @@
 package v1
 
 import (
-	"errors"
-	"strings"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
-
-// mockProvider conforms to the singleValueProvider interface and allows testing the
-// singleValueProvider interface
-type mockProvider struct {
-	getValueCallArgs []string // keeps track of args for each call to getValue
-}
-
-// GetValue returns
-// 0. If [id] has prefix 'err_', returns (nil, errors.New(id))
-// 1. Otherwise, returns ([]byte(id), nil)
-func (p *mockProvider) GetValue(id string) ([]byte, error) {
-	p.getValueCallArgs = append(p.getValueCallArgs, id)
-
-	if strings.HasPrefix(id, "err_") {
-		return nil, errors.New(id)
-	}
-	return []byte(id), nil
-}
 
 func TestGetValues(t *testing.T) {
 	Convey("GetValues", t, func() {
@@ -32,18 +12,18 @@ func TestGetValues(t *testing.T) {
 		ids := []string{"foo", "err_meow", "bar", "bar", "err_meow", "err_baz"}
 
 		Convey("Sequentially call GetValue on unique ids", func() {
-			p := &mockProvider{}
+			p := &MockProvider{}
 			_, _ = GetValues(
 				p,
 				ids...,
 			)
 
-			So(p.getValueCallArgs, ShouldResemble, []string{"foo", "err_meow", "bar", "err_baz"})
+			So(p.GetValueCallArgs, ShouldResemble, []string{"foo", "err_meow", "bar", "err_baz"})
 		})
 
 		Convey("Returns good or bad responses depending on unique ids", func() {
 			providerResponses, err := GetValues(
-				&mockProvider{},
+				&MockProvider{},
 				ids...,
 			)
 			So(err, ShouldBeNil)
@@ -59,18 +39,18 @@ func TestGetValues(t *testing.T) {
 
 // ensureGoodResponse ensures [key] exists within a provider-responses map, and that the
 // entry has no error and the value is []byte(key), in line with how
-// mockProvider#GetValue works
+// MockProvider#GetValue works
 func ensureGoodResponse(responses map[string]ProviderResponse, key string) {
 	So(responses, ShouldContainKey, key)
 	So(responses[key].Error, ShouldBeNil)
-	So(responses[key].Value, ShouldResemble, []byte(key))
+	So(responses[key].Value, ShouldResemble, []byte(key+"_value"))
 }
 
 // ensureErrResponse ensures [key] exists within a provider-responses map, and that the
 // entry has no value and the error string is equal to [key], in line with how
-// mockProvider#GetValue works
+// MockProvider#GetValue works
 func ensureErrResponse(responses map[string]ProviderResponse, key string) {
 	So(responses, ShouldContainKey, key)
 	So(responses[key].Value, ShouldBeNil)
-	So(responses[key].Error.Error(), ShouldEqual, key)
+	So(responses[key].Error.Error(), ShouldEqual, key+"_value")
 }

--- a/internal/plugin/v1/testutils/testutils.go
+++ b/internal/plugin/v1/testutils/testutils.go
@@ -21,11 +21,54 @@ func CanProvide(provider plugin_v1.Provider, id string, expectedValue string) fu
 		values, err := provider.GetValues(id)
 
 		convey.So(err, convey.ShouldBeNil)
-		convey.So(values[id], convey.ShouldNotBeNil)
-		convey.So(values[id].Error, convey.ShouldBeNil)
-		convey.So(values[id].Value, convey.ShouldNotBeNil)
-		convey.So(string(values[id].Value), convey.ShouldEqual, expectedValue)
+
+		value := values[id]
+		assertGoodProviderResponse(value, expectedValue)
 	}
+}
+
+// CanProvideMultiple calls GetValues on the provider and ensures that the provider's
+// responses for the each id match the expected value and there are no errors. It also
+// duplicates some ids to ensure GetValues can handle multiple instances of the same id
+func CanProvideMultiple(
+	provider plugin_v1.Provider,
+	expectedStringValueByID map[string]string,
+) func() {
+	return func() {
+		ids := make([]string, 0, len(expectedStringValueByID)*2)
+		expectedStringValueByID := map[string]string{}
+
+		for id := range expectedStringValueByID {
+			ids = append(ids, id)
+			ids = append(ids, id)
+		}
+
+		responses, err := provider.GetValues(ids...)
+
+		// Ensure no global error
+		convey.So(err, convey.ShouldBeNil)
+		// Ensure there many responses as there are ids
+		convey.So(len(responses), convey.ShouldEqual, len(ids))
+		// Ensure each id has the expected response
+		for _, id := range ids {
+			assertGoodProviderResponse(
+				responses[id],
+				expectedStringValueByID[id],
+			)
+		}
+	}
+}
+
+// assertGoodProviderResponse asserts that a provider response has the expected string
+// value and no error
+func assertGoodProviderResponse(
+	response plugin_v1.ProviderResponse,
+	expectedValueAsStr string,
+) {
+	convey.So(response, convey.ShouldNotBeNil)
+	convey.So(response.Error, convey.ShouldBeNil)
+	convey.So(response.Value, convey.ShouldNotBeNil)
+	convey.So(string(response.Value), convey.ShouldEqual, expectedValueAsStr)
 }
 
 // ReportsTestCase captures a test case where a provider is expected to return an error

--- a/internal/plugin/v1/testutils/testutils.go
+++ b/internal/plugin/v1/testutils/testutils.go
@@ -1,0 +1,50 @@
+package testutils
+
+import (
+	"github.com/smartystreets/goconvey/convey"
+
+	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
+)
+
+// CanProvideTestCase captures a test case where a provider is expected to return a value
+// and no error
+type CanProvideTestCase struct {
+	Description   string
+	ID            string
+	ExpectedValue string
+}
+
+// CanProvide calls GetValues on the provider and ensures that the provider response for
+// the given id has the expected value and no error
+func CanProvide(provider plugin_v1.Provider, id string, expectedValue string) func() {
+	return func() {
+		values, err := provider.GetValues(id)
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(values[id], convey.ShouldNotBeNil)
+		convey.So(values[id].Error, convey.ShouldBeNil)
+		convey.So(values[id].Value, convey.ShouldNotBeNil)
+		convey.So(string(values[id].Value), convey.ShouldEqual, expectedValue)
+	}
+}
+
+// ReportsTestCase captures a test case where a provider is expected to return an error
+type ReportsTestCase struct {
+	Description       string
+	ID                string
+	ExpectedErrString string
+}
+
+// Reports calls GetValues on the provider and ensures that the provider response for the
+// given id has the expected error and no value
+func Reports(provider plugin_v1.Provider, id string, expectedErrString string) func() {
+	return func() {
+		values, err := provider.GetValues(id)
+
+		convey.So(err, convey.ShouldBeNil)
+		convey.So(values, convey.ShouldContainKey, id)
+		convey.So(values[id].Value, convey.ShouldBeNil)
+		convey.So(values[id].Error, convey.ShouldNotBeNil)
+		convey.So(values[id].Error.Error(), convey.ShouldEqual, expectedErrString)
+	}
+}

--- a/internal/providers/awssecrets/provider.go
+++ b/internal/providers/awssecrets/provider.go
@@ -48,7 +48,7 @@ func (p *Provider) GetName() string {
 
 // GetValues takes in variable ids and returns their resolved values. This method is
 // needed to the Provider interface
-func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+func (p *Provider) GetValues(ids ...string) (map[string]plugin_v1.ProviderResponse, error) {
 	return plugin_v1.GetValues(p, ids...)
 }
 

--- a/internal/providers/awssecrets/provider.go
+++ b/internal/providers/awssecrets/provider.go
@@ -46,6 +46,12 @@ func (p *Provider) GetName() string {
 	return p.Name
 }
 
+// GetValues takes in variable ids and returns their resolved values. This method is
+// needed to the Provider interface
+func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+	return plugin_v1.GetValues(p, ids...)
+}
+
 // GetValue obtains a secret value by id.
 func (p *Provider) GetValue(id string) ([]byte, error) {
 	client := p.Client

--- a/internal/providers/conjur/provider.go
+++ b/internal/providers/conjur/provider.go
@@ -139,6 +139,12 @@ func (p *Provider) GetName() string {
 	return p.Name
 }
 
+// GetValues takes in variable ids and returns their resolved values. This method is
+// needed to the Provider interface
+func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+	return plugin_v1.GetValues(p, ids...)
+}
+
 // GetValue obtains a value by ID. The recognized IDs are:
 //	* "accessToken"
 // 	* Any Conjur variable ID

--- a/internal/providers/conjur/provider.go
+++ b/internal/providers/conjur/provider.go
@@ -141,7 +141,7 @@ func (p *Provider) GetName() string {
 
 // GetValues takes in variable ids and returns their resolved values. This method is
 // needed to the Provider interface
-func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+func (p *Provider) GetValues(ids ...string) (map[string]plugin_v1.ProviderResponse, error) {
 	return plugin_v1.GetValues(p, ids...)
 }
 

--- a/internal/providers/env/provider.go
+++ b/internal/providers/env/provider.go
@@ -27,7 +27,7 @@ func (p *EnvironmentProvider) GetName() string {
 
 // GetValues takes in variable ids and returns their resolved values. This method is
 // needed to the Provider interface
-func (p *EnvironmentProvider) GetValues(ids ...string) ([][]byte, error) {
+func (p *EnvironmentProvider) GetValues(ids ...string) (map[string]plugin_v1.ProviderResponse, error) {
 	return plugin_v1.GetValues(p, ids...)
 }
 

--- a/internal/providers/env/provider.go
+++ b/internal/providers/env/provider.go
@@ -25,6 +25,12 @@ func (p *EnvironmentProvider) GetName() string {
 	return p.Name
 }
 
+// GetValues takes in variable ids and returns their resolved values. This method is
+// needed to the Provider interface
+func (p *EnvironmentProvider) GetValues(ids ...string) ([][]byte, error) {
+	return plugin_v1.GetValues(p, ids...)
+}
+
 // GetValue obtains a value by ID. Any environment is a recognized ID.
 func (p *EnvironmentProvider) GetValue(id string) (result []byte, err error) {
 	var found bool

--- a/internal/providers/file/provider.go
+++ b/internal/providers/file/provider.go
@@ -24,6 +24,12 @@ func (p *Provider) GetName() string {
 	return p.Name
 }
 
+// GetValues takes in variable ids and returns their resolved values. This method is
+// needed to the Provider interface
+func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+	return plugin_v1.GetValues(p, ids...)
+}
+
 // GetValue reads the contents of the identified file.
 func (p *Provider) GetValue(id string) ([]byte, error) {
 	return ioutil.ReadFile(id)

--- a/internal/providers/file/provider.go
+++ b/internal/providers/file/provider.go
@@ -26,7 +26,7 @@ func (p *Provider) GetName() string {
 
 // GetValues takes in variable ids and returns their resolved values. This method is
 // needed to the Provider interface
-func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+func (p *Provider) GetValues(ids ...string) (map[string]plugin_v1.ProviderResponse, error) {
 	return plugin_v1.GetValues(p, ids...)
 }
 

--- a/internal/providers/keychain/provider.go
+++ b/internal/providers/keychain/provider.go
@@ -25,6 +25,12 @@ func (p *Provider) GetName() string {
 	return p.Name
 }
 
+// GetValues takes in variable ids and returns their resolved values. This method is
+// needed to the Provider interface
+func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+	return plugin_v1.GetValues(p, ids...)
+}
+
 // GetValue reads the contents of the identified file.
 func (p *Provider) GetValue(id string) ([]byte, error) {
 	tokens := strings.Split(id, "#")

--- a/internal/providers/keychain/provider.go
+++ b/internal/providers/keychain/provider.go
@@ -27,7 +27,7 @@ func (p *Provider) GetName() string {
 
 // GetValues takes in variable ids and returns their resolved values. This method is
 // needed to the Provider interface
-func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+func (p *Provider) GetValues(ids ...string) (map[string]plugin_v1.ProviderResponse, error) {
 	return plugin_v1.GetValues(p, ids...)
 }
 

--- a/internal/providers/kubernetessecrets/provider.go
+++ b/internal/providers/kubernetessecrets/provider.go
@@ -38,6 +38,12 @@ func (p *Provider) GetName() string {
 	return p.Name
 }
 
+// GetValues takes in variable ids and returns their resolved values. This method is
+// needed to the Provider interface
+func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+	return plugin_v1.GetValues(p, ids...)
+}
+
 // GetValue obtains a value by id. Any secret which is stored in Kubernetes Secrets is recognized.
 // The data type returned by Kubernetes Secrets is map[string][]byte. Therefore this provider needs
 // to know which field to return from the map. The field to be returned is specified by appending '#fieldName' to the id argument.

--- a/internal/providers/kubernetessecrets/provider.go
+++ b/internal/providers/kubernetessecrets/provider.go
@@ -40,7 +40,7 @@ func (p *Provider) GetName() string {
 
 // GetValues takes in variable ids and returns their resolved values. This method is
 // needed to the Provider interface
-func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+func (p *Provider) GetValues(ids ...string) (map[string]plugin_v1.ProviderResponse, error) {
 	return plugin_v1.GetValues(p, ids...)
 }
 

--- a/internal/providers/literal/provider.go
+++ b/internal/providers/literal/provider.go
@@ -27,6 +27,6 @@ func (p *Provider) GetValue(id string) ([]byte, error) {
 
 // GetValues takes in variable ids and returns their resolved values. This method is
 // needed to the Provider interface
-func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+func (p *Provider) GetValues(ids ...string) (map[string]plugin_v1.ProviderResponse, error) {
 	return plugin_v1.GetValues(p, ids...)
 }

--- a/internal/providers/literal/provider.go
+++ b/internal/providers/literal/provider.go
@@ -24,3 +24,9 @@ func (p *Provider) GetName() string {
 func (p *Provider) GetValue(id string) ([]byte, error) {
 	return []byte(id), nil
 }
+
+// GetValues takes in variable ids and returns their resolved values. This method is
+// needed to the Provider interface
+func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+	return plugin_v1.GetValues(p, ids...)
+}

--- a/internal/providers/vault/provider.go
+++ b/internal/providers/vault/provider.go
@@ -129,6 +129,6 @@ func (p *Provider) GetValue(id string) ([]byte, error) {
 
 // GetValues takes in variable ids and returns their resolved values. This method is
 // needed to the Provider interface
-func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+func (p *Provider) GetValues(ids ...string) (map[string]plugin_v1.ProviderResponse, error) {
 	return plugin_v1.GetValues(p, ids...)
 }

--- a/internal/providers/vault/provider.go
+++ b/internal/providers/vault/provider.go
@@ -126,3 +126,9 @@ func (p *Provider) GetValue(id string) ([]byte, error) {
 
 	return parseSecret(secret, path, fields)
 }
+
+// GetValues takes in variable ids and returns their resolved values. This method is
+// needed to the Provider interface
+func (p *Provider) GetValues(ids ...string) ([][]byte, error) {
+	return plugin_v1.GetValues(p, ids...)
+}

--- a/internal/summon/command/run.go
+++ b/internal/summon/command/run.go
@@ -54,6 +54,10 @@ func resolveSecrets(provider plugin_v1.Provider, secretsMap secretsyml.SecretsMa
 		}
 	}
 
+	if atLeastOneVar := len(varSecretsSpecPaths) > 0; !atLeastOneVar {
+		return result, nil
+	}
+
 	// Get the variable values
 	providerResponses, err := provider.GetValues(varSecretsSpecPaths...)
 	if err != nil {

--- a/internal/summon/command/run_test.go
+++ b/internal/summon/command/run_test.go
@@ -1,0 +1,110 @@
+package command
+
+import (
+	"testing"
+
+	"github.com/cyberark/summon/secretsyml"
+	"github.com/stretchr/testify/assert"
+
+	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
+)
+
+func Test_resolveSecrets(t *testing.T) {
+	p := plugin_v1.MockProvider{}
+	secretsMap := func() secretsyml.SecretsMap {
+		return secretsyml.SecretsMap{
+			"bar": secretsyml.SecretSpec{
+				Tags: []secretsyml.YamlTag{secretsyml.Literal},
+				Path: "bar_path",
+			},
+			"baz": secretsyml.SecretSpec{
+				Tags: []secretsyml.YamlTag{secretsyml.Var},
+				Path: "baz_path",
+			},
+			"foo": secretsyml.SecretSpec{
+				Tags: []secretsyml.YamlTag{secretsyml.Var, secretsyml.File},
+				Path: "foo_path",
+			},
+		}
+	}
+
+	t.Run("Resolves variable and literal secrets", func(t *testing.T) {
+		secrets, err := resolveSecrets(
+			&p,
+			secretsMap(),
+		)
+
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(
+			t,
+			secrets,
+			map[string]string{
+				"bar": "bar_path",
+				"baz": "baz_path_value",
+				"foo": "foo_path_value",
+			})
+	})
+
+	t.Run("Reports errors", func(t *testing.T) {
+		sm := secretsMap()
+		sm["err1"] = secretsyml.SecretSpec{
+			Tags: []secretsyml.YamlTag{secretsyml.Var, secretsyml.File},
+			Path: "err_first",
+		}
+		sm["err2"] = secretsyml.SecretSpec{
+			Tags: []secretsyml.YamlTag{secretsyml.Var},
+			Path: "err_second",
+		}
+
+		secrets, err := resolveSecrets(
+			&p,
+			sm,
+		)
+
+		if !assert.EqualError(t, err, "err_first_value\nerr_second_value") {
+			return
+		}
+		assert.Nil(t, secrets)
+	})
+}
+
+func Test_buildEnvironment(t *testing.T) {
+	tempFactory := NewTempFactory("")
+
+	defer tempFactory.Cleanup()
+
+	env, err := buildEnvironment(
+		map[string]string{
+			"bar": "bar_val",
+			"baz": "baz_val",
+			"foo": "foo_val",
+		},
+		secretsyml.SecretsMap{
+			"bar": secretsyml.SecretSpec{
+				Tags: []secretsyml.YamlTag{secretsyml.Literal, secretsyml.File},
+			},
+			"baz": secretsyml.SecretSpec{
+				Tags: []secretsyml.YamlTag{secretsyml.Literal, secretsyml.File},
+			},
+			"foo": secretsyml.SecretSpec{
+				Tags: []secretsyml.YamlTag{secretsyml.Literal},
+			},
+		},
+		&tempFactory,
+	)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(
+		t,
+		env,
+		[]string{
+			"bar=" + tempFactory.files[0],
+			"baz=" + tempFactory.files[1],
+			"foo=foo_val",
+		},
+	)
+}

--- a/internal/summon/command/temp_factory_test.go
+++ b/internal/summon/command/temp_factory_test.go
@@ -9,9 +9,6 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-// TODO: Test TempFactory.Cleanup()
-// TODO: Test TempFactory.Push()
-
 func splitEq(s string) (string, string) {
 	a := strings.SplitN(s, "=", 2)
 	return a[0], a[1]
@@ -39,9 +36,61 @@ func (e *envSnapshot) restoreEnv() {
 	}
 }
 
+func assertMissingFile(f string) {
+	_, err := os.Stat(f)
+	So(err, ShouldNotBeNil)
+	So(err.Error(), ShouldContainSubstring, "no such file or directory")
+}
+
+func assertFileContents(f string, expectedValue string) {
+	actualContent, err := ioutil.ReadFile(f)
+	So(err, ShouldBeNil)
+	So(expectedValue, ShouldEqual, string(actualContent))
+}
+
+func TestTempFactory_Cleanup(t *testing.T) {
+	Convey("Cleanup deletes all temp files", t, func() {
+		tempFactory := NewCustomTempFactory("", "non-existent")
+
+		f1, err := tempFactory.Push("meow")
+		So(err, ShouldBeNil)
+		f2, err := tempFactory.Push("moo")
+		So(err, ShouldBeNil)
+
+		assertFileContents(f1, "meow")
+		assertFileContents(f2, "moo")
+
+		tempFactory.Cleanup()
+
+		assertMissingFile(f1)
+		assertMissingFile(f2)
+	})
+}
+
+func TestTempFactory_Push(t *testing.T) {
+	Convey("Push creates temp file", t, func() {
+		tempFactory := NewTempFactory("")
+		defer tempFactory.Cleanup()
+
+		f, err := tempFactory.Push("moo")
+		So(err, ShouldBeNil)
+		assertFileContents(f, "moo")
+	})
+
+	Convey("Push reports errors", t, func() {
+		tempFactory := NewTempFactory("dir-not-found")
+		defer tempFactory.Cleanup()
+
+		_, err := tempFactory.Push("moo")
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "no such file or directory")
+	})
+}
+
 func TestTempFactory_NewTempFactory(t *testing.T) {
 	Convey("Uses constructor arg path if provided", t, func() {
 		tempFactory := NewTempFactory("somedir")
+		defer tempFactory.Cleanup()
 
 		So(tempFactory, ShouldResemble, TempFactory{
 			files: []string(nil),
@@ -55,6 +104,11 @@ func TestTempFactory_NewTempFactory(t *testing.T) {
 
 		Convey("tries using shared memory path first", func() {
 			tempFactory := NewTempFactory("")
+
+			_, err := os.Stat("/dev/shm")
+			if os.IsNotExist(err) {
+				return
+			}
 
 			So(tempFactory, ShouldResemble, TempFactory{
 				files: []string(nil),

--- a/k8s-ci/k8s_crds/test
+++ b/k8s-ci/k8s_crds/test
@@ -16,6 +16,11 @@ exit_err() {
    cat ${log};
    rm -rf ${log};
 
+
+  # Snapshot of workloads
+  kubectl --namespace "$(current_namespace)" get pods || true
+  kubectl --namespace "$(current_namespace)" get events --field-selector type=Warning || true
+
    exit 1
 }
 
@@ -69,7 +74,7 @@ function wait_for_CRD() {
 
 function wait_for_pod() {
   echo "waiting for pod to be ready"
-  
+
   local attempt_count=0
   local max_attempts=10
   until pod_ready; do
@@ -161,4 +166,4 @@ function main() {
   run_test_case "update configuration object" ohnoeswechangedit supersecretpassword
 }
 
-main
+main || exit_err "Failed inside main"

--- a/k8s-ci/k8s_crds/test
+++ b/k8s-ci/k8s_crds/test
@@ -18,10 +18,14 @@ exit_err() {
 
 
   # Snapshot of workloads
+  echo "- Snapshot of workloads on exit"
+  echo "-- Current namespace: $(current_namespace)"
+  echo "-- Pods in namespace:"
   kubectl --namespace "$(current_namespace)" get pods || true
+  echo "-- Warning events in namespace:"
   kubectl --namespace "$(current_namespace)" get events --field-selector type=Warning || true
 
-   exit 1
+  exit 1
 }
 
 function cleanup() {

--- a/k8s-ci/k8s_crds/test
+++ b/k8s-ci/k8s_crds/test
@@ -166,4 +166,4 @@ function main() {
   run_test_case "update configuration object" ohnoeswechangedit supersecretpassword
 }
 
-main || exit_err "Failed inside main"
+main || exit_err "K8s-CRD test: Failed inside main()"

--- a/k8s-ci/k8s_crds/test
+++ b/k8s-ci/k8s_crds/test
@@ -9,13 +9,12 @@ rm -rf ${log}
 export SECRETLESS_CRD_SUFFIX=${TEST_ID-}
 
 exit_err() {
-   printf '\n--------------------- \n\n'
-   printf '\n- exited\n\n'
-   echo >&2 "${1}"
-   printf '\n-- last logs\n\n'
-   cat ${log};
-   rm -rf ${log};
-
+  printf '\n--------------------- \n\n'
+  printf '\n- exited\n\n'
+  echo >&2 "${1}"
+  printf '\n-- last logs\n\n'
+  cat ${log};
+  rm -rf ${log};
 
   # Snapshot of workloads
   echo "- Snapshot of workloads on exit"

--- a/k8s-ci/k8s_crds/test
+++ b/k8s-ci/k8s_crds/test
@@ -18,11 +18,10 @@ exit_err() {
 
   # Snapshot of workloads
   echo "- Snapshot of workloads on exit"
-  echo "-- Current namespace: $(current_namespace)"
-  echo "-- Pods in namespace:"
-  kubectl --namespace "$(current_namespace)" get pods || true
-  echo "-- Warning events in namespace:"
-  kubectl --namespace "$(current_namespace)" get events --field-selector type=Warning || true
+  echo "-- Pods:"
+  kubectl get pods || true
+  echo "-- Warning events:"
+  kubectl get events --field-selector type=Warning || true
 
   exit 1
 }

--- a/test/connector/http/conjur/conjur_provider_test.go
+++ b/test/connector/http/conjur/conjur_provider_test.go
@@ -32,46 +32,46 @@ func TestConjur_Provider(t *testing.T) {
 	})
 
 	Convey("Can provide an access token", t, func() {
-		value, err := provider.GetValue("accessToken")
+		values, err := provider.GetValues("accessToken")
 		So(err, ShouldBeNil)
 
 		token := make(map[string]string)
-		err = json.Unmarshal(value, &token)
+		err = json.Unmarshal(values[0], &token)
 		So(err, ShouldBeNil)
 		So(token["protected"], ShouldNotBeNil)
 		So(token["payload"], ShouldNotBeNil)
 	})
 
 	Convey("Can provide a secret to a fully qualified variable", t, func() {
-		value, err := provider.GetValue("dev:variable:db/password")
+		values, err := provider.GetValues("dev:variable:db/password")
 		So(err, ShouldBeNil)
 
-		So(string(value), ShouldEqual, "secret")
+		So(string(values[0]), ShouldEqual, "secret")
 	})
 
 	Convey("Can retrieve a secret value with spaces", t, func() {
-		value, err := provider.GetValue("my var")
+		values, err := provider.GetValues("my var")
 		So(err, ShouldBeNil)
 
-		So(string(value), ShouldEqual, "othersecret")
+		So(string(values[0]), ShouldEqual, "othersecret")
 	})
 
 	Convey("Can provide the default Conjur account name", t, func() {
-		value, err := provider.GetValue("variable:db/password")
+		values, err := provider.GetValues("variable:db/password")
 		So(err, ShouldBeNil)
 
-		So(string(value), ShouldEqual, "secret")
+		So(string(values[0]), ShouldEqual, "secret")
 	})
 
 	Convey("Can provide the default Conjur account name and resource type", t, func() {
-		value, err := provider.GetValue("db/password")
+		values, err := provider.GetValues("db/password")
 		So(err, ShouldBeNil)
 
-		So(string(value), ShouldEqual, "secret")
+		So(string(values[0]), ShouldEqual, "secret")
 	})
 
 	Convey("Cannot provide an unknown value", t, func() {
-		_, err = provider.GetValue("foobar")
+		_, err = provider.GetValues("foobar")
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "404 Not Found. Variable 'foobar' not found in account 'dev'.")
 	})

--- a/test/connector/http/conjur/conjur_provider_test.go
+++ b/test/connector/http/conjur/conjur_provider_test.go
@@ -32,47 +32,74 @@ func TestConjur_Provider(t *testing.T) {
 	})
 
 	Convey("Can provide an access token", t, func() {
-		values, err := provider.GetValues("accessToken")
+		id := "accessToken"
+		values, err := provider.GetValues(id)
+
 		So(err, ShouldBeNil)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
 
 		token := make(map[string]string)
-		err = json.Unmarshal(values[0], &token)
+		err = json.Unmarshal(values[id].Value, &token)
 		So(err, ShouldBeNil)
 		So(token["protected"], ShouldNotBeNil)
 		So(token["payload"], ShouldNotBeNil)
 	})
 
 	Convey("Can provide a secret to a fully qualified variable", t, func() {
-		values, err := provider.GetValues("dev:variable:db/password")
-		So(err, ShouldBeNil)
+		id := "dev:variable:db/password"
+		values, err := provider.GetValues(id)
 
-		So(string(values[0]), ShouldEqual, "secret")
+		So(err, ShouldBeNil)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, "secret")
 	})
 
 	Convey("Can retrieve a secret value with spaces", t, func() {
-		values, err := provider.GetValues("my var")
-		So(err, ShouldBeNil)
+		id := "my var"
+		values, err := provider.GetValues(id)
 
-		So(string(values[0]), ShouldEqual, "othersecret")
+		So(err, ShouldBeNil)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, "othersecret")
 	})
 
 	Convey("Can provide the default Conjur account name", t, func() {
-		values, err := provider.GetValues("variable:db/password")
-		So(err, ShouldBeNil)
+		id := "variable:db/password"
+		values, err := provider.GetValues(id)
 
-		So(string(values[0]), ShouldEqual, "secret")
+		So(err, ShouldBeNil)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, "secret")
 	})
 
 	Convey("Can provide the default Conjur account name and resource type", t, func() {
-		values, err := provider.GetValues("db/password")
-		So(err, ShouldBeNil)
+		id := "db/password"
+		values, err := provider.GetValues(id)
 
-		So(string(values[0]), ShouldEqual, "secret")
+		So(err, ShouldBeNil)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, "secret")
 	})
 
 	Convey("Cannot provide an unknown value", t, func() {
-		_, err = provider.GetValues("foobar")
-		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldEqual, "404 Not Found. Variable 'foobar' not found in account 'dev'.")
+		id := "foobar"
+
+		values, err := provider.GetValues(id)
+
+		So(err, ShouldBeNil)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldNotBeNil)
+		So(values[id].Error.Error(), ShouldEqual, "404 Not Found. Variable 'foobar' not found in account 'dev'.")
+		So(values[id].Value, ShouldBeNil)
 	})
 }

--- a/test/providers/keychain/keychain_provider_test.go
+++ b/test/providers/keychain/keychain_provider_test.go
@@ -40,15 +40,15 @@ func TestKeychainProvider(t *testing.T) {
 	Convey("Can provide a valid secret value", t, func() {
 		id := strings.Join([]string{service, account}, "#")
 
-		value, err := provider.GetValue(id)
+		values, err := provider.GetValues(id)
 		So(err, ShouldBeNil)
-		So(string(value), ShouldEqual, secret)
+		So(string(values[0]), ShouldEqual, secret)
 	})
 
 	Convey("Returns an error for an invalid secret value", t, func() {
 		id := "madeup#secret"
 
-		_, err := provider.GetValue(id)
+		_, err := provider.GetValues(id)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "The specified item could not be found in the keychain.")
 	})

--- a/test/providers/keychain/keychain_provider_test.go
+++ b/test/providers/keychain/keychain_provider_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 	"testing"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
@@ -22,6 +21,15 @@ func TestKeychainProvider(t *testing.T) {
 	service := os.Getenv("SERVICE")
 	account := os.Getenv("ACCOUNT")
 	secret := os.Getenv("SECRET")
+
+	// e.g. ${service}_1#${account}_1
+	getSecretPath := func(idx int) string {
+		return service + "_" + string(idx) + "#" + account + "_" + string(idx)
+	}
+	// e.g. ${secret}_1
+	getSecretValue := func(idx int) string {
+		return secret + "_" + string(idx)
+	}
 
 	options := plugin_v1.ProviderOptions{
 		Name: name,
@@ -43,8 +51,21 @@ func TestKeychainProvider(t *testing.T) {
 		t,
 		testutils.CanProvide(
 			provider,
-			strings.Join([]string{service, account}, "#"),
-			secret,
+			getSecretPath(1),
+			getSecretValue(1),
+		),
+	)
+
+	Convey(
+		"Multiple Provides ",
+		t,
+		testutils.CanProvideMultiple(
+			provider,
+			map[string]string{
+				getSecretPath(1): getSecretValue(1),
+				getSecretPath(2): getSecretValue(2),
+				getSecretPath(3): getSecretValue(3),
+			},
 		),
 	)
 

--- a/test/providers/keychain/keychain_provider_test.go
+++ b/test/providers/keychain/keychain_provider_test.go
@@ -42,14 +42,20 @@ func TestKeychainProvider(t *testing.T) {
 
 		values, err := provider.GetValues(id)
 		So(err, ShouldBeNil)
-		So(string(values[0]), ShouldEqual, secret)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, secret)
 	})
 
 	Convey("Returns an error for an invalid secret value", t, func() {
 		id := "madeup#secret"
 
-		_, err := provider.GetValues(id)
-		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldEqual, "The specified item could not be found in the keychain.")
+		values, err := provider.GetValues(id)
+		So(err, ShouldBeNil)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldNotBeNil)
+		So(values[id].Error.Error(), ShouldEqual, "The specified item could not be found in the keychain.")
+		So(values[id].Value, ShouldBeNil)
 	})
 }

--- a/test/providers/keychain/keychain_provider_test.go
+++ b/test/providers/keychain/keychain_provider_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
+	"github.com/cyberark/secretless-broker/internal/plugin/v1/testutils"
 	"github.com/cyberark/secretless-broker/internal/providers"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -37,25 +38,23 @@ func TestKeychainProvider(t *testing.T) {
 		So(provider.GetName(), ShouldEqual, name)
 	})
 
-	Convey("Can provide a valid secret value", t, func() {
-		id := strings.Join([]string{service, account}, "#")
+	Convey(
+		"Can provide a valid secret value",
+		t,
+		testutils.CanProvide(
+			provider,
+			strings.Join([]string{service, account}, "#"),
+			secret,
+		),
+	)
 
-		values, err := provider.GetValues(id)
-		So(err, ShouldBeNil)
-		So(values[id], ShouldNotBeNil)
-		So(values[id].Error, ShouldBeNil)
-		So(values[id].Value, ShouldNotBeNil)
-		So(string(values[id].Value), ShouldEqual, secret)
-	})
-
-	Convey("Returns an error for an invalid secret value", t, func() {
-		id := "madeup#secret"
-
-		values, err := provider.GetValues(id)
-		So(err, ShouldBeNil)
-		So(values[id], ShouldNotBeNil)
-		So(values[id].Error, ShouldNotBeNil)
-		So(values[id].Error.Error(), ShouldEqual, "The specified item could not be found in the keychain.")
-		So(values[id].Value, ShouldBeNil)
-	})
+	Convey(
+		"Returns an error for an invalid secret value",
+		t,
+		testutils.CanProvide(
+			provider,
+			"madeup#secret",
+			"The specified item could not be found in the keychain.",
+		),
+	)
 }

--- a/test/providers/keychain/load_test_env_vars
+++ b/test/providers/keychain/load_test_env_vars
@@ -5,3 +5,4 @@ set -euo pipefail
 export SERVICE="Secretless_Test"
 export ACCOUNT="KeychainProvider"
 export SECRET="secret"
+export NUM_SECRETS="3"

--- a/test/providers/keychain/start
+++ b/test/providers/keychain/start
@@ -10,16 +10,24 @@ echo "Deleting prior password values stored for this test..."
 source load_test_env_vars
 
 # add secrets to keychain
-security add-generic-password \
-  -a $ACCOUNT \
-  -s $SERVICE \
-  -w $SECRET
+for (( idx=1; idx<=NUM_SECRETS; idx++ ))
+do
+  secret_account="${ACCOUNT}_${idx}"
+  secret_service="${SERVICE}_${idx}"
+  secret_value="${SECRET}_${idx}"
 
-# verify that the secret has been loaded successfully
-secret=$(security find-generic-password -a $ACCOUNT -s $SERVICE -w)
-if [[ "$secret" == "$SECRET" ]]; then
-  echo "Secret has been loaded"
-else
-  echo "Error loading secret"
-  exit 1
-fi
+  security add-generic-password \
+    -a "${secret_account}" \
+    -s "${secret_service}" \
+    -w "${secret_value}"
+
+  # verify that the secret has been loaded successfully
+  stored_secret_value=$(security find-generic-password \
+    -a "${secret_account}" -s "${secret_service}" -w)
+  if [[ "${stored_secret_value}" == "${secret_value}" ]]; then
+    echo "Secret has been loaded"
+  else
+    echo "Error loading a secret"
+    exit 1
+  fi
+done

--- a/test/providers/keychain/stop
+++ b/test/providers/keychain/stop
@@ -5,18 +5,24 @@ set -euo pipefail
 # load the environment with the test config
 source load_test_env_vars
 
-# delete the password if it exists, and send stderr to stdout
-# do not die if the request errors
-delete_output="$(security delete-generic-password \
-                -a $ACCOUNT \
-                -s $SERVICE 2>&1)" || true
+for (( idx=1; idx<=NUM_SECRETS; idx++ ))
+do
+  secret_account="${ACCOUNT}_${idx}"
+  secret_service="${SERVICE}_${idx}"
 
-# if output includes "SecKeychainSearchCopyNext", password does not exist
-# overwrite output messages for clarity / simplicity
-if [[ $delete_output == *"SecKeychainSearchCopyNext"* ]]; then
-  echo "Password does not exist."
-elif [[ $delete_output == *"password has been deleted"* ]]; then
-  echo "Password has been deleted."
-else
-  echo "$delete_output"
-fi
+  # delete the password if it exists, and send stderr to stdout
+  # do not die if the request errors
+  delete_output="$(security delete-generic-password \
+                  -a "${secret_account}" \
+                  -s "${secret_service}" 2>&1)" || true
+
+  # if output includes "SecKeychainSearchCopyNext", password does not exist
+  # overwrite output messages for clarity / simplicity
+  if [[ "${delete_output}" == *"SecKeychainSearchCopyNext"* ]]; then
+    echo "Password does not exist."
+  elif [[ "${delete_output}" == *"password has been deleted"* ]]; then
+    echo "Password has been deleted."
+  else
+    echo "${delete_output}"
+  fi
+done

--- a/test/providers/kubernetessecrets/kubernetes_provider_test.go
+++ b/test/providers/kubernetessecrets/kubernetes_provider_test.go
@@ -53,36 +53,36 @@ func TestKubernetes_Provider(t *testing.T) {
 	})
 
 	Convey("Reports when the secret id does not contain a field name", t, func() {
-		value, err := provider.GetValue("foobar")
+		values, err := provider.GetValues("foobar")
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "Kubernetes secret id must contain secret name and field name in the format secretName#fieldName, received 'foobar'")
-		So(value, ShouldBeNil)
+		So(values, ShouldBeNil)
 	})
 
 	Convey("Reports when the secret id has empty field name", t, func() {
-		value, err := provider.GetValue("foobar#")
+		values, err := provider.GetValues("foobar#")
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "field name missing from Kubernetes secret id 'foobar#'")
-		So(value, ShouldBeNil)
+		So(values, ShouldBeNil)
 	})
 
 	Convey("Reports when Kubernetes is unable to find secret", t, func() {
-		value, err := provider.GetValue("foobar#maybe")
+		values, err := provider.GetValues("foobar#maybe")
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "could not find Kubernetes secret from 'foobar#maybe'")
-		So(value, ShouldBeNil)
+		So(values, ShouldBeNil)
 	})
 
 	Convey("Reports when Kubernetes is unable to find field name in secret", t, func() {
-		value, err := provider.GetValue("database#missing")
+		values, err := provider.GetValues("database#missing")
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "could not find field 'missing' in Kubernetes secret 'database'")
-		So(value, ShouldBeNil)
+		So(values, ShouldBeNil)
 	})
 
 	Convey("Can provide a secret", t, func() {
-		value, err := provider.GetValue("database#password")
+		values, err := provider.GetValues("database#password")
 		So(err, ShouldBeNil)
-		So(string(value), ShouldEqual, "secret")
+		So(string(values[0]), ShouldEqual, "secret")
 	})
 }

--- a/test/providers/kubernetessecrets/test
+++ b/test/providers/kubernetessecrets/test
@@ -9,7 +9,7 @@ while getopts :l opt; do
 done
 
 if $local_test; then
-  docker_args="-v $(cd ../..; pwd):/secretless"
+  docker_args="-v $(cd ../../..; pwd):/secretless"
 fi
 
 docker-compose run \

--- a/test/providers/vault/vault_provider_test.go
+++ b/test/providers/vault/vault_provider_test.go
@@ -29,48 +29,80 @@ func TestVault_Provider(t *testing.T) {
 	})
 
 	Convey("Reports when the secret is not found", t, func() {
-		values, err := provider.GetValues("foobar")
-		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldEqual, "HashiCorp Vault provider could not find secret 'foobar'")
-		So(values[0], ShouldBeNil)
+		id := "foobar"
+		values, err := provider.GetValues(id)
+
+		So(err, ShouldBeNil)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldNotBeNil)
+		So(values[id].Error, ShouldEqual, "HashiCorp Vault provider could not find secret 'foobar'")
+		So(values[id].Value, ShouldBeNil)
 	})
 
 	Convey("Reports when a field in the secret is not found", t, func() {
-		values, err := provider.GetValues("cubbyhole/first-secret#foo.bar")
-		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldEqual, "HashiCorp Vault provider expects secret in 'foo.bar' at 'cubbyhole/first-secret'")
-		So(values[0], ShouldBeNil)
+		id := "cubbyhole/first-secret#foo.bar"
+		values, err := provider.GetValues(id)
+
+		So(err, ShouldBeNil)
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldNotBeNil)
+		So(values[id].Error, ShouldEqual, "HashiCorp Vault provider expects secret in 'foo.bar' at 'cubbyhole/first-secret'")
+		So(values[id].Value, ShouldBeNil)
 	})
 
 	Convey("Can provide a cubbyhole secret", t, func() {
-		values, err := provider.GetValues("cubbyhole/first-secret#some-key")
+		id := "cubbyhole/first-secret#some-key"
+		values, err := provider.GetValues(id)
+
 		So(err, ShouldBeNil)
-		So(string(values[0]), ShouldEqual, "one")
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, "one")
 	})
 
 	Convey("Can provide a cubbyhole secret with default field name", t, func() {
-		values, err := provider.GetValues("cubbyhole/second-secret")
+		id :="cubbyhole/second-secret"
+		values, err := provider.GetValues(id)
+
 		So(err, ShouldBeNil)
-		So(string(values[0]), ShouldEqual, "two")
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, "two")
 	})
 
 	Convey("Can provide a KV v1 secret", t, func() {
-		values, err := provider.GetValues("kv/db/password#password")
+		id := "kv/db/password#password"
+		values, err := provider.GetValues(id)
+
 		So(err, ShouldBeNil)
-		So(string(values[0]), ShouldEqual, "db-secret")
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, "db-secret")
 	})
 
 	Convey("Can provide a KV v1 secret with default field name", t, func() {
-		values, err := provider.GetValues("kv/web/password")
+		id := "kv/web/password"
+		values, err := provider.GetValues(id)
+
 		So(err, ShouldBeNil)
-		So(err, ShouldBeNil)
-		So(string(values[0]), ShouldEqual, "web-secret")
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, "web-secret")
 	})
 
 	// note the "data" in path and in the fields to navigate, which is required in KV v2
 	Convey("Can provide latest KV v2 secret", t, func() {
-		values, err := provider.GetValues("secret/data/service#data.api-key")
+		id := "secret/data/service#data.api-key"
+		values, err := provider.GetValues(id)
+
 		So(err, ShouldBeNil)
-		So(string(values[0]), ShouldEqual, "service-api-key")
+		So(values[id], ShouldNotBeNil)
+		So(values[id].Error, ShouldBeNil)
+		So(values[id].Value, ShouldNotBeNil)
+		So(string(values[id].Value), ShouldEqual, "service-api-key")
 	})
 }

--- a/test/providers/vault/vault_provider_test.go
+++ b/test/providers/vault/vault_provider_test.go
@@ -29,47 +29,48 @@ func TestVault_Provider(t *testing.T) {
 	})
 
 	Convey("Reports when the secret is not found", t, func() {
-		value, err := provider.GetValue("foobar")
+		values, err := provider.GetValues("foobar")
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "HashiCorp Vault provider could not find secret 'foobar'")
-		So(value, ShouldBeNil)
+		So(values[0], ShouldBeNil)
 	})
 
 	Convey("Reports when a field in the secret is not found", t, func() {
-		value, err := provider.GetValue("cubbyhole/first-secret#foo.bar")
+		values, err := provider.GetValues("cubbyhole/first-secret#foo.bar")
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "HashiCorp Vault provider expects secret in 'foo.bar' at 'cubbyhole/first-secret'")
-		So(value, ShouldBeNil)
+		So(values[0], ShouldBeNil)
 	})
 
 	Convey("Can provide a cubbyhole secret", t, func() {
-		value, err := provider.GetValue("cubbyhole/first-secret#some-key")
+		values, err := provider.GetValues("cubbyhole/first-secret#some-key")
 		So(err, ShouldBeNil)
-		So(string(value), ShouldEqual, "one")
+		So(string(values[0]), ShouldEqual, "one")
 	})
 
 	Convey("Can provide a cubbyhole secret with default field name", t, func() {
-		value, err := provider.GetValue("cubbyhole/second-secret")
+		values, err := provider.GetValues("cubbyhole/second-secret")
 		So(err, ShouldBeNil)
-		So(string(value), ShouldEqual, "two")
+		So(string(values[0]), ShouldEqual, "two")
 	})
 
 	Convey("Can provide a KV v1 secret", t, func() {
-		value, err := provider.GetValue("kv/db/password#password")
+		values, err := provider.GetValues("kv/db/password#password")
 		So(err, ShouldBeNil)
-		So(string(value), ShouldEqual, "db-secret")
+		So(string(values[0]), ShouldEqual, "db-secret")
 	})
 
 	Convey("Can provide a KV v1 secret with default field name", t, func() {
-		value, err := provider.GetValue("kv/web/password")
+		values, err := provider.GetValues("kv/web/password")
 		So(err, ShouldBeNil)
-		So(string(value), ShouldEqual, "web-secret")
+		So(err, ShouldBeNil)
+		So(string(values[0]), ShouldEqual, "web-secret")
 	})
 
 	// note the "data" in path and in the fields to navigate, which is required in KV v2
 	Convey("Can provide latest KV v2 secret", t, func() {
-		value, err := provider.GetValue("secret/data/service#data.api-key")
+		values, err := provider.GetValues("secret/data/service#data.api-key")
 		So(err, ShouldBeNil)
-		So(string(value), ShouldEqual, "service-api-key")
+		So(string(values[0]), ShouldEqual, "service-api-key")
 	})
 }

--- a/test/providers/vault/vault_provider_test.go
+++ b/test/providers/vault/vault_provider_test.go
@@ -46,6 +46,19 @@ func TestVault_Provider(t *testing.T) {
 			)
 		}
 	})
+
+	Convey(
+		"Multiple Provides ",
+		t,
+		testutils.CanProvideMultiple(
+			provider,
+			map[string]string{
+				"cubbyhole/first-secret#some-key": "one",
+				"cubbyhole/second-secret":         "two",
+				"kv/db/password#password":         "two",
+			},
+		),
+	)
 }
 
 var reportsTestCases = []testutils.ReportsTestCase{

--- a/test/providers/vault/vault_provider_test.go
+++ b/test/providers/vault/vault_provider_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
+	"github.com/cyberark/secretless-broker/internal/plugin/v1/testutils"
 	"github.com/cyberark/secretless-broker/internal/providers"
 )
 
@@ -31,8 +32,8 @@ func TestVault_Provider(t *testing.T) {
 	Convey("Reports", t, func() {
 		for _, testCase := range reportsTestCases {
 			Convey(
-				testCase.description,
-				reports(provider, testCase.id, testCase.expectedErrString),
+				testCase.Description,
+				testutils.Reports(provider, testCase.ID, testCase.ExpectedErrString),
 			)
 		}
 	})
@@ -40,89 +41,53 @@ func TestVault_Provider(t *testing.T) {
 	Convey("Provides", t, func() {
 		for _, testCase := range canProvideTestCases {
 			Convey(
-				testCase.description,
-				canProvide(provider, testCase.id, testCase.expectedValue),
+				testCase.Description,
+				testutils.CanProvide(provider, testCase.ID, testCase.ExpectedValue),
 			)
 		}
 	})
 }
 
-type canProvideTestCase struct {
-	description   string
-	id            string
-	expectedValue string
-}
-
-func canProvide(provider plugin_v1.Provider, id string, expectedValue string) func() {
-	return func() {
-		values, err := provider.GetValues(id)
-
-		So(err, ShouldBeNil)
-		So(values[id], ShouldNotBeNil)
-		So(values[id].Error, ShouldBeNil)
-		So(values[id].Value, ShouldNotBeNil)
-		So(string(values[id].Value), ShouldEqual, expectedValue)
-	}
-}
-
-type reportsTestCase struct {
-	description       string
-	id                string
-	expectedErrString string
-}
-
-func reports(provider plugin_v1.Provider, id string, expectedErrString string) func() {
-	return func() {
-		values, err := provider.GetValues(id)
-
-		So(err, ShouldBeNil)
-		So(values[id], ShouldNotBeNil)
-		So(values[id].Error, ShouldNotBeNil)
-		So(values[id].Error.Error(), ShouldEqual, expectedErrString)
-		So(values[id].Value, ShouldBeNil)
-	}
-}
-
-var reportsTestCases = []reportsTestCase{
+var reportsTestCases = []testutils.ReportsTestCase{
 	{
-		description: "Reports when the secret is not found",
-		id:          "foobar",
-		expectedErrString: "HashiCorp Vault provider could not find secret " +
+		Description: "Reports when the secret is not found",
+		ID:          "foobar",
+		ExpectedErrString: "HashiCorp Vault provider could not find secret " +
 			"'foobar'",
 	},
 	{
-		description: "Reports when a field in the secret is not found",
-		id:          "cubbyhole/first-secret#foo.bar",
-		expectedErrString: "HashiCorp Vault provider expects secret in " +
+		Description: "Reports when a field in the secret is not found",
+		ID:          "cubbyhole/first-secret#foo.bar",
+		ExpectedErrString: "HashiCorp Vault provider expects secret in " +
 			"'foo.bar' at 'cubbyhole/first-secret'",
 	},
 }
 
-var canProvideTestCases = []canProvideTestCase{
+var canProvideTestCases = []testutils.CanProvideTestCase{
 	{
-		description:   "Can provide a cubbyhole secret",
-		id:            "cubbyhole/first-secret#some-key",
-		expectedValue: "one",
+		Description:   "Can provide a cubbyhole secret",
+		ID:            "cubbyhole/first-secret#some-key",
+		ExpectedValue: "one",
 	},
 	{
-		description:   "Can provide a cubbyhole secret with default field name",
-		id:            "cubbyhole/second-secret",
-		expectedValue: "two",
+		Description:   "Can provide a cubbyhole secret with default field name",
+		ID:            "cubbyhole/second-secret",
+		ExpectedValue: "two",
 	},
 	{
-		description:   "Can provide a KV v1 secret",
-		id:            "kv/db/password#password",
-		expectedValue: "db-secret",
+		Description:   "Can provide a KV v1 secret",
+		ID:            "kv/db/password#password",
+		ExpectedValue: "db-secret",
 	},
 	{
-		description:   "Can provide a KV v1 secret with default field name",
-		id:            "kv/web/password",
-		expectedValue: "web-secret",
+		Description:   "Can provide a KV v1 secret with default field name",
+		ID:            "kv/web/password",
+		ExpectedValue: "web-secret",
 	},
 	{
 		// note the "data" in path and in the fields to navigate, which is required in KV v2
-		description:   "Can provide latest KV v2 secret",
-		id:            "secret/data/service#data.api-key",
-		expectedValue: "service-api-key",
+		Description:   "Can provide latest KV v2 secret",
+		ID:            "secret/data/service#data.api-key",
+		ExpectedValue: "service-api-key",
 	},
 }

--- a/test/summon2/summon2_run_test.go
+++ b/test/summon2/summon2_run_test.go
@@ -21,6 +21,13 @@ type MapProvider struct {
 func (mp MapProvider) GetName() string {
 	return "mapProvider"
 }
+
+// GetValues takes in variable ids and returns their resolved values. This method is
+// needed to the Provider interface
+func (mp MapProvider) GetValues(ids ...string) ([][]byte, error) {
+	return plugin_v1.GetValues(mp, ids...)
+}
+
 func (mp MapProvider) GetValue(id string) ([]byte, error) {
 	value, ok := mp.Secrets[id]
 	if ok {

--- a/test/summon2/summon2_run_test.go
+++ b/test/summon2/summon2_run_test.go
@@ -24,7 +24,7 @@ func (mp MapProvider) GetName() string {
 
 // GetValues takes in variable ids and returns their resolved values. This method is
 // needed to the Provider interface
-func (mp MapProvider) GetValues(ids ...string) ([][]byte, error) {
+func (mp MapProvider) GetValues(ids ...string) (map[string]plugin_v1.ProviderResponse, error) {
 	return plugin_v1.GetValues(mp, ids...)
 }
 


### PR DESCRIPTION
GetValues works exactly the same as GetValue, however GetValues gives providers the ability to implement arbitrary batch retrieval mechanisms.

Succeeded by https://github.com/cyberark/secretless-broker/pull/1356 (Cobertura got in the way)

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Connected to #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
