### PR TITLE
Fix: Junit collects after all integration tests are done

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,9 +22,9 @@ pipeline {
     }
 
     stage('Update Submodules') {
-        steps {
-            sh 'git submodule update --init --recursive'
-        }
+      steps {
+        sh 'git submodule update --init --recursive'
+      }
     }
 
     stage('Build and Unit tests') {
@@ -119,23 +119,21 @@ pipeline {
             '''
           ).trim().split()
 
-          def integrationSteps = [:]
+          def integrationStages = [:]
 
           // Create an integration test stage for each directory we collected previously.
           // We want to be sure to skip any tests, such as keychain tests, that can only be ran manually.
           directories.each { name ->
             if (name == "keychain") return
 
-            def stepName = "Integration: ${name}"
-
-            integrationSteps[stepName] = {
+            integrationStages["Integration: ${name}"] = {
               sh "./bin/run_integration ${name}"
-              junit "**/test/**/junit.xml"
             }
           }
 
-          parallel integrationSteps
+          parallel integrationStages
         }
+        junit "**/test/**/junit.xml"
       }
     }
 


### PR DESCRIPTION
### What does this PR do?

The build would occasionally fail since multiple junit collections were being carried out as part of this arrangement of stages. Collecting at the end prevents any contention

### What ticket does this PR close?

N/A

### Checklists

#### Change log

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests

- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
