### PR TITLE
Update dev environment to work on CyberArk NG laptops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,7 @@ github.com/cyberark/
 # Image scan files
 scan_results-*.json
 scan_results-*.xml
+
+# Temporary directories to store the CyberArk proxy CA certificate
+build_ca_certificate/
+bin/juxtaposer/build_ca_certificate

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,17 @@ FROM golang:1.15-buster as secretless-builder
 MAINTAINER CyberArk Software Ltd.
 LABEL builder="secretless-builder"
 
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 WORKDIR /secretless
 
 # TODO: Expand this with build args when we support other arches

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -2,6 +2,17 @@ FROM golang:1.15-buster as secretless-builder
 MAINTAINER CyberArk Software Ltd.
 LABEL builder="secretless-builder"
 
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 WORKDIR /secretless
 
 # TODO: Expand this with build args when we support other arches

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,6 +1,17 @@
 FROM golang:1.15-buster
 MAINTAINER CyberArk Software Ltd.
 
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 RUN apt-get update && \
     apt-get install -y curl \
                        jq \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,6 +2,17 @@ FROM golang:1.15-alpine
 MAINTAINER CyberArk Software Ltd.
 LABEL id="secretless-test-runner"
 
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 WORKDIR /secretless
 
 RUN apk add -u curl \

--- a/bin/build
+++ b/bin/build
@@ -24,43 +24,52 @@ else
   DOCKER_FLAGS="${DOCKER_FLAGS} --force-rm"
 fi
 
-echo "Building secretless-broker:$FULL_VERSION_TAG Docker image"
-# NOTE: the latest tag is required by downstream pipeline stages
-# (we want the flags to be word split here)
-# shellcheck disable=SC2086
-docker build --tag "secretless-broker:${FULL_VERSION_TAG}" \
-             --tag "secretless-broker:latest" \
-             --target "secretless-broker" \
-             $DOCKER_FLAGS \
-             --file "$TOPLEVEL_DIR/Dockerfile" \
-             "$TOPLEVEL_DIR"
+function main() {
+  retrieve_cyberark_ca_cert
+  build_docker_images
+}
 
-echo "Building secretless-dev:$FULL_VERSION_TAG Docker image"
-# NOTE: the latest tag is required by downstream pipeline stages
-# (we want the flags to be word split here)
-# shellcheck disable=SC2086
-docker build --tag "secretless-dev:${FULL_VERSION_TAG}" \
-             --tag "secretless-dev:latest" \
-             $DOCKER_FLAGS \
-             --file "$TOPLEVEL_DIR/Dockerfile.dev" \
-             "$TOPLEVEL_DIR"
+function build_docker_images() {
+  echo "Building secretless-broker:$FULL_VERSION_TAG Docker image"
+  # NOTE: the latest tag is required by downstream pipeline stages
+  # (we want the flags to be word split here)
+  # shellcheck disable=SC2086
+  docker build --tag "secretless-broker:${FULL_VERSION_TAG}" \
+               --tag "secretless-broker:latest" \
+               --target "secretless-broker" \
+               $DOCKER_FLAGS \
+               --file "$TOPLEVEL_DIR/Dockerfile" \
+               "$TOPLEVEL_DIR"
 
-echo "Building secretless-broker-quickstart:$FULL_VERSION_TAG Docker image"
-# NOTE: the latest tag is required by downstream pipeline stages
-# (we want the flags to be word split here)
-# shellcheck disable=SC2086
-docker build --tag "secretless-broker-quickstart:${FULL_VERSION_TAG}" \
-             --tag "secretless-broker-quickstart:latest" \
-             $DOCKER_FLAGS \
-             --file "$QUICK_START_DIR/Dockerfile" \
-             "$QUICK_START_DIR"
+  echo "Building secretless-dev:$FULL_VERSION_TAG Docker image"
+  # NOTE: the latest tag is required by downstream pipeline stages
+  # (we want the flags to be word split here)
+  # shellcheck disable=SC2086
+  docker build --tag "secretless-dev:${FULL_VERSION_TAG}" \
+               --tag "secretless-dev:latest" \
+               $DOCKER_FLAGS \
+               --file "$TOPLEVEL_DIR/Dockerfile.dev" \
+               "$TOPLEVEL_DIR"
 
-echo "Building secretless-broker-redhat:$FULL_VERSION_TAG Docker image"
-# (we want the flags to be word split here)
-# shellcheck disable=SC2086
-docker build --tag "secretless-broker-redhat:${FULL_VERSION_TAG}" \
-             --target "secretless-broker-redhat" \
-             --build-arg VERSION="${FULL_VERSION_TAG}" \
-             $DOCKER_FLAGS \
-              --file "$TOPLEVEL_DIR/Dockerfile" \
-             "$TOPLEVEL_DIR"
+  echo "Building secretless-broker-quickstart:$FULL_VERSION_TAG Docker image"
+  # NOTE: the latest tag is required by downstream pipeline stages
+  # (we want the flags to be word split here)
+  # shellcheck disable=SC2086
+  docker build --tag "secretless-broker-quickstart:${FULL_VERSION_TAG}" \
+               --tag "secretless-broker-quickstart:latest" \
+               $DOCKER_FLAGS \
+               --file "$QUICK_START_DIR/Dockerfile" \
+               "$QUICK_START_DIR"
+
+  echo "Building secretless-broker-redhat:$FULL_VERSION_TAG Docker image"
+  # (we want the flags to be word split here)
+  # shellcheck disable=SC2086
+  docker build --tag "secretless-broker-redhat:${FULL_VERSION_TAG}" \
+               --target "secretless-broker-redhat" \
+               --build-arg VERSION="${FULL_VERSION_TAG}" \
+               $DOCKER_FLAGS \
+                --file "$TOPLEVEL_DIR/Dockerfile" \
+               "$TOPLEVEL_DIR"
+}
+
+main

