### PR TITLE
Fix Keychain tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,6 @@ require (
 	github.com/joho/godotenv v1.2.0
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/lib/pq v0.0.0-20180123210206-19c8e9ad0095
-	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pkg/profile v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,7 @@ github.com/containerd/containerd v1.3.2 h1:ForxmXkA6tPIvffbrDAcPUIB32QgXkt2XFj+F
 github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/cyberark/conjur-api-go v0.5.2 h1:8ntk07YNRz5bBwjNXkDEAPR70Yr+J2MN8NGlkhaMC3k=
 github.com/cyberark/conjur-api-go v0.5.2/go.mod h1:hwaReWirzgKor+JtH6vbwZaASDXulvd0SzGCloC5uOc=
+github.com/cyberark/conjur-authn-k8s-client v0.13.0/go.mod h1:JTeGIeRO59J7mMEc5yF6FPtk1QnaAzs4GyZa4WldqZc=
 github.com/cyberark/conjur-authn-k8s-client v0.19.0 h1:zHjdKyZ8bu4cRyV3iYMh1/XfIVtTugoiU/CflnboP9Q=
 github.com/cyberark/conjur-authn-k8s-client v0.19.0/go.mod h1:qacUJXCppU1Rg/C+br9B1jBitTq4yG04oc4a+cfI200=
 github.com/cyberark/secretless-broker v1.4.1-0.20191211191712-251c5ec034af/go.mod h1:+GueI3WCJL5gDYaYa38ZokAR8ceEyCVet7MkuZyjf80=

--- a/internal/plugin/v1/testutils/testutils.go
+++ b/internal/plugin/v1/testutils/testutils.go
@@ -16,12 +16,14 @@ type CanProvideTestCase struct {
 
 // CanProvide calls GetValues on the provider and ensures that the provider response for
 // the given id has the expected value and no error
-func CanProvide(provider plugin_v1.Provider, id string, expectedValue string) func() {
+func CanProvide(provider plugin_v1.Provider,
+	id string,
+	expectedValue string) func() {
 	return func() {
 		values, err := provider.GetValues(id)
 
+		convey.So(values[id].Error, convey.ShouldBeNil)
 		convey.So(err, convey.ShouldBeNil)
-
 		value := values[id]
 		assertGoodProviderResponse(value, expectedValue)
 	}

--- a/test/providers/keychain/keychain_provider_test.go
+++ b/test/providers/keychain/keychain_provider_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strconv"
 	"testing"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
@@ -24,11 +25,11 @@ func TestKeychainProvider(t *testing.T) {
 
 	// e.g. ${service}_1#${account}_1
 	getSecretPath := func(idx int) string {
-		return service + "_" + string(idx) + "#" + account + "_" + string(idx)
+		return service + "_" + strconv.Itoa(idx) + "#" + account + "_" + strconv.Itoa(idx)
 	}
 	// e.g. ${secret}_1
 	getSecretValue := func(idx int) string {
-		return secret + "_" + string(idx)
+		return secret + "_" + strconv.Itoa(idx)
 	}
 
 	options := plugin_v1.ProviderOptions{
@@ -72,7 +73,7 @@ func TestKeychainProvider(t *testing.T) {
 	Convey(
 		"Returns an error for an invalid secret value",
 		t,
-		testutils.CanProvide(
+		testutils.Reports(
 			provider,
 			"madeup#secret",
 			"The specified item could not be found in the keychain.",


### PR DESCRIPTION
### What does this PR do?
- Fixed an erraneous assertion in our keychain tests
- replaced calls to `string()` with `strconv.ItoA`, which is the safe way to convert
an int to a string

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [X] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [X] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
