### PR TITLE
Run Secretless macOS tests via Github Actions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,30 @@
 ### What does this PR do?
+
 - _What's changed? Why were these changes made?_
 - _How should the reviewer approach this PR, especially if manual tests are required?_
 - _Are there relevant screenshots you can add to the PR description?_
 
 ### What ticket does this PR close?
+
 Resolves #[relevant GitHub issues, eg 76]
 
 ### Checklists
 
 #### Change log
+
 - [ ] The CHANGELOG has been updated, or
 - [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update
 
 #### Test coverage
+
 - [ ] This PR includes new unit and integration tests to go with the code changes, or
 - [ ] The changes in this PR do not require tests
 
 #### Documentation
+
 - [ ] This PR does not require updating any documentation, or
 - [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs
 
 #### (For releases only) Manual tests
-- [ ] Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)
+
 - [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+    name: Build Secretless
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - run: ./bin/build
+
+  osx_tests:
+    name: Run Secretless macOS tests
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      # Cache go module dependencies based on go.sum to improve workflow execution time.
+      - uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      # Download go modules
+      - run: go mod download
+      # Run keychain tests
+      - run: cd test/providers/keychain && ./start && ./test && ./stop

--- a/go.mod
+++ b/go.mod
@@ -23,15 +23,16 @@ require (
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/joho/godotenv v1.2.0
 	github.com/json-iterator/go v1.1.8 // indirect
+	github.com/keybase/go-keychain v0.0.0-20201121013009-976c83ec27a6
 	github.com/lib/pq v0.0.0-20180123210206-19c8e9ad0095
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.2.1
 	github.com/prometheus/client_golang v1.2.1 // indirect
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.3.0
-	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529
+	github.com/stretchr/testify v1.5.1
+	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20180712090710-2d6f90ab1293
 	k8s.io/apiextensions-apiserver v0.0.0-20180808065829-408db4a50408

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,9 @@ github.com/jtolds/gls v4.2.1+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVY
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/keybase/go-keychain v0.0.0-20201121013009-976c83ec27a6 h1:Mj0fhP9dzHKPijsmli/XbXMDKe1/KWy5xKci8e3nmBg=
+github.com/keybase/go-keychain v0.0.0-20201121013009-976c83ec27a6/go.mod h1:N83iQ9rnnzi2KZuTu+0xBcD1JNWn1jSN140ggAF7HeE=
+github.com/keybase/go.dbus v0.0.0-20200324223359-a94be52c0b03/go.mod h1:a8clEhrrGV/d76/f9r2I41BwANMihfZYV9C223vaxqE=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
@@ -195,6 +198,8 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1 h1:F++O52m40owAmADcojzM+9gyjmMOY/T4oYJkgFDH8RE=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -246,11 +251,14 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529 h1:iMGN4xG0cnqj3t+zOM8wUB0BiPKHEwSxEZCvzcbZuvk=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 h1:3zb4D3T4G8jdExgVU/95+vQXfpEPiMdCaZgmGVxjNHM=
+golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=

--- a/test/providers/keychain/README.md
+++ b/test/providers/keychain/README.md
@@ -1,18 +1,22 @@
 # keychain_provider tests
 
-The OS X Keychain Provider is meant for interactive use by a user, which
-is why this test is "manual".
+The OS X Keychain Provider is meant for interactive use by a user. In production,
+it will open a confirmation dialog at least once to request access to the
+keychain for Secretless.
 
-The (keychain_provider_test.go)[keychain_provider_test.go] will open a
-confirmation dialog during this test, and you'll need to click "Allow"
+The tests are captured in [keychain_provider_test.go](keychain_provider_test.go).
 
 To run the test locally if you are working on a Mac, just run
 
 ```
-./start
 ./test
 ```
 
-from this directory. The `start` script prepares your local
-environment by adding a secret to your OSX Keyring.  To clean up after running
-the test, you can run `./stop`.
+from this directory. The `test` script both prepares your local environment by
+adding secrets to your OSX Keyring and runs the tests against the Keyring. It's
+necessary for the Secrets to be added in the same process where the tests are
+run because the keychain automatically trusts (to read a secret) the process
+that writes a secret. Without this a user would need to confirm a keychain
+prompt at least once before a secret read is permitted.
+
+To independently clean up any test fixtures you can run `./stop`.

--- a/test/providers/keychain/cleanup_main.go
+++ b/test/providers/keychain/cleanup_main.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+// The main package simply cleans up the test fixtures
+func main() {
+	cleanup()
+	fmt.Println("Cleanup: Removed test secrets from Keychain.")
+}

--- a/test/providers/keychain/keychain_provider_test.go
+++ b/test/providers/keychain/keychain_provider_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"os"
-	"strconv"
 	"testing"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
@@ -13,30 +11,26 @@ import (
 )
 
 func TestKeychainProvider(t *testing.T) {
-	var err error
-	var provider plugin_v1.Provider
+	// Setup.
 
-	name := "keychain"
-
-	// get the environment variables with the test config
-	service := os.Getenv("SERVICE")
-	account := os.Getenv("ACCOUNT")
-	secret := os.Getenv("SECRET")
-
-	// e.g. ${service}_1#${account}_1
-	getSecretPath := func(idx int) string {
-		return service + "_" + strconv.Itoa(idx) + "#" + account + "_" + strconv.Itoa(idx)
-	}
-	// e.g. ${secret}_1
-	getSecretValue := func(idx int) string {
-		return secret + "_" + strconv.Itoa(idx)
+	// Create all the keychain items here.
+	//
+	// It's necessary to do this here because the keychain automatically trusts the
+	// process that writes the secret. Without this a user would need confirm a keychain
+	// prompt at least once before a read is possible.
+	cleanup()
+	defer cleanup()
+	if err := setup(); err != nil {
+		t.Fatal(err)
 	}
 
-	options := plugin_v1.ProviderOptions{
-		Name: name,
-	}
+	// Testing.
 
-	provider, err = providers.ProviderFactories[name](options)
+	providerName := "keychain"
+
+	provider, err := providers.ProviderFactories[providerName](plugin_v1.ProviderOptions{
+		Name: providerName,
+	})
 	if err != nil {
 		// there was an error creating the provider, so exit the tests
 		t.Error("Unable to create keychain provider.")
@@ -44,7 +38,7 @@ func TestKeychainProvider(t *testing.T) {
 	}
 
 	Convey("Has the expected provider name", t, func() {
-		So(provider.GetName(), ShouldEqual, name)
+		So(provider.GetName(), ShouldEqual, providerName)
 	})
 
 	Convey(

--- a/test/providers/keychain/load_test_env_vars
+++ b/test/providers/keychain/load_test_env_vars
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-set -euo pipefail
-
-export SERVICE="Secretless_Test"
-export ACCOUNT="KeychainProvider"
-export SECRET="secret"
-export NUM_SECRETS="3"

--- a/test/providers/keychain/shared.go
+++ b/test/providers/keychain/shared.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/keybase/go-keychain"
+)
+
+const service = "TestGenericPasswordRef"
+const account = "test"
+const secret = "toomanysecrets"
+
+// e.g. ${service}_1#${account}_1
+func getSecretPath(idx int) string {
+	return getService(idx) + "#" + getAccount(idx)
+}
+
+// e.g. ${account}_1
+func getAccount(idx int) string {
+	return account + "_" + strconv.Itoa(idx)
+}
+
+// e.g. ${service}_1
+func getService(idx int) string {
+	return service + "_" + strconv.Itoa(idx)
+}
+
+// e.g. ${secret}_1
+func getSecretValue(idx int) string {
+	return secret + "_" + strconv.Itoa(idx)
+}
+
+const numTestSecrets = 3
+
+// setup populates the keychain with test secrets
+func setup() error {
+	// Create all the keychain items here.
+	//
+	// It's necessary to do this inside the test process so that the keychain
+	// automatically trusts the process that writes the secret. Without this a
+	// user would need confirm a keychain prompt at least once before a read is possible.
+	for idx := 1; idx <= numTestSecrets; idx++ {
+		item := keychain.NewGenericPassword(
+			getService(idx),
+			getAccount(idx),
+			"",
+			[]byte(getSecretValue(idx)),
+			"",
+		)
+
+		if err := keychain.AddItem(item); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// cleanup remove all the test secrets from the keychain
+func cleanup() {
+	for idx := 1; idx <= numTestSecrets; idx++ {
+		item := keychain.NewGenericPassword(
+			getService(idx),
+			getAccount(idx),
+			"",
+			[]byte(getSecretValue(idx)),
+			"",
+		)
+		_ = keychain.DeleteItem(item)
+	}
+}

--- a/test/providers/keychain/start
+++ b/test/providers/keychain/start
@@ -1,33 +1,4 @@
 #!/bin/bash
 
-set -euo pipefail
-
-# clear out previously created test variables
-echo "Deleting prior password values stored for this test..."
+# Clear out previously store secrets from keychain
 ./stop
-
-# load the environment with the test config
-source load_test_env_vars
-
-# add secrets to keychain
-for (( idx=1; idx<=NUM_SECRETS; idx++ ))
-do
-  secret_account="${ACCOUNT}_${idx}"
-  secret_service="${SERVICE}_${idx}"
-  secret_value="${SECRET}_${idx}"
-
-  security add-generic-password \
-    -a "${secret_account}" \
-    -s "${secret_service}" \
-    -w "${secret_value}"
-
-  # verify that the secret has been loaded successfully
-  stored_secret_value=$(security find-generic-password \
-    -a "${secret_account}" -s "${secret_service}" -w)
-  if [[ "${stored_secret_value}" == "${secret_value}" ]]; then
-    echo "Secret has been loaded"
-  else
-    echo "Error loading a secret"
-    exit 1
-  fi
-done

--- a/test/providers/keychain/stop
+++ b/test/providers/keychain/stop
@@ -1,28 +1,5 @@
 #!/bin/bash
-
 set -euo pipefail
 
-# load the environment with the test config
-source load_test_env_vars
-
-for (( idx=1; idx<=NUM_SECRETS; idx++ ))
-do
-  secret_account="${ACCOUNT}_${idx}"
-  secret_service="${SERVICE}_${idx}"
-
-  # delete the password if it exists, and send stderr to stdout
-  # do not die if the request errors
-  delete_output="$(security delete-generic-password \
-                  -a "${secret_account}" \
-                  -s "${secret_service}" 2>&1)" || true
-
-  # if output includes "SecKeychainSearchCopyNext", password does not exist
-  # overwrite output messages for clarity / simplicity
-  if [[ "${delete_output}" == *"SecKeychainSearchCopyNext"* ]]; then
-    echo "Password does not exist."
-  elif [[ "${delete_output}" == *"password has been deleted"* ]]; then
-    echo "Password has been deleted."
-  else
-    echo "${delete_output}"
-  fi
-done
+# Clear out previously store secrets from keychain
+go run ./...

--- a/test/providers/keychain/test
+++ b/test/providers/keychain/test
@@ -1,9 +1,5 @@
 #!/bin/bash
-
 set -euo pipefail
 
-# load the environment with the test config
-source load_test_env_vars
-
-# run the test
-go test -v .
+# Run the tests
+go test -mod=readonly -v -count 1 ./...


### PR DESCRIPTION
### What does this PR do?
- _What's changed? Why were these changes made?_

This PR removes the need to manually test the OSX keychain provider. This is done by refactoring the tests and running them on every commit via Github Actions.

The PR also removes the manual test for the OSX keychain provider from the PR template.

- _How should the reviewer approach this PR, especially if manual tests are required?_

Check the Github Action runs to ensure all is well.

The Github Actions pipeline is in `.github/workflows/ci.yml`.

Most everything else is in `test/providers/keychain`. This PR mainly removes the previous tests which relied on using the `security` util on OSX to write secrets to the keychain. Instead we now use [go-keychain](https://github.com/keybase/go-keychain) in process with the tests to do this. The benefit of this is that it avoids a keychain prompt when the secrets are read, the keychain automatically trusts (to read a secret) the process
that writes a secret.

- _Are there relevant screenshots you can add to the PR description?_

N/A

### What ticket does this PR close?
No associated issue

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] This PR does not require updating any documentation, or
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests
- [ ] 💥  ~Manually tested [Keychain provider](https://github.com/cyberark/secretless-broker/tree/master/test/providers/keychain)~
- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
