### PR TITLE
Bump openssl version in images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN go build -ldflags="-X github.com/cyberark/secretless-broker/pkg/secretless.T
 FROM alpine:3.12 as secretless-broker
 MAINTAINER CyberArk Software, Inc.
 
-RUN apk add -u shadow libc6-compat && \
+RUN apk add -u shadow libc6-compat openssl && \
     # Add Limited user
     groupadd -r secretless \
              -g 777 && \


### PR DESCRIPTION
### What does this PR do?
Added `openssl` to the `apk` add and update command
in the secretless-image

### What ticket does this PR close?
-

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [X] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
