### PR TITLE
Use pristine checkout for creating a draft release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,8 +192,14 @@ pipeline {
         }
         stage('Create draft release') {
           steps {
-            sh "summon --yaml 'GITHUB_TOKEN: !var github/users/conjur-jenkins/api-token' ./bin/build_release"
-            archiveArtifacts 'dist/goreleaser/'
+            dir('./pristine-checkout') {
+              // Go releaser requires a pristine checkout
+              checkout scm
+              sh 'git submodule update --init --recursive'
+              // Create draft release
+              sh "summon --yaml 'GITHUB_TOKEN: !var github/users/conjur-jenkins/api-token' ./bin/build_release"
+              archiveArtifacts 'dist/goreleaser/'
+            }
           }
         }
       }


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

Goreleaser step now uses a pristine checkout for creating a release. See this passing tag build https://jenkins.conjur.net/blue/organizations/jenkins/cyberark--secretless-broker/detail/v1.7.2/2/pipeline/28.

NOTE: an alternative approach might have been to use `.gitingore` but it seems a lot more brittle than what this PR introducees.


- _How should the reviewer approach this PR, especially if manual tests are required?_
- _Are there relevant screenshots you can add to the PR description?_

### What ticket does this PR close?
Resolves #1341 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
