### PR TITLE
Change the base Alpine container to 3.14 to preserve ongoing trivy scanning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Secretless and secretless-redhat containers now use Alpine 3.14 as their base
+  image. [PR cyberark/secretless-broker#1423](https://github.com/cyberark/secretless-broker/pull/1423)
+
 ## [1.7.5] - 2021-08-04
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN go build -ldflags="-X github.com/cyberark/secretless-broker/pkg/secretless.T
 
 
 # =================== MAIN CONTAINER ===================
-FROM alpine:3.12 as secretless-broker
+FROM alpine:3.14 as secretless-broker
 MAINTAINER CyberArk Software Ltd.
 
 RUN apk add -u shadow libc6-compat openssl && \

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -35,7 +35,7 @@ RUN go build -ldflags="-X github.com/cyberark/secretless-broker/pkg/secretless.T
 
 
 # =================== MAIN CONTAINER ===================
-FROM alpine:3.12 as secretless-broker
+FROM alpine:3.14 as secretless-broker
 MAINTAINER CyberArk Software Ltd.
 
 RUN apk add -u shadow libc6-compat && \

--- a/bin/run_gosec
+++ b/bin/run_gosec
@@ -52,7 +52,7 @@ modified_directories="./..."
 if [[ ${current_branch} != 'main' ]]; then 
     echo 'Current branch is not main - running gosec on modified packages for this branch only'
     git fetch origin main:refs/remotes/origin/main
-    modified_directories=($(git diff origin/main...origin/"${current_branch}" --name-only | xargs -L1 dirname | uniq))
+    modified_directories=($(git diff origin/main...origin/"${current_branch}" --name-only | xargs -L1 sh -c '[ "$#" -gt 0 ] && dirname "$@"' - | uniq))
 fi
 
 # Remove output file just in case it exists


### PR DESCRIPTION
### What does this PR do?

Change the base Alpine container to 3.14 to preserve ongoing trivy scanning

### What ticket does this PR close?

Resolves -

### Checklists

#### Change log

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation, or
- [] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests

- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