--- a/bin/build_utils
+++ b/bin/build_utils
@@ -29,3 +29,31 @@ function gen_versions() {
     echo $version
   done
 }
+
+function retrieve_cyberark_ca_cert() {
+  # On CyberArk dev laptops, golang module dependencies are downloaded with a
+  # corporate proxy in the middle. For these connections to succeed we need to
+  # configure the proxy CA certificate in build containers.
+  #
+  # To allow this script to also work on non-CyberArk laptops where the CA
+  # certificate is not available, we update container certificates based on
+  # a (potentially empty) certificate directory, rather than relying on the
+  # CA file itself.
+  mkdir -p "$(repo_root)/build_ca_certificate"
+
+  # Only attempt to extract the certificate if the security
+  # command is available.
+  #
+  # The certificate file must have the .crt extension to be imported
+  # by `update-ca-certificates`.
+  if command -v security &> /dev/null
+  then
+    security find-certificate \
+      -a -c "CyberArk Enterprise Root CA" \
+      -p > build_ca_certificate/cyberark_root.crt
+  fi
+}
+
+repo_root() {
+  git rev-parse --show-toplevel
+}

--- a/bin/juxtaposer/Dockerfile
+++ b/bin/juxtaposer/Dockerfile
@@ -1,5 +1,16 @@
 FROM golang:1.12.5-alpine as perftool-builder
 
+# On CyberArk dev laptops, golang module dependencies are downloaded with a
+# corporate proxy in the middle. For these connections to succeed we need to
+# configure the proxy CA certificate in build containers.
+#
+# To allow this script to also work on non-CyberArk laptops where the CA
+# certificate is not available, we copy the (potentially empty) directory
+# and update container certificates based on that, rather than rely on the
+# CA file itself.
+ADD build_ca_certificate /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
 WORKDIR /perftool
 ENV CGO_ENABLED=0
 

--- a/bin/juxtaposer/deploy/build_and_push_image
+++ b/bin/juxtaposer/deploy/build_and_push_image
@@ -1,23 +1,61 @@
 #!/bin/bash
 set -euo pipefail
 
-CURRENT_DIR=$(dirname "${BASH_SOURCE[0]}")
+CURRENT_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
-if ! oc whoami &> /dev/null; then
-  oc login
-fi
-docker login -u _ -p "$(oc whoami -t)" "$DOCKER_REGISTRY_PATH"
+function main() {
+  retrieve_cyberark_ca_cert
+  oc_login
+  build_docker_images
+}
 
-test_app_image="$DOCKER_REGISTRY_PATH/$TEST_APP_NAMESPACE_NAME/$APP_NAME:$TEST_APP_NAMESPACE_NAME"
+function retrieve_cyberark_ca_cert() {
+  pushd "$CURRENT_DIR/.."
+    # On CyberArk dev laptops, golang module dependencies are downloaded with
+    # a corporate proxy in the middle. For these connections to succeed we
+    # need to configure the proxy CA certificate in build containers.
+    #
+    # To allow this script to also work on non-CyberArk laptops where the CA
+    # certificate is not available, we update container certificates based on
+    # a (potentially empty) certificate directory, rather than relying on the
+    # CA file itself.
+    mkdir -p build_ca_certificate
 
-echo "Building and pushing image..."
+    # Only attempt to extract the certificate if the security
+    # command is available.
+    #
+    # The certificate file must have the .crt extension to be imported
+    # by `update-ca-certificates`.
+    if command -v security &> /dev/null
+    then
+      security find-certificate \
+        -a -c "CyberArk Enterprise Root CA" \
+        -p > build_ca_certificate/cyberark_root.crt
+    fi
+  popd
+}
 
-echo "Building $APP_NAME image"
-pushd "$CURRENT_DIR/.."
-  docker build -t "$APP_NAME:$TEST_APP_NAMESPACE_NAME" .
-popd
+function oc_login() {
+  if ! oc whoami &> /dev/null; then
+    oc login
+  fi
+  docker login -u _ -p "$(oc whoami -t)" "$DOCKER_REGISTRY_PATH"
+}
 
