### PR TITLE
Fix GH Actions on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,10 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      # Uninstall old go
-      - run: brew uninstall go@1.15
       # Install go1.17
-      - run: brew install go@1.17
-      # Add go1.17 to PATH
-      - run: echo "/usr/local/opt/go@1.17/bin" >> $GITHUB_PATH
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '~1.17.0'
       # Get go version
       - run: go version
       # Download go modules


### PR DESCRIPTION
### Desired Outcome

Github Action "CI / Functional Tests on macOS" should pass.

### Implemented Changes

- Removed command to uninstall go 1.15 as it's no longer installed as of actions/virtual-environments#5280. Instead, use actions/setup-go. 

### Connected Issue/Story

N/A

### Definition of Done

- [x] Github action "CI / Functional Tests on macOS" passes

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
