### PR TITLE
1046 - Tests don't exit on failure

### DIFF
--- a/bin/run_integration
+++ b/bin/run_integration
@@ -84,7 +84,7 @@ if [[ -x "./stop" ]]; then
 fi
 
 # Translate and copy results unit junit.xml for Jenkins
-rm --force "${test_dir}/junit.xml"
+rm -f "${test_dir}/junit.xml"
 
 docker run --rm \
   --volume "${test_dir}/:/secretless/test/output/" \

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/joho/godotenv v1.2.0
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/lib/pq v0.0.0-20180123210206-19c8e9ad0095
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1
@@ -34,7 +33,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
-	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20180712090710-2d6f90ab1293
 	k8s.io/apiextensions-apiserver v0.0.0-20180808065829-408db4a50408

--- a/test/connector/http/basicauth/test
+++ b/test/connector/http/basicauth/test
@@ -16,6 +16,8 @@ if $local_test; then
   docker_volume_args=(--volume "$(cd ../../../..; pwd):/secretless")
 fi
 
+TEST_FAILED="false"
+
 assert_contains() {
   # assert_contains <string> <substring>
   local string=$1
@@ -36,7 +38,7 @@ assert_contains() {
   echo "${substring}"
   echo ""
 
-  exit 1
+  TEST_FAILED="true"
 }
 
 ping_target_service_thru_secretless() {
@@ -93,4 +95,9 @@ echo "Test: Secretless configured with incorrect password fails"
 bad_resp=$(ping_target_service_thru_secretless 8081)
 assert_contains "$bad_resp" "401 Unauthorized"
 
-echo "PASS"
+if [[ "$TEST_FAILED" == "true" ]]; then
+  echo "FAILED: basicauth/test"
+  exit 1
+fi
+
+echo "PASS: basicauth/test"


### PR DESCRIPTION
### What does this PR do?
Our generic and basicauth tests currently exit after the
first failure. Adjustments have been made to prevent
this, so tests display all failures before exiting.

### What ticket does this PR close?
Resolves #1046 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
