### PR TITLE
Updating naming for Conjur editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [Quick Start](#quick-start)
 - [Additional demos](#run-more-secretless-broker-demos)
 - [Using Secretless](#using-secretless)
-  - [Using This Project With Conjur-OSS](#using-secretless-broker-with-conjur-oss)
+  - [Using This Project With Conjur-OSS](#using-secretless-broker-with-conjur-open-source)
   - [About our releases](#about-our-releases)
 - [Community](#community)
 - [Performance](#performance)
@@ -141,10 +141,11 @@ For an even more in-depth demo, check out our [Deploying to Kubernetes](https://
 
 For complete documentation on using Secretless, please see [our documentation](https://docs.secretless.io/Latest/en/Content/Resources/_TopNav/cc_Home.htm). The documentation includes comprehensive guides for how to get up and running with Secretless.
 
-## Using secretless-broker with Conjur OSS
+## Using secretless-broker with Conjur Open Source
 
-Are you using this project with [Conjur OSS](https://github.com/cyberark/conjur)? 
-Then we **strongly** recommend choosing the version of this project to use from 
+Are you using this project with
+[Conjur Open Source](https://github.com/cyberark/conjur)?
+Then we **strongly** recommend choosing the version of this project to use from
 the latest [Conjur OSS suite release](https://docs.conjur.org/Latest/en/Content/Overview/Conjur-OSS-Suite-Overview.html).
 Conjur maintainers perform additional testing on the suite release versions to ensure
 compatibility. When possible, upgrade your Conjur version to match the


### PR DESCRIPTION
Updating naming for Conjur editions

- converts `Conjur OSS` to `Conjur Open Source`
- converts `DAP`/`Dynamic Access Provider` to `Conjur Enterprise`
- maintains `Conjur OSS Suite` and `Conjur Open Source Suite`

This is part of an automated batch of PRs across many repos listed in [cyberark/community#92](https://github.com/cyberark/community/issues/92)
