### PR TITLE
Add missing summon enviroinment for promoting release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ if (params.MODE == "PROMOTE") {
     sh "docker pull registry.tld/secretless-broker-quickstart:${sourceVersion}"
     sh "docker pull registry.tld/secretless-broker-redhat:${sourceVersion}"
     // Promote source version to target version.
-    sh "summon ./bin/publish --promote --source ${sourceVersion} --target ${targetVersion}"
+    sh "summon -e common ./bin/publish --promote --source ${sourceVersion} --target ${targetVersion}"
   }
   return
 }


### PR DESCRIPTION
### Desired Outcome

Fix Jenkins failing to promote releases generated by the new auto release process.

```
./bin/publish: line 130: REDHAT_API_KEY: unbound variable
```

### Implemented Changes

- Added missing `-e common` flag when calling summon

### Connected Issue/Story

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
