### PR TITLE
PostgreSQL connector supports SSL Mode = prefer from client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Fixes PostgreSQL signaling in case of SSLRequest from the client,
+  correctly sends SSL Not Supported message instead of general error.
+  Supports downgrade to unsecured connection in case of `SSLMode = prefer`.  
+  [cyberark/secretless-broker#1377](https://github.com/cyberark/secretless-broker/issues/1377)
+
 ## [1.7.2] - 2020-02-05
 
 ### Added

--- a/internal/plugin/connectors/tcp/pg/connector.go
+++ b/internal/plugin/connectors/tcp/pg/connector.go
@@ -1,6 +1,7 @@
 package pg
 
 import (
+	"io"
 	"net"
 
 	"github.com/cyberark/secretless-broker/internal/plugin/connectors/tcp/pg/protocol"
@@ -43,6 +44,13 @@ func (s *SingleUseConnector) abort(err error) {
 	s.clientConn.Write(pgError.GetPacket())
 }
 
+func (s *SingleUseConnector) sslNotSupported() {
+	if s.clientConn == nil {
+		return
+	}
+	s.clientConn.Write([]byte{protocol.SSLNotAllowed})
+}
+
 // Connect implements the tcp.Connector func signature.
 //
 // It is the main method of the SingleUseConnector. It:
@@ -60,7 +68,10 @@ func (s *SingleUseConnector) Connect(
 	s.clientConn = clientConn
 
 	if err = s.Startup(); err != nil {
-		s.abort(err)
+		// connection closed by the client (f.e. SSLMode=require). Do not send error to the closed connection.
+		if err != io.EOF {
+			s.abort(err)
+		}
 		return nil, err
 	}
 

--- a/test/connector/tcp/pg/tests/essentials_test.go
+++ b/test/connector/tcp/pg/tests/essentials_test.go
@@ -93,7 +93,7 @@ func TestEssentials(t *testing.T) {
 					Password: "wrongpassword",
 					SSL:      true,
 				},
-				CmdOutput: StringPointer("SSL not supported"),
+				CmdOutput: StringPointer("server does not support SSL, but SSL was required"),
 			},
 		})
 	})

--- a/test/connector/tcp/pg/tests/sslmode_test.go
+++ b/test/connector/tcp/pg/tests/sslmode_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	. "github.com/cyberark/secretless-broker/test/util/testutil"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestCustom(t *testing.T) {
+
+	lc := FindLiveConfiguration(
+		AbstractConfiguration{
+			SocketType: TCP,
+			TLSSetting: TLS,
+			SSLMode:    Default,
+		},
+	)
+
+	connectPort := lc.ConnectionPort
+
+	connectionParams := []string{"dbname=postgres", "password=x"}
+	args := []string{
+		"-c", "select count(*) from test.test",
+		"--username", "x",
+		"--port", connectPort.ToPortString(),
+		"--host", connectPort.Host(),
+	}
+
+	Convey("sslmode=require", t, func() {
+		cmdOut, _ := exec.Command("psql", append(args, strings.Join(append(connectionParams, "sslmode=require"), " "))...).CombinedOutput()
+		So(string(cmdOut), ShouldContainSubstring, "psql: server does not support SSL, but SSL was required")
+	})
+
+	Convey("sslmode=prefer", t, func() {
+		cmdOut, _ := exec.Command("psql", append(args, strings.Join(append(connectionParams, "sslmode=prefer"), " "))...).CombinedOutput()
+		So(string(cmdOut), ShouldContainSubstring, "count")
+	})
+
+}

--- a/test/util/testutil/run_test_case.go
+++ b/test/util/testutil/run_test_case.go
@@ -37,6 +37,14 @@ func NewRunTestCase(runQuery RunQueryType) RunTestCaseType {
 	}
 }
 
+// FindLiveConfiguration takes AbstractConfiguration and finds a live configuration for
+// an active Secretless endpoint
+func FindLiveConfiguration(ac AbstractConfiguration) LiveConfiguration {
+	_, testSuiteConfigurations := GenerateConfigurations()
+
+	return testSuiteConfigurations.Find(ac)
+}
+
 // RunQueryType represents a function that takes in database credentials
 // and options, uses them to execute a test query, and returns the output
 // of that query.


### PR DESCRIPTION
### What does this PR do?
- Improved connection handling in PostgreSQL for SSLRequest initial packet. It now correctly signalize not supported SSL and enables downgrade to unencrypted transport. https://www.postgresql.org/docs/current/protocol-flow.html 
-  Easy testable by `psql` command with pgsqlmode changes:
    - `PGSSLMODE=prefer` - didn't work in a current version
    - `PGSSLMODE=disable`- worked well and is still working
    - `PGSSLMODE=require` - bad signaling in the current version - now correctly prints that server doesn't support SSL instead of connection error

### What ticket does this PR close?
#1377

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [X] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
