### PR TITLE
Update RH base image to UBI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update RH base image to `ubi8/ubi` instead of `rhel7/rhel`.
+  [PR cyberark/secretless-broker#1411](https://github.com/cyberark/secretless-broker/pull/1411)
+
 ## [1.7.3] - 2020-03-09
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ COPY --from=secretless-builder /secretless/dist/linux/amd64/secretless-broker \
                                /secretless/dist/linux/amd64/summon2 /usr/local/bin/
 
 # =================== MAIN CONTAINER (REDHAT) ===================
-FROM registry.access.redhat.com/rhel as secretless-broker-redhat
+FROM registry.access.redhat.com/ubi8/ubi as secretless-broker-redhat
 MAINTAINER CyberArk Software Ltd.
 
 ARG VERSION


### PR DESCRIPTION
### What does this PR do?

The `rhel7/rhel` base image we've been using has a [CVE](https://access.redhat.com/security/cve/cve-2021-27219) and no updated image in sight. In this change, we move to using the `ubi8/ubi` base image for Secretless, hopefully with better results.

### What ticket does this PR close?

n/a

### Checklists

#### Change log

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests

- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
