### PR TITLE
Add schema for CRD

### DIFF
--- a/internal/configurationmanagers/kubernetes/crd/crd_injector.go
+++ b/internal/configurationmanagers/kubernetes/crd/crd_injector.go
@@ -6,43 +6,140 @@ import (
 	"log"
 	"strings"
 
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func createCRD(apiExtClient *apiextensionsclientset.Clientset) error {
-	secretlessCRD := &apiextensionsv1beta1.CustomResourceDefinition{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: CRDFQDNName,
+// This schema should be kept up-to-date to match secretless-resource-definition.yaml
+// and the Config struct in pkg/secretless/config/v1/config.go
+var secretlessCRD = &apiextensionsv1.CustomResourceDefinition{
+	ObjectMeta: meta_v1.ObjectMeta{
+		Name: CRDFQDNName,
+	},
+	Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+		Group: CRDGroupName,
+		Names: apiextensionsv1.CustomResourceDefinitionNames{
+			Kind:       strings.Title(CRDLongName),
+			Plural:     CRDName,
+			ShortNames: CRDShortNames,
 		},
-		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group: CRDGroupName,
-			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
-				Kind:       strings.Title(CRDLongName),
-				Plural:     CRDName,
-				ShortNames: CRDShortNames,
-			},
-			Version: "v1",
-			Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{
-				apiextensionsv1beta1.CustomResourceDefinitionVersion{
-					Name:    "v1",
-					Served:  true,
-					Storage: true,
+		Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+			{
+				Name:    "v1",
+				Served:  true,
+				Storage: true,
+				Schema: &apiextensionsv1.CustomResourceValidation{
+					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
+						Properties: map[string]apiextensionsv1.JSONSchemaProps{
+							"spec": {
+								Type: "object",
+								Properties: map[string]apiextensionsv1.JSONSchemaProps{
+									"listeners": {
+										Type: "array",
+										Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+											Schema: &apiextensionsv1.JSONSchemaProps{
+												Type: "object",
+												Properties: map[string]apiextensionsv1.JSONSchemaProps{
+													"name": {
+														Type: "string",
+													},
+													"protocol": {
+														Type: "string",
+													},
+													"socket": {
+														Type: "string",
+													},
+													"address": {
+														Type: "string",
+													},
+													"debug": {
+														Type: "boolean",
+													},
+													"caCertFiles": {
+														Type: "array",
+														Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+															Schema: &apiextensionsv1.JSONSchemaProps{
+																Type: "string",
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+									"handlers": {
+										Type: "array",
+										Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+											Schema: &apiextensionsv1.JSONSchemaProps{
+												Type: "object",
+												Properties: map[string]apiextensionsv1.JSONSchemaProps{
+													"name": {
+														Type: "string",
+													},
+													"type": {
+														Type: "string",
+													},
+													"listener": {
+														Type: "string",
+													},
+													"debug": {
+														Type: "boolean",
+													},
+													"match": {
+														Type: "array",
+														Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+															Schema: &apiextensionsv1.JSONSchemaProps{
+																Type: "string",
+															},
+														},
+													},
+													"credentials": {
+														Type: "array",
+														Items: &apiextensionsv1.JSONSchemaPropsOrArray{
+															Schema: &apiextensionsv1.JSONSchemaProps{
+																Type: "object",
+																Properties: map[string]apiextensionsv1.JSONSchemaProps{
+																	"name": {
+																		Type: "string",
+																	},
+																	"provider": {
+																		Type: "string",
+																	},
+																	"id": {
+																		Type: "string",
+																	},
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
-			Scope: apiextensionsv1beta1.NamespaceScoped,
 		},
-	}
+		Scope: apiextensionsv1.NamespaceScoped,
+	},
+}
 
-	res, err := apiExtClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(context.TODO(), secretlessCRD, meta_v1.CreateOptions{})
+func createCRD(apiExtClient *apiextensionsclientset.Clientset) error {
+	res, err := apiExtClient.ApiextensionsV1().CustomResourceDefinitions().Create(
+		context.TODO(), secretlessCRD, meta_v1.CreateOptions{})
+
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return fmt.Errorf("%s: ERROR: Could not create Secretless CRD: %v - %v", PluginName,
 			err, res)
 	}
 
-	if apierrors.IsAlreadyExists(err) == false {
+	if !apierrors.IsAlreadyExists(err) {
 		log.Printf("%s: CRD was uccessfully added!", PluginName)
 	}
 

--- a/k8s-ci/k8s_crds/deployment.yaml.sh
+++ b/k8s-ci/k8s_crds/deployment.yaml.sh
@@ -100,4 +100,5 @@ spec:
         imagePullPolicy: Always
         ports:
           - containerPort: 8080
+
 EOL

--- a/resource-definitions/README.md
+++ b/resource-definitions/README.md
@@ -36,7 +36,7 @@ configurations.secretless.io   1m
 $ kubectl get crd -o yaml
 apiVersion: v1
 items:
-- apiVersion: apiextensions.k8s.io/v1beta1
+- apiVersion: apiextensions.k8s.io/v1
   kind: CustomResourceDefinition
   metadata:
     annotations:
@@ -145,6 +145,14 @@ customresourcedefinition.apiextensions.k8s.io "configurations.secretless.io" del
 
 This method is a bit more complicated, especially if it's run in-cluster due to needing to
 have service account privileges but with that prerequisite, you can then use the `crd_injector.go`:
+
+Open the `crd_injector.go` file in an editor and add the CRD schema:
+
+```go
+var crdSchema = &apiextensionsv1.JSONSchemaProps{
+ // NOTE: Take the CRD schema from the internal/configurationmanagers/kubernetes/crd/crd_injector.go
+}
+```
 
 ```
 $ kubectl get crd

--- a/resource-definitions/crd_watcher.go
+++ b/resource-definitions/crd_watcher.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"os"
@@ -66,7 +67,7 @@ func main() {
 	}
 
 	// List the available configurations
-	list, err := clientset.SecretlessV1().Configurations("default").List(meta_v1.ListOptions{})
+	list, err := clientset.SecretlessV1().Configurations("default").List(context.Background(), meta_v1.ListOptions{})
 	log.Printf("Available configs: %v", len(list.Items))
 	for _, config := range list.Items {
 		yamlContent, err := yaml.Marshal(&config)
@@ -79,10 +80,10 @@ func main() {
 
 	watchList := &cache.ListWatch{
 		ListFunc: func(listOpts meta_v1.ListOptions) (result runtime.Object, err error) {
-			return clientset.SecretlessV1().Configurations(meta_v1.NamespaceAll).List(listOpts)
+			return clientset.SecretlessV1().Configurations(meta_v1.NamespaceAll).List(context.Background(), listOpts)
 		},
 		WatchFunc: func(listOpts meta_v1.ListOptions) (watch.Interface, error) {
-			return clientset.SecretlessV1().Configurations(meta_v1.NamespaceAll).Watch(listOpts)
+			return clientset.SecretlessV1().Configurations(meta_v1.NamespaceAll).Watch(context.Background(), listOpts)
 		},
 	}
 

--- a/resource-definitions/secretless-resource-definition.yaml
+++ b/resource-definitions/secretless-resource-definition.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: configurations.secretless.io
@@ -9,10 +9,63 @@ spec:
     plural: configurations
     singular: configuration
     shortNames:
-    - sbconfig
+      - sbconfig
   scope: Namespaced
-  version: v1
   versions:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                listeners:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      protocol:
+                        type: string
+                      socket:
+                        type: string
+                      address:
+                        type: string
+                      debug:
+                        type: boolean
+                      caCertFiles:
+                        type: array
+                        items:
+                          type: string
+                handlers:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      type:
+                        type: string
+                      listener:
+                        type: string
+                      debug:
+                        type: boolean
+                      match:
+                        type: array
+                        items:
+                          type: string
+                      credentials:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            provider:
+                              type: string
+                            id:
+                              type: string


### PR DESCRIPTION
### Desired Outcome

One of the ways that the CyberArk Secretless Broker (SB) can be configured is by using a Kubernetes Custom Resource Definition (CRD) that is specifically created for SB Configuration. This method of configuration is documented [here](https://github.com/cyberark/secretless-broker/tree/main/resource-definitions).

Currently, our documentation suggests that users should deploy these CRDs using the `{{apiextensions.k8s.io/v1beta1}}`
Kubernetes API version. However, support for this API version has been _*fully removed*_ in Kubernetes API controllers as of Kubernetes v1.22.

This means that any customers who want to use the Secretless Broker in Kubernetes clusters that are v1.22 or newer (or, correspondingly OpenShift v4.9 or newer) must create CRDs using the `v1` API version, that is, `apiextensions.k8s.io/v1`.

However, for this `v1` API version, the CRD specifications must include a structural schema as described here:
https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema

An example of a CRD manifest that contains a structural schema is here:
https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition

More details at https://github.com/cyberark/sidecar-injector/pull/64

### Implemented Changes

- Upgrade all uses of the `v1beta1` api to use `v1`
- Added schema to template and injector code

### Connected Issue/Story

CyberArk internal issue link: [ONYX-14759](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14759)

### Definition of Done

- [x] Upgrade our documentation for Secretless Broker to use the newer `v1` API version.
- [x] Add this schema to our Secretless Broker E2E tests

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
