### PR TITLE
Added entries for OCP support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Support for OpenShift 4.3 and 4.5.
+  [conjurdemos/kubernetes-conjur-demo#122](https://github.com/conjurdemos/kubernetes-conjur-demo/issues/122)
+
+### Deprecated
+- Support for OpenShift 3.9 and 3.10 is removed in this release.
+  [conjurdemos/kubernetes-conjur-demo#122](https://github.com/conjurdemos/kubernetes-conjur-demo/issues/122)
+
 ## [1.7.1] - 2020-10-20
 
 ### Added


### PR DESCRIPTION
### What does this PR do?
The changelog is updated to indicate support added for OCP 4.3, 4.5 and dropped for OCP 3.9, 3.10.

### What ticket does this PR close?
Resolves conjurdemos/kubernetes-conjur-demo#122

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs - doc issue TBA

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
