### PR TITLE
Increase Minimum Line Code Coverage Threshold

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
 
     stage('Cobertura') {
       steps {
-        cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'test/test-coverage/coverage.xml', conditionalCoverageTargets: '50, 0, 0', failUnhealthy: false, failUnstable: false, lineCoverageTargets: '50, 0, 0', maxNumberOfBuilds: 0, methodCoverageTargets: '50, 0, 0', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+        cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'test/test-coverage/coverage.xml', conditionalCoverageTargets: '70, 0, 70', failUnhealthy: true, failUnstable: true, lineCoverageTargets: '70, 70, 70', maxNumberOfBuilds: 0, methodCoverageTargets: '70, 0, 70', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
       }
     }
 

--- a/internal/configurationmanagers/configfile/empty_test.go
+++ b/internal/configurationmanagers/configfile/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package configfile

--- a/internal/configurationmanagers/configfile/fs_watcher.go
+++ b/internal/configurationmanagers/configfile/fs_watcher.go
@@ -7,11 +7,13 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+var logFatal = log.Fatal
+
 // AttachWatcher adds a listener of chenge event to a filepath
 func AttachWatcher(filename string, runner func()) {
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		log.Fatal(err)
+		logFatal(err)
 	}
 
 	go func() {
@@ -47,7 +49,7 @@ func AttachWatcher(filename string, runner func()) {
 	log.Printf("Attaching filesystem notifier onto %s", filename)
 	err = watcher.Add(filename)
 	if err != nil {
-		log.Fatal(err)
+		logFatal(err)
 		watcher.Close()
 	}
 }

--- a/internal/configurationmanagers/configfile/fs_watcher_test.go
+++ b/internal/configurationmanagers/configfile/fs_watcher_test.go
@@ -1,0 +1,63 @@
+package configfile
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAttachWatcher(t *testing.T) {
+	t.Run("AttachWatcher", func(t *testing.T) {
+		// Mock the log.Fatal function to intercept fatal errors for inspection
+		var watcherErr error
+		logFatal = func(v ...interface{}) {
+			watcherErr = v[0].(error)
+		}
+		// Create a listener that will track the number of times the watcher detects a file change
+		changeCount := 0
+		// Allow a 10ms delay for the watcher to detect the file change
+		delay := time.Millisecond * 10
+		onChange := func() {
+			changeCount++
+		}
+
+		checkChangeCount := func(t *testing.T, expectedValue int) {
+			// Wait the specified amount, the assert that the change count is as expected
+			time.Sleep(delay)
+			assert.Equal(t, expectedValue, changeCount)
+		}
+
+		// Create a temp file to watch
+		tempDir, _ := ioutil.TempDir("", "configfile_watcher")
+		defer os.RemoveAll(tempDir)
+		file, err := os.CreateTemp(tempDir, "configfile")
+		assert.NoError(t, err)
+
+		AttachWatcher(file.Name(), onChange)
+		checkChangeCount(t, 0)
+		assert.NoError(t, watcherErr)
+
+		// Write to the file and check that the listener is called
+		_, err = file.WriteString("test")
+		assert.NoError(t, err)
+		checkChangeCount(t, 1)
+		assert.NoError(t, watcherErr)
+
+		_, err = file.WriteString("test again")
+		file.Close()
+		assert.NoError(t, err)
+		checkChangeCount(t, 2)
+		assert.NoError(t, watcherErr)
+
+		// Delete the file and check that the listener is called and an error occurs
+		err = os.Remove(file.Name())
+		assert.NoError(t, err)
+		// Wait longer because the watcher tries to reattach to deleted files in case they're recreated
+		time.Sleep(1 * time.Second)
+		checkChangeCount(t, 3)
+		assert.Error(t, watcherErr)
+	})
+}

--- a/internal/plugin/connectors/http/generic/connector_test.go
+++ b/internal/plugin/connectors/http/generic/connector_test.go
@@ -1,0 +1,164 @@
+package generic
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	mockLogger "github.com/cyberark/secretless-broker/pkg/secretless/log/mock"
+	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func sampleOauth1ConfigYAML() []byte {
+	return []byte(`
+  oauth1:
+    consumer_key: "{{ .consumer_key }}"
+    consumer_secret: "{{ .consumer_secret }}"
+    token: "{{ .token }}"
+    token_secret: "{{ .token_secret }}"
+  forceSSL: true
+  authenticateURLsMatching:
+    - ^http
+`)
+}
+
+func sampleOauth1Config() (*config, error) {
+	cfgYAML, err := NewConfigYAML(sampleOauth1ConfigYAML())
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing sample config YAML")
+	}
+	cfg, err := newConfig(cfgYAML)
+	if err != nil {
+		return nil, errors.Wrap(err, "error calling newConfig()")
+	}
+	return cfg, err
+}
+
+func plainRequest() *http.Request {
+	req, err := http.NewRequest("GET", "http://example.com", &bytes.Buffer{})
+	if err != nil {
+		panic(err)
+	}
+	return req
+}
+
+func requestWithAuthHeader() *http.Request {
+	req := plainRequest()
+	req.Header.Set("Authorization", "Basic 1234567890")
+	return req
+}
+
+func plainConfig() *config {
+	cfg, err := sampleConfig()
+	if err != nil {
+		panic(err)
+	}
+	return cfg
+}
+
+func oauth1Config() *config {
+	cfg, err := sampleOauth1Config()
+	if err != nil {
+		panic(err)
+	}
+	return cfg
+}
+
+var testCases = []struct {
+	description string
+	cfg         *config
+	request     *http.Request
+	creds       connector.CredentialValuesByID
+	expErrStr   string
+}{
+	{
+		description: "happy path",
+		cfg:         plainConfig(),
+		request:     plainRequest(),
+		creds: connector.CredentialValuesByID{
+			"username": []byte("someuser"),
+			"key":      []byte("someKey"),
+			"name":     []byte("Foo Bar"),
+		},
+	},
+	{
+		description: "missing username",
+		cfg:         plainConfig(),
+		request:     plainRequest(),
+		creds: connector.CredentialValuesByID{
+			"key":  []byte("someKey"),
+			"name": []byte("Foo Bar"),
+		},
+		expErrStr: "missing required credential: \"username\"",
+	},
+	{
+		description: "missing query params",
+		cfg:         plainConfig(),
+		request:     plainRequest(),
+		creds: connector.CredentialValuesByID{
+			"username": []byte("someuser"),
+		},
+		expErrStr: "failed to render query params: Key: couldn't render template",
+	},
+	{
+		description: "oauth1 happy path",
+		cfg:         oauth1Config(),
+		request:     plainRequest(),
+		creds: connector.CredentialValuesByID{
+			"consumer_key":    []byte("someConsumerKey"),
+			"consumer_secret": []byte("someConsumerSecret"),
+			"token":           []byte("someToken"),
+			"token_secret":    []byte("someTokenSecret"),
+		},
+	},
+	{
+		description: "oauth1 missing params",
+		cfg:         oauth1Config(),
+		request:     plainRequest(),
+		creds: connector.CredentialValuesByID{
+			"consumer_key":    []byte(nil),
+			"consumer_secret": []byte("someConsumerSecret"),
+			"token":           []byte("someToken"),
+			"token_secret":    []byte("someTokenSecret"),
+		},
+		expErrStr: "failed to create oAuth1 'Authorization' header: required oAuth1 parameter 'consumer_key' not found",
+	},
+	{
+		description: "oauth1 duplicate auth header",
+		cfg:         oauth1Config(),
+		request:     requestWithAuthHeader(),
+		creds: connector.CredentialValuesByID{
+			"consumer_key":    []byte("someConsumerKey"),
+			"consumer_secret": []byte("someConsumerSecret"),
+			"token":           []byte("someToken"),
+			"token_secret":    []byte("someTokenSecret"),
+		},
+		expErrStr: "authorization header already exists, cannot override header",
+	},
+}
+
+func TestConnect(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			logger := mockLogger.NewLogger()
+			c := Connector{
+				logger: logger,
+				config: tc.cfg,
+			}
+
+			err := c.Connect(tc.request, tc.creds)
+
+			if tc.expErrStr != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expErrStr)
+				return
+			}
+
+			assert.NoError(t, err)
+			// Ensure forceSSL is working
+			assert.Equal(t, tc.request.URL.Scheme, "https")
+		})
+	}
+}

--- a/internal/plugin/connectors/mock/empty_test.go
+++ b/internal/plugin/connectors/mock/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package mock

--- a/internal/plugin/connectors/tcp/mssql/mock/empty_test.go
+++ b/internal/plugin/connectors/tcp/mssql/mock/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package mock

--- a/internal/providers/env/empty_test.go
+++ b/internal/providers/env/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package env

--- a/internal/providers/env/provider_test.go
+++ b/internal/providers/env/provider_test.go
@@ -1,0 +1,50 @@
+package env
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProvider(t *testing.T) {
+	// Set an environment variable for testing
+	os.Setenv("TEST_ENV_VAR", "test_env_val")
+	defer os.Unsetenv("TEST_ENV_VAR")
+
+	testCases := []struct {
+		desc        string
+		expectedID  string
+		expectedVal string
+		expectedErr error
+	}{
+		{
+			desc:        "GetValue returns the value of the environment variable",
+			expectedID:  "TEST_ENV_VAR",
+			expectedVal: "test_env_val",
+		},
+		{
+			desc:        "GetValue returns an error if the environment variable is not found",
+			expectedID:  "TEST_ENV_VAR_NOT_FOUND",
+			expectedErr: fmt.Errorf("%s cannot find environment variable '%s'", "env", "TEST_ENV_VAR_NOT_FOUND"),
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			provider := &EnvironmentProvider{
+				Name: "env",
+			}
+			assert.Equal(t, "env", provider.GetName())
+
+			val, err := provider.GetValue(testCase.expectedID)
+			if testCase.expectedErr != nil {
+				assert.EqualError(t, err, testCase.expectedErr.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, testCase.expectedVal, string(val))
+			}
+		})
+	}
+}

--- a/pkg/k8sclient/clientset/versioned/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package versioned

--- a/pkg/k8sclient/clientset/versioned/fake/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/fake/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package fake

--- a/pkg/k8sclient/clientset/versioned/scheme/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/scheme/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package scheme

--- a/pkg/k8sclient/clientset/versioned/typed/secretless.io/v1/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/typed/secretless.io/v1/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package v1

--- a/pkg/k8sclient/clientset/versioned/typed/secretless.io/v1/fake/empty_test.go
+++ b/pkg/k8sclient/clientset/versioned/typed/secretless.io/v1/fake/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package fake

--- a/pkg/k8sclient/informers/externalversions/empty_test.go
+++ b/pkg/k8sclient/informers/externalversions/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package externalversions

--- a/pkg/k8sclient/informers/externalversions/internalinterfaces/empty_test.go
+++ b/pkg/k8sclient/informers/externalversions/internalinterfaces/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package internalinterfaces

--- a/pkg/k8sclient/informers/externalversions/secretless.io/empty_test.go
+++ b/pkg/k8sclient/informers/externalversions/secretless.io/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package secretless

--- a/pkg/k8sclient/informers/externalversions/secretless.io/v1/empty_test.go
+++ b/pkg/k8sclient/informers/externalversions/secretless.io/v1/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package v1

--- a/pkg/k8sclient/listers/secretless.io/v1/empty_test.go
+++ b/pkg/k8sclient/listers/secretless.io/v1/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package v1

--- a/pkg/secretless/log/mock/empty_test.go
+++ b/pkg/secretless/log/mock/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package mock

--- a/pkg/secretless/plugin/sharedobj/external_plugins_test.go
+++ b/pkg/secretless/plugin/sharedobj/external_plugins_test.go
@@ -10,26 +10,96 @@ import (
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/sharedobj/mock"
 )
 
+var metadataTestCases = []struct {
+	description   string
+	rawPlugin     rawPlugin
+	rawPluginName string
+	expectedType  string
+	expectedID    string
+	expectedError string
+}{
+	{
+		description:   "happy path",
+		rawPlugin:     mock.RawPlugins["http1"],
+		rawPluginName: "mock_plugin",
+		expectedType:  "connector.http",
+		expectedID:    "extHTTP1",
+	},
+	{
+		description: "empty plugin id results in error",
+		rawPlugin: mock.RawPlugin{
+			PluginAPIVersion: "0.1.0",
+			PluginType:       "connector.http",
+		},
+		rawPluginName: "mock_plugin",
+		expectedError: "PluginInfo['id'] is blank",
+	},
+	{
+		description: "empty plugin type results in error",
+		rawPlugin: mock.RawPlugin{
+			PluginAPIVersion: "0.1.0",
+			PluginID:         "extHTTP1",
+		},
+		rawPluginName: "mock_plugin",
+		expectedError: "PluginInfo['type'] is blank",
+	},
+	{
+		description: "empty plugin api version in error",
+		rawPlugin: mock.RawPlugin{
+			PluginType: "connector.http",
+			PluginID:   "extHTTP1",
+		},
+		rawPluginName: "mock_plugin",
+		expectedError: "PluginInfo['pluginAPIVersion'] is blank",
+	},
+	{
+		description: "unsupported plugin api version in error",
+		rawPlugin: mock.RawPlugin{
+			PluginType:       "connector.http",
+			PluginID:         "extHTTP1",
+			PluginAPIVersion: "0.2.0",
+		},
+		rawPluginName: "mock_plugin",
+		expectedError: "plugin 'mock_plugin' (API v0.2.0) is not a supported API version (v0.1.0)",
+	},
+	{
+		description: "plugin without PluginInfo results in error",
+		rawPlugin: mock.InvalidPlugin{
+			PluginAPIVersion: "0.1.0",
+			PluginID:         "extHTTP1",
+			PluginType:       "connector.tcp",
+			ErrorOnLookup:    true,
+		},
+		rawPluginName: "mock_plugin",
+		expectedError: "error on lookup",
+	},
+	{
+		description: "plugin with wrong type for PluginInfo results in error",
+		rawPlugin: mock.InvalidPlugin{
+			PluginAPIVersion: "0.1.0",
+			PluginID:         "extHTTP1",
+			PluginType:       "connector.tcp",
+		},
+		rawPluginName: "mock_plugin",
+		expectedError: "could not cast PluginInfo to proper type",
+	},
+}
+
 func TestParsePluginMetadata(t *testing.T) {
-	t.Run("Correctly parses plugin metadata", func(t *testing.T) {
-		// Set up for test
-		rawPlugin := mock.RawPlugins["http1"]
-		rawPluginName := "mock_plugin"
+	for _, tc := range metadataTestCases {
+		t.Run(tc.description, func(t *testing.T) {
+			// Run test
+			pluginType, pluginID, err := parsePluginMetadata(tc.rawPlugin, tc.rawPluginName)
 
-		// Run test
-		pluginType, pluginID, err := parsePluginMetadata(rawPlugin, rawPluginName)
-
-		// Check results
-		expType := "connector.http"
-		expID := "extHTTP1"
-
-		assert.NoError(t, err)
-		if err != nil {
-			return
-		}
-		assert.Equal(t, expType, pluginType)
-		assert.Equal(t, expID, pluginID)
-	})
+			if tc.expectedError != "" {
+				assert.EqualError(t, err, tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedType, pluginType)
+				assert.Equal(t, tc.expectedID, pluginID)
+			}
+		})
+	}
 }
 
 // directoryPluginLookup implements an external DirectoryPluginLookupFunc
