### PR TITLE
Update goreleaser brews.github to brews.tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -112,7 +112,7 @@ brews:
       bin.install "secretless-broker"
     test: |
       system "#{bin}/secretless-broker", "-version"
-    github:
+    tap:
       owner: cyberark
       name: homebrew-tools
     skip_upload: true


### PR DESCRIPTION
Support for brews.github was removed in v0.152.0: https://goreleaser.com/deprecations/#brewsgithub

### What does this PR do?
- _What's changed? Why were these changes made?_
- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
