### PR TITLE
Change MSSQL repo from Ubuntu to Debian and retry on repo list download failure

### DIFF
--- a/test/connector/tcp/mssql/Dockerfile
+++ b/test/connector/tcp/mssql/Dockerfile
@@ -7,7 +7,10 @@ RUN apt-get update && apt-get install -y \
 
 # Add custom MS repository
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list > /etc/apt/sources.list.d/mssql-release.list
+RUN curl --fail \
+	--retry 5 \
+	--retry-max-time 10 \
+	https://packages.microsoft.com/config/debian/10/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
 
 # Install SQL Server drivers and tools
 RUN apt-get update && ACCEPT_EULA=Y apt-get install -y libodbc1 unixodbc msodbcsql17 mssql-tools unixodbc-dev


### PR DESCRIPTION
### What does this PR do?

- Changed MSSQL repo from Ubuntu 16.04 to Debian 10 (Buster), which is more appropriate for the Buster container in which the integration test is run.
- Added curl flags to retry the repo list download on error - a maximum of 5 times, 10 second timeout.
- HTTP error code will now propagate up to curl return code so CI will stop on error

### What ticket does this PR close?

N/A

### Checklists

#### Change log

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests

- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
