### PR TITLE
Bumped version to v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.7.1] - 2020-10-20
+
 ### Added
 - The `vault` provider now supports loading secrets from the KV Version 2 secret
   engine. Reference a secret in Vault using the right path and a field
@@ -524,7 +527,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.7.0...HEAD
+[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.7.1...HEAD
 [0.2.0]: https://github.com/cyberark/secretless-broker/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/cyberark/secretless-broker/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/cyberark/secretless-broker/compare/v0.3.0...v0.4.0
@@ -551,3 +554,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [1.5.2]: https://github.com/cyberark/secretless-broker/compare/v1.5.1...v1.5.2
 [1.6.0]: https://github.com/cyberark/secretless-broker/compare/v1.5.2...v1.6.0
 [1.7.0]: https://github.com/cyberark/secretless-broker/compare/v1.6.0...v1.7.0
+[1.7.1]: https://github.com/cyberark/secretless-broker/compare/v1.7.0...v1.7.1

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -13,7 +13,7 @@ SECTION 1: Apache License 2.0
 >>> github.com/containerd/containerd-1.3.2
 >>> github.com/CrunchyData/crunchy-proxy-0.0.0-20170717145745-c0da73ca9dde
 >>> github.com/cyberark/conjur-api-go-0.5.2
->>> github.com/cyberark/conjur-authn-k8s-client-0.16.1
+>>> github.com/cyberark/conjur-authn-k8s-client-0.19.0
 >>> github.com/docker/distribution-2.7.1
 >>> github.com/docker/docker-1.4.2-0.20191231165639-e6f6c35b7902
 >>> github.com/docker/go-connections-0.4.0
@@ -164,7 +164,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 
->>> github.com/cyberark/conjur-authn-k8s-client-0.16.1
+>>> github.com/cyberark/conjur-authn-k8s-client-0.19.0
 
 Copyright (c) 2020 CyberArk Software Ltd. All rights reserved.
 

--- a/pkg/secretless/version.go
+++ b/pkg/secretless/version.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Version field is a SemVer that should indicate the baked-in version
 // of the broker
-var Version = "1.7.0"
+var Version = "1.7.1"
 
 // Tag field denotes the specific build type for the broker. It may
 // be replaced by compile-time variables if needed to provide the git


### PR DESCRIPTION
This commit increases the version to v1.7.1 in preparation to package
all the changes since v1.7.0 release.

### What ticket does this PR close?
N/A

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch