### PR TITLE
Add empty tests to force go to include coverage for dirs without tests

### DIFF
--- a/cmd/secretless-broker/empty_test.go
+++ b/cmd/secretless-broker/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package main

--- a/internal/configurationmanagers/configfile/empty_test.go
+++ b/internal/configurationmanagers/configfile/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package configfile

--- a/internal/configurationmanagers/kubernetes/crd/empty_test.go
+++ b/internal/configurationmanagers/kubernetes/crd/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package crd

--- a/internal/plugin/connectors/http/basicauth/empty_test.go
+++ b/internal/plugin/connectors/http/basicauth/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package basicauth

--- a/internal/plugin/connectors/http/conjur/empty_test.go
+++ b/internal/plugin/connectors/http/conjur/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package conjur

--- a/internal/plugin/connectors/http/empty_test.go
+++ b/internal/plugin/connectors/http/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package http

--- a/internal/plugin/connectors/mock/empty_test.go
+++ b/internal/plugin/connectors/mock/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package mock

--- a/internal/plugin/connectors/ssh/empty_test.go
+++ b/internal/plugin/connectors/ssh/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package ssh

--- a/internal/plugin/connectors/sshagent/empty_test.go
+++ b/internal/plugin/connectors/sshagent/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package sshagent

--- a/internal/plugin/connectors/tcp/mssql/mock/empty_test.go
+++ b/internal/plugin/connectors/tcp/mssql/mock/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package mock

--- a/internal/plugin/connectors/tcp/mssql/types/empty_test.go
+++ b/internal/plugin/connectors/tcp/mssql/types/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package types

--- a/internal/plugin/v1/eventnotifier/empty_test.go
+++ b/internal/plugin/v1/eventnotifier/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package eventnotifier

--- a/internal/plugin/v1/testutils/empty_test.go
+++ b/internal/plugin/v1/testutils/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package testutils

--- a/internal/providers/awssecrets/empty_test.go
+++ b/internal/providers/awssecrets/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package awssecrets

--- a/internal/providers/conjur/empty_test.go
+++ b/internal/providers/conjur/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package conjur

--- a/internal/providers/env/empty_test.go
+++ b/internal/providers/env/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package env

--- a/internal/providers/file/empty_test.go
+++ b/internal/providers/file/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package file

--- a/internal/providers/keychain/empty_test.go
+++ b/internal/providers/keychain/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package keychain

--- a/internal/providers/kubernetessecrets/empty_test.go
+++ b/internal/providers/kubernetessecrets/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package kubernetessecrets

--- a/internal/providers/literal/empty_test.go
+++ b/internal/providers/literal/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package literal

--- a/internal/providers/vault/empty_test.go
+++ b/internal/providers/vault/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package vault

--- a/internal/proxyservice/empty_test.go
+++ b/internal/proxyservice/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package proxyservice

--- a/pkg/apis/secretless.io/empty_test.go
+++ b/pkg/apis/secretless.io/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package secretless

--- a/pkg/apis/secretless.io/v1/empty_test.go
+++ b/pkg/apis/secretless.io/v1/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package v1

--- a/pkg/k8sclient/clientset/versioned/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package versioned

--- a/pkg/k8sclient/clientset/versioned/fake/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/fake/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package fake

--- a/pkg/k8sclient/clientset/versioned/scheme/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/scheme/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package scheme

--- a/pkg/k8sclient/clientset/versioned/typed/secretless.io/v1/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/typed/secretless.io/v1/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package v1

--- a/pkg/k8sclient/clientset/versioned/typed/secretless.io/v1/fake/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/typed/secretless.io/v1/fake/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package fake

--- a/pkg/k8sclient/informers/externalversions/empty_test.go
+++ b/pkg/k8sclient/informers/externalversions/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package externalversions

--- a/pkg/k8sclient/informers/externalversions/internalinterfaces/empty_test.go
+++ b/pkg/k8sclient/informers/externalversions/internalinterfaces/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package internalinterfaces

--- a/pkg/k8sclient/informers/externalversions/secretless.io/empty_test.go
+++ b/pkg/k8sclient/informers/externalversions/secretless.io/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package secretless

--- a/pkg/k8sclient/informers/externalversions/secretless.io/v1/empty_test.go
+++ b/pkg/k8sclient/informers/externalversions/secretless.io/v1/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package v1

--- a/pkg/k8sclient/listers/secretless.io/v1/empty_test.go
+++ b/pkg/k8sclient/listers/secretless.io/v1/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package v1

--- a/pkg/secretless/log/empty_test.go
+++ b/pkg/secretless/log/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package log

--- a/pkg/secretless/log/mock/empty_test.go
+++ b/pkg/secretless/log/mock/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package mock

--- a/pkg/secretless/plugin/connector/http/empty_test.go
+++ b/pkg/secretless/plugin/connector/http/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package http

--- a/pkg/secretless/plugin/connector/tcp/empty_test.go
+++ b/pkg/secretless/plugin/connector/tcp/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package tcp

--- a/pkg/secretless/plugin/empty_test.go
+++ b/pkg/secretless/plugin/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package plugin

--- a/pkg/secretless/plugin/sharedobj/mock/empty_test.go
+++ b/pkg/secretless/plugin/sharedobj/mock/empty_test.go
@@ -1,0 +1,6 @@
+// This is an empty test file used to force Go test to include this package in
+// coverage reports even though there are no existing (non-empty) Go test
+// files. If/when Go tests are added for this package, please delete this
+// empty test file since it will no longer be needed.
+
+package mock


### PR DESCRIPTION
### Desired Outcome

Currently, the Golang code coverage automated tests that are run via Jenkins are
not including Go packages that don't have any Go test files. If we want accurate
code coverage reports, then these packages should be reported as having 0% coverage
and included in the overall coverage report. Otherwise, we're overestimating our actual
code coverage.

### Implemented Changes

For all Go package directories that don't have any Go tests, a file is temporarily added
called `empty_test.go` that only includes a package statement (and some comments).
This will force Go to include the package in coverage reports as being 0% covered.

The `empty_test.go` files should be deleted whenever Go tests are actually added
to each package.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-17302](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-17302)

### Definition of Done

- [x] `empty_test.go` files added.
- [x] Jenkins tests pass.

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
