### PR TITLE
Add unit tests for postgres connector startup message logic

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 golang.org/x/crypto v0.0.0-20180621125126-a49355c7e3f8/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/internal/plugin/connectors/tcp/pg/backend.go
+++ b/internal/plugin/connectors/tcp/pg/backend.go
@@ -88,6 +88,7 @@ func (s *SingleUseConnector) ConnectToBackend() error {
 	}
 
 	startupMessage := protocol.CreateStartupMessage(
+		protocol.ProtocolVersion,
 		s.connectionDetails.Username,
 		s.databaseName,
 		s.connectionDetails.Options,

--- a/internal/plugin/connectors/tcp/pg/protocol/startup.go
+++ b/internal/plugin/connectors/tcp/pg/protocol/startup.go
@@ -40,14 +40,19 @@ func ParseStartupMessage(message []byte) (version int32, options map[string]stri
 
 // CreateStartupMessage creates a PG startup message. This message is used to
 // startup all connections with a PG backend.
-func CreateStartupMessage(username string, database string, options map[string]string) []byte {
+func CreateStartupMessage(
+	version int32,
+	username string,
+	database string,
+	options map[string]string,
+) []byte {
 	message := NewMessageBuffer([]byte{})
 
 	/* Temporarily set the message length to 0. */
 	message.WriteInt32(0)
 
 	/* Set the protocol version. */
-	message.WriteInt32(ProtocolVersion)
+	message.WriteInt32(version)
 
 	/*
 	 * The protocol version number is followed by one or more pairs of

--- a/internal/plugin/connectors/tcp/pg/startup.go
+++ b/internal/plugin/connectors/tcp/pg/startup.go
@@ -9,7 +9,11 @@ import (
 // Startup performs the startup handshake with the client and parses the client
 // options to extract the database name.
 func (s *SingleUseConnector) Startup() error {
-	s.logger.Debugf("Handling connection %+v -> %+v", s.clientConn.RemoteAddr(), s.clientConn.LocalAddr())
+	s.logger.Debugf(
+		"Handling connection %+v -> %+v",
+		s.clientConn.RemoteAddr(),
+		s.clientConn.LocalAddr(),
+	)
 
 	version, options, err := s.parseStartupMessage()
 	if err != nil {

--- a/internal/plugin/connectors/tcp/pg/startup_test.go
+++ b/internal/plugin/connectors/tcp/pg/startup_test.go
@@ -1,0 +1,115 @@
+package pg
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/cyberark/secretless-broker/internal/plugin/connectors/tcp/pg/protocol"
+	loggermock "github.com/cyberark/secretless-broker/pkg/secretless/log/mock"
+)
+
+func readMessageType(r io.Reader) (byte, error) {
+	messageTypeBytes := make([]byte, 1)
+	if err := binary.Read(r, binary.BigEndian, &messageTypeBytes); err != nil {
+		return 0, err
+	}
+	return messageTypeBytes[0], nil
+}
+
+func sendStartupMessage(w io.Writer, version int32) {
+	message := protocol.CreateStartupMessage(
+		version,
+		"username-from-client",
+		"db-from-client",
+		map[string]string{
+			"option-1": "option-1-from-client",
+		})
+	_, err := w.Write(message)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func pipeWithDeadline() (net.Conn, net.Conn) {
+	r, w := net.Pipe()
+	r.SetDeadline(time.Now().Add(2 * time.Second))
+	w.SetDeadline(time.Now().Add(2 * time.Second))
+
+	return r, w
+}
+
+func TestStartup(t *testing.T) {
+	t.Run("handle client startup message with no TLS request", func(t *testing.T) {
+		r, w := pipeWithDeadline()
+
+		connector := SingleUseConnector{
+			clientConn: r,
+			logger:     &loggermock.LoggerMock{},
+		}
+		go func() {
+			sendStartupMessage(w, protocol.ProtocolVersion)
+		}()
+
+		err := connector.Startup()
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		assert.Equal(t, err, nil)
+		assert.Equal(t, connector.databaseName, "db-from-client")
+	})
+
+	t.Run("handle client startup message with TLS request yielding to no TLS", func(t *testing.T) {
+		r, w := pipeWithDeadline()
+
+		connector := SingleUseConnector{
+			clientConn: r,
+			logger:     &loggermock.LoggerMock{},
+		}
+		go func() {
+			sendStartupMessage(w, protocol.SSLRequestCode)
+
+			messageType, err := readMessageType(w)
+			assert.NoError(t, err)
+			assert.Equal(t, messageType, protocol.SSLNotAllowed)
+
+			sendStartupMessage(w, protocol.ProtocolVersion)
+		}()
+
+		err := connector.Startup()
+		assert.NoError(t, err)
+	})
+
+	t.Run("error on client startup message with sustained TLS request after no TLS", func(t *testing.T) {
+		r, w := pipeWithDeadline()
+
+		connector := SingleUseConnector{
+			clientConn: r,
+			logger:     &loggermock.LoggerMock{},
+		}
+		go func() {
+			sendStartupMessage(w, protocol.SSLRequestCode)
+
+			messageType, err := readMessageType(w)
+			assert.Nil(t, err)
+			assert.Equal(t, messageType, protocol.SSLNotAllowed)
+
+			sendStartupMessage(w, protocol.SSLRequestCode)
+
+			messageType, err = readMessageType(w)
+			assert.Nil(t, err)
+			assert.Equal(t, messageType, protocol.SSLNotAllowed)
+		}()
+
+		err := connector.Startup()
+		if !assert.Error(t, err) {
+			return
+		}
+		assert.Contains(t, err.Error(), "Unexpected SSL Request after SSL not supported response")
+	})
+}


### PR DESCRIPTION
### What does this PR do?

Add unit tests for postgres connector handling startup messages

The test cases might look a bit scary but they're hyper specific and only deal with a single request-response message types. These are:
1. Startup message for Postgres (from the client) which contains a "version" at the start (tells us to use TLS or not), followed by options (e.g. username, database etc.).
2. Response to the client. For the tests we actually only care about the first byte which tells us if it's an error or not.

There are 3 tests
1. Corresponds to `sslmode=disable`. The client doesn't request TLS.
2. Corresponds to `sslmode=prefer`. The client requests TLS, Secretless says TLS not supported, The client sends the startup message against with no TLS request
3. Corresponds to `sslmode=INSIST!`. This one is made up but validates the logic for a client that keeps sending startup messages requesting TLS when Secretless has responded with TLS not supported. We'd never expect a normal client to do this but you get abusive clients. This test would catch things like infinite recursion had we decided to implement the second read of the startup message using recursion.

`sslmode=require` would correspond to (2) with the client closing the connection after Secretless responds.

### What ticket does this PR close?

Resolves build failures from low coverage. Capybara 😓 

### Checklists

#### Change log

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests

- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
