### PR TITLE
Updating the Goreleaser version

### DIFF
--- a/bin/build_release
+++ b/bin/build_release
@@ -11,7 +11,7 @@ GO_VERSION="v$(grep "^\bgo\b" "${REPO_ROOT}/go.mod" | awk '{print $2}')"
 # Use a GoReleaser Docker image containing cross-compilation tools
 # This image is recommended by the official GoReleaser docs
 # https://goreleaser.com/cookbooks/cgo-and-crosscompiling/
-GORELEASER_IMAGE="troian/golang-cross"
+GORELEASER_IMAGE="goreleaser/goreleaser-cross"
 
 # Get the latest tags
 GORELEASER_TAGS_JSON="$(curl --silent --show-error https://registry.hub.docker.com/v2/repositories/${GORELEASER_IMAGE}/tags?page_size=100)"


### PR DESCRIPTION
### Desired Outcome

Goreleaser should build for the new Apple hardware

### Implemented Changes

Updated to the standard goreleaser as it now supports the needed builds.

### Connected Issue/Story

Needed by #1449 

CyberArk internal issue link: [insert issue ID]()

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
