### PR TITLE
WIP Fix conflict in container naming for basicauth tests

### DIFF
--- a/test/connector/http/basicauth/test
+++ b/test/connector/http/basicauth/test
@@ -43,7 +43,9 @@ assert_contains() {
 
 ping_target_service_thru_secretless() {
   port=$1
-  docker_cmd="docker-compose run --rm --no-deps"
+
+  id="$(openssl rand -hex 6)-basicauth"
+  docker_cmd="docker-compose run --rm --no-deps --name $id"
 
   # NOTE: We must use an array here so that we can double quote it when we use
   # it but still have it passed as individual args.  This keeps shellcheck


### PR DESCRIPTION
### What does this PR do?

Fix conflict in container naming for basicauth tests

### What ticket does this PR close?

Resolves #[relevant GitHub issues, eg 76]

### Checklists

#### Change log

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests

- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
