### PR TITLE
Fix `build_release`

### DIFF
--- a/bin/build_release
+++ b/bin/build_release
@@ -1,14 +1,45 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 
-CURRENT_DIR=$("$(dirname "$0")/abspath")
+set -eo pipefail
 
-echo "Current dir: $CURRENT_DIR"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# registry.tld/goreleaser is able to carry out cross-compilation
+# Get the version of Go specified by the "go directive" in go.mod
+# Grep it to avoid Go binary dependency
+GO_VERSION="v$(grep "^\bgo\b" "${REPO_ROOT}/go.mod" | awk '{print $2}')"
+
+# Use a GoReleaser Docker image containing cross-compilation tools
+# This image is recommended by the official GoReleaser docs
+# https://goreleaser.com/cookbooks/cgo-and-crosscompiling/
+GORELEASER_IMAGE="troian/golang-cross"
+
+# Get the latest tags
+GORELEASER_TAGS_JSON="$(curl --silent --show-error https://registry.hub.docker.com/v2/repositories/${GORELEASER_IMAGE}/tags?page_size=100)"
+
+# Get the latest tag matching the GO_VERSION
+GORELEASER_LATEST_TAG="$(echo "${GORELEASER_TAGS_JSON}" | \
+  jq \
+    --raw-output \
+    --arg GO_VERSION "${GO_VERSION}" \
+    '
+      .results |
+      map(select(.name | contains($GO_VERSION) and (contains("-") | not))) |
+      first |
+      .name
+    '
+)"
+
+if [[ -z "${GORELEASER_LATEST_TAG}" ]]; then
+  echo "Could not find tag for Docker image \"${GORELEASER_IMAGE}\" matching GO_VERSION=${GO_VERSION}"
+  exit 1
+fi
+
+echo "Docker image for release build: ${GORELEASER_IMAGE}:${GORELEASER_LATEST_TAG}"
+
 docker run --rm -t \
   --env GITHUB_TOKEN \
-  --volume "$CURRENT_DIR/..:/secretless-broker" \
+  --volume "${REPO_ROOT}:/secretless-broker" \
   --workdir /secretless-broker \
-  "registry.tld/goreleaser" --rm-dist "$@"
+  "${GORELEASER_IMAGE}:${GORELEASER_LATEST_TAG}" --rm-dist "$@"
 
 echo "Releases built. Archives can be found in dist/goreleaser"


### PR DESCRIPTION
### What does this PR do?

* The **Build Release Artifacts** step on `main` is failing in Jenkins. The current build process pulls a GoReleaser image of unknown origins from the private registry and builds with `go1.13` which fails on this repo which requires `go>=1.16`

* `bin/build_release` is modified to use a public GoReleaser docker image containing the necessary CGO-enabled cross-compilation tools. This image is recommended by the official GoReleaser docs: https://goreleaser.com/cookbooks/cgo-and-crosscompiling/
  * Also now ensures the Go compiler version used matches the `GoVersion` in `go.mod`

* Build succeeds locally using the `--snapshot` flag. It *should* succeed after merge to `main`

### What ticket does this PR close?

Resolves N/A

### Checklists

#### Change log

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] This PR does not require updating any documentation, or
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs

#### (For releases only) Manual tests

- [ ] Manually run [Kubernetes-Conjur demo](https://github.com/conjurdemos/kubernetes-conjur-demo) with a local Secretless Broker image build of your branch
