### PR TITLE
Fix bug in check latest tag

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -42,7 +42,7 @@ function main() {
 
   # Add 'latest' tag only when TAG_NAME is the highest semantic tag
   local LATEST_TAG
-  LATEST_TAG="$(git tag | sort -r --version-sort)"
+  LATEST_TAG="$(git tag | sort -r --version-sort | head -1)"
   if [[ "${TAG_NAME}" == "${LATEST_TAG}" ]]; then
     TAGS+=('latest')
   fi


### PR DESCRIPTION
### What does this PR do?

Fixes `latest` tags not being pushed to DockerHub

### What ticket does this PR close?

Resolves N/A

### Checklists

#### Change log

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests

- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