@@ -67,7 +137,7 @@ func TestExternalPlugins(t *testing.T) {
 	})
 
 	// Test detection of conflicting external plugin names.
-	TestCases := []struct {
+	testCases := []struct {
 		description   string
 		addPluginName string
 		addPluginType string // "connector.http" or "connector.tcp"
@@ -100,7 +170,7 @@ func TestExternalPlugins(t *testing.T) {
 		},
 	}
 
-	for _, tc := range TestCases {
+	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			// Set up baseline test plugins
 			testPlugins := map[string]mock.RawPlugin{}

--- a/pkg/secretless/plugin/sharedobj/mock/empty_test.go
+++ b/pkg/secretless/plugin/sharedobj/mock/empty_test.go
@@ -1,6 +1,0 @@
-// This is an empty test file used to force Go test to include this package in
-// coverage reports even though there are no existing (non-empty) Go test
-// files. If/when Go tests are added for this package, please delete this
-// empty test file since it will no longer be needed.
-
-package mock

--- a/pkg/secretless/plugin/sharedobj/mock/invalid_plugin.go
+++ b/pkg/secretless/plugin/sharedobj/mock/invalid_plugin.go
@@ -1,0 +1,30 @@
+package mock
+
+import (
+	"fmt"
+	go_plugin "plugin"
+)
+
+// InvalidPlugin implements the rawPlugin interface
+type InvalidPlugin struct {
+	PluginAPIVersion string
+	PluginType       string
+	PluginID         string
+	ErrorOnLookup    bool
+}
+
+// Lookup returns a go_plugin.Symbol for a given symbol name string. A go_plugin.Symbol
+// is an empty interface, and can be instantiated with a function or a struct.
+// This method is intended to mimic the Lookup method for a standard Go plugin.
+func (r InvalidPlugin) Lookup(symbolName string) (go_plugin.Symbol, error) {
+	if r.ErrorOnLookup {
+		return nil, fmt.Errorf("error on lookup")
+	}
+
+	switch symbolName {
+	case "PluginInfo":
+		// Return something other than the correct type
+		return func() string { return "test" }, nil
+	}
+	return nil, fmt.Errorf("unknown symbolName %s", symbolName)
+}


### PR DESCRIPTION
### Desired Outcome

The current code coverage is currently hovering around 65%. Try to get it above 70% and increase the minimum coverage to 70% in the Jenkinsfile.

Min. Coverage: 70%

Desired Coverage: 80%

Optimal Coverage: 90%

### Implemented Changes

- Removed empty_test.go files from mock directories, so those directories are not counted towards coverage. This increase combined coverage from UT and integration tests to 68.7%.
- Added more unit tests to increase combined coverage to 70.7%.
- Modified Jenkinsfile to fail if combined coverage falls below 70%.
 
### Connected Issue/Story

CyberArk internal issue link: [ONYX-14781](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-14781)

### Definition of Done

- [x] Cobertura reports at least 70% code coverage
- [x] CI fails if test coverage is less than 70%

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [x] This PR includes new unit and integration tests to go with the code
  changes, or
- [ ] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