-docker tag "$APP_NAME:$TEST_APP_NAMESPACE_NAME" "$test_app_image"
+function build_docker_images() {
+  test_app_image="$DOCKER_REGISTRY_PATH/$TEST_APP_NAMESPACE_NAME/$APP_NAME:$TEST_APP_NAMESPACE_NAME"
 
-echo "Pushing $test_app_image to OpenShift..."
-docker push "$test_app_image"
+  echo "Building and pushing image..."
+
+  echo "Building $APP_NAME image"
+  pushd "$CURRENT_DIR/.."
+    docker build -t "$APP_NAME:$TEST_APP_NAMESPACE_NAME" .
+  popd
+
+  docker tag "$APP_NAME:$TEST_APP_NAMESPACE_NAME" "$test_app_image"
+
+  echo "Pushing $test_app_image to OpenShift..."
+  docker push "$test_app_image"
+}
+
+main

--- a/bin/test_unit
+++ b/bin/test_unit
@@ -2,51 +2,67 @@
 
 set -eo pipefail
 
+. bin/build_utils
+
 current_dir=$("$(dirname "$0")"/abspath)
 toplevel_dir=$current_dir/..
-
 junit_output_dir=test/unit-test-output
-mkdir -p "$junit_output_dir"
-rm -f "$junit_output_dir/*"
 
-echo "Building unit test image..."
-docker build "$toplevel_dir" \
-             -t secretless-unit-test-runner:latest \
-             -f "$toplevel_dir"/Dockerfile.test
+function main() {
+  retrieve_cyberark_ca_cert
+  build_ut_docker_image
+  run_unit_tests
+  format_output
+}
 
-echo "Running unit tests..."
-set +e
-  # TODO: Use `go vet` too
-  # NOTE: We're leaving out cmd/shared because it was causing
-  #       a "g++": executable file not found in $PATH error, and
-  #       the code is not being used anyway (was part of an Envoy POC)
-  docker run --rm -t \
+function build_ut_docker_image() {
+  echo "Building unit test image..."
+  docker build "$toplevel_dir" \
+               -t secretless-unit-test-runner:latest \
+               -f "$toplevel_dir"/Dockerfile.test
+}
+
+function run_unit_tests() {
+  echo "Running unit tests..."
+  set +e
+    mkdir -p "$junit_output_dir"
+    rm -f "$junit_output_dir/*"
+
+    # TODO: Use `go vet` too
+    # NOTE: We're leaving out cmd/shared because it was causing
+    #       a "g++": executable file not found in $PATH error, and
+    #       the code is not being used anyway (was part of an Envoy POC)
+    docker run --rm -t \
+      --volume "$toplevel_dir"/:/secretless \
+      secretless-unit-test-runner:latest \
+      go test \
+        -v \
+        -timeout 3m \
+        -vet=off \
+        -coverprofile="./$junit_output_dir/c.out" \
+        ./cmd/secretless-broker... \
+        ./cmd/summon2... \
+        ./internal/... \
+        ./pkg/... \
+      | tee -a "./$junit_output_dir/junit.output"
+    echo "Unit test exit status: $?"
+  set -e
+}
+
+function format_output() {
+  # Format output
+  docker run --rm \
     --volume "$toplevel_dir"/:/secretless \
+    --workdir "/secretless/$junit_output_dir" \
     secretless-unit-test-runner:latest \
-    go test \
-      -v \
-      -timeout 3m \
-      -vet=off \
-      -coverprofile="./$junit_output_dir/c.out" \
-      ./cmd/secretless-broker... \
-      ./cmd/summon2... \
-      ./internal/... \
-      ./pkg/... \
-    | tee -a "./$junit_output_dir/junit.output"
-  echo "Unit test exit status: $?"
-set -e
+      sh -exc "
+        rm -f junit.xml
+  
+        # Format test output XML
+        cat junit.output | go-junit-report > junit.xml
+  
+        # Format coverage output XML
+        gocov convert c.out | gocov-xml > coverage.xml"
+}
 
-# Format output
-docker run --rm \
-  --volume "$toplevel_dir"/:/secretless \
-  --workdir "/secretless/$junit_output_dir" \
-  secretless-unit-test-runner:latest \
-    sh -exc "
-rm -f junit.xml
-
-# Format test output XML
-cat junit.output | go-junit-report > junit.xml
-
-# Format coverage output XML
-gocov convert c.out | gocov-xml > coverage.xml
-"
+main

--- a/go.sum
+++ b/go.sum
@@ -307,6 +307,7 @@ golang.org/x/net v0.0.0-20190613194153-d28f0bde5980 h1:dfGZHvZk057jK2MCeWus/TowK
 golang.org/x/net v0.0.0-20190613194153-d28f0bde5980/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -330,7 +331,9 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20181227161524-e6919f6577db h1:6/JqlYfC1CCaLnGceQTI+sDGhC9UBSPAsBqI0Gun6kU=


### PR DESCRIPTION
### What does this PR do?

On CyberArk dev laptops, golang module dependencies are downloaded with a corporate proxy in the middle. For these connections to succeed we need to configure the proxy CA certificate in build containers.

To allow build script to also work on non-CyberArk laptops where the CA certificate is not available, we copy the (potentially empty) directory into the build containers, and update container certificates based on that directory, rather than relying on the CA file itself.

### What ticket does this PR close?

### Checklists

#### Change log

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests

- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
