### PR TITLE
Remove GoConvey from tests

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -34,6 +34,13 @@ plugins:
         ruby:
         swift:
         typescript:
+    exclude_patterns:
+      # Exclude individual tests that have code duplication
+      - "internal/util/health_test.go"
+      - "test/connector/tcp/mysql/tests/init_test.go"
+      - "test/connector/tcp/mysql/tests/essentials_test.go"
+      - "test/connector/tcp/pg/tests/init_test.go"
+      - "test/connector/tcp/pg/tests/essentials_test.go"
 
   fixme: # Flags any FIXME, TODO, BUG, XXX, HACK comments so they can be fixed
     enabled: true

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -39,13 +39,11 @@ RUN groupadd -r secretless \
 # the happen to be written in Go:
 #
 # go-junit-report => Convert go test output to junit xml
-# goconvey => Go testing tool
 # reflex => Utility for watching files and executing process in response to changes
 # gocov => converts native coverage output to gocov's JSON interchange format
 # gocov-xml => converts gocov format to XML for use with Jenkins/Cobertura
 # gocovmerge => Merges multiple 'go test -coverprofile' results into one profile
 RUN go get -u github.com/jstemmer/go-junit-report && \
-    go get github.com/smartystreets/goconvey && \
     go get github.com/cespare/reflex && \
     go get github.com/axw/gocov/gocov && \
     go get github.com/AlekSi/gocov-xml && \

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -39,7 +39,6 @@ SECTION 4: MIT License
 >>> github.com/joho/godotenv-1.4.0
 >>> github.com/keybase/go-keychain-0.0.0-20220610143837-c2ce06069005
 >>> github.com/lib/pq-1.10.6
->>> github.com/smartystreets/goconvey-1.7.2
 >>> github.com/stretchr/testify-1.7.2
 >>> gopkg.in/yaml.v2-2.4.0
 
@@ -550,19 +549,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
->>> github.com/smartystreets/goconvey-1.7.2
-
-Copyright (c) 2016 SmartyStreets, LLC
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-NOTE: Various optional and subordinate components carry their own licensing requirements and restrictions. Use of those components is subject to the terms and conditions outlined the respective license of each component.
 
 
 >>> github.com/stretchr/testify-1.7.2

--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,7 @@ require (
 	github.com/lib/pq v1.10.6
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/profile v1.6.0
-	github.com/smartystreets/goconvey v1.7.2
-	github.com/stretchr/testify v1.7.2
+	github.com/stretchr/testify v1.8.0
 	github.com/urfave/cli v1.22.9
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	gopkg.in/yaml.v2 v2.4.0
@@ -91,7 +90,6 @@ require (
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/go-cmp v0.5.7 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
@@ -103,7 +101,6 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/jtolds/gls v4.20.0+incompatible // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -120,17 +117,16 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
-	github.com/smartystreets/assertions v1.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
 	go.opentelemetry.io/otel v1.7.0 // indirect
 	go.opentelemetry.io/otel/exporters/jaeger v1.7.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.7.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.7.0 // indirect
 	go.opentelemetry.io/otel/trace v1.7.0 // indirect
-	golang.org/x/net v0.0.0-20220607020251-c690dde0001d // indirect
+	golang.org/x/net v0.0.0-20220812174116-3211cb980234 // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,10 @@ github.com/cyberark/conjur-authn-k8s-client v0.23.7 h1:TgjYOb94StPaK19w9aaGx/xZX
 github.com/cyberark/conjur-authn-k8s-client v0.23.7/go.mod h1:+Yeek99Ijq2IB3WYHx+Wp9aUfyMm42WjZshVlbtIKcg=
 github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-394 h1:Ffl+3eKkawBUtaRC2O0rTT3KGvr/NzaO6BB7HI0fly4=
 github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-394/go.mod h1:IU6D7QQezwoCi6GaKa+79ZrBNyJzFCbIAep0VrLHK6o=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-478/go.mod h1:IU6D7QQezwoCi6GaKa+79ZrBNyJzFCbIAep0VrLHK6o=
 github.com/cyberark/summon v0.9.3 h1:lMsQEVGREwcce8ZjYKFbyihe+GueWmROFvYau7+T31k=
 github.com/cyberark/summon v0.9.3/go.mod h1:2Mh4/bYeYX8uWeMj9JuySUnmWMGHUyXK88NdP8nPSSY=
+github.com/cyberark/summon v0.9.4/go.mod h1:o6y8/NyiqA2+cneZKkGt9NsfhQK2wD0+aWDgPqLWiGk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -303,8 +305,6 @@ github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1ks85zJ1lfDGgIiMDuIptTOhJq+zKyg=
-github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -410,7 +410,6 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
@@ -559,11 +558,7 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
-github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
-github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
-github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
-github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -583,6 +578,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
@@ -592,6 +588,7 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -701,6 +698,7 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d h1:4SFsTMi4UahlKoloni7L4eYzhFRifURQLw+yv0QDCx8=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220812174116-3211cb980234/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -793,6 +791,7 @@ golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/internal/plugin/v1/provider_test.go
+++ b/internal/plugin/v1/provider_test.go
@@ -3,36 +3,36 @@ package v1
 import (
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetValues(t *testing.T) {
-	Convey("GetValues", t, func() {
+	t.Run("GetValues", func(t *testing.T) {
 		// ids, 4 of which are unique
 		ids := []string{"foo", "err_meow", "bar", "bar", "err_meow", "err_baz"}
 
-		Convey("Sequentially call GetValue on unique ids", func() {
+		t.Run("Sequentially call GetValue on unique ids", func(t *testing.T) {
 			p := &MockProvider{}
 			_, _ = GetValues(
 				p,
 				ids...,
 			)
 
-			So(p.GetValueCallArgs, ShouldResemble, []string{"foo", "err_meow", "bar", "err_baz"})
+			assert.ObjectsAreEqualValues([]string{"foo", "err_meow", "bar", "err_baz"}, p.GetValueCallArgs)
 		})
 
-		Convey("Returns good or bad responses depending on unique ids", func() {
+		t.Run("Returns good or bad responses depending on unique ids", func(t *testing.T) {
 			providerResponses, err := GetValues(
 				&MockProvider{},
 				ids...,
 			)
-			So(err, ShouldBeNil)
-			So(len(providerResponses), ShouldEqual, 4)
+			assert.NoError(t, err)
+			assert.Len(t, providerResponses, 4)
 
-			ensureGoodResponse(providerResponses, "foo")
-			ensureGoodResponse(providerResponses, "bar")
-			ensureErrResponse(providerResponses, "err_baz")
-			ensureErrResponse(providerResponses, "err_meow")
+			ensureGoodResponse(providerResponses, "foo", t)
+			ensureGoodResponse(providerResponses, "bar", t)
+			ensureErrResponse(providerResponses, "err_baz", t)
+			ensureErrResponse(providerResponses, "err_meow", t)
 		})
 	})
 }
@@ -40,17 +40,17 @@ func TestGetValues(t *testing.T) {
 // ensureGoodResponse ensures [key] exists within a provider-responses map, and that the
 // entry has no error and the value is []byte(key), in line with how
 // MockProvider#GetValue works
-func ensureGoodResponse(responses map[string]ProviderResponse, key string) {
-	So(responses, ShouldContainKey, key)
-	So(responses[key].Error, ShouldBeNil)
-	So(responses[key].Value, ShouldResemble, []byte(key+"_value"))
+func ensureGoodResponse(responses map[string]ProviderResponse, key string, t *testing.T) {
+	assert.Contains(t, responses, key)
+	assert.Nil(t, responses[key].Error)
+	assert.Equal(t, key+"_value", string(responses[key].Value))
 }
 
 // ensureErrResponse ensures [key] exists within a provider-responses map, and that the
 // entry has no value and the error string is equal to [key], in line with how
 // MockProvider#GetValue works
-func ensureErrResponse(responses map[string]ProviderResponse, key string) {
-	So(responses, ShouldContainKey, key)
-	So(responses[key].Value, ShouldBeNil)
-	So(responses[key].Error.Error(), ShouldEqual, key+"_value")
+func ensureErrResponse(responses map[string]ProviderResponse, key string, t *testing.T) {
+	assert.Contains(t, responses, key)
+	assert.Nil(t, responses[key].Value)
+	assert.Equal(t, key+"_value", string(responses[key].Error.Error()))
 }

--- a/pkg/secretless/config/config_test.go
+++ b/pkg/secretless/config/config_test.go
@@ -4,22 +4,22 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	crd_api_v1 "github.com/cyberark/secretless-broker/pkg/apis/secretless.io/v1"
 )
 
 func Test_Config(t *testing.T) {
-	Convey("Reports absence of handlers", t, func() {
+	t.Run("Reports absence of handlers", func(t *testing.T) {
 		yaml := `
 ---
 `
 		_, err := Load([]byte(yaml))
-		So(fmt.Sprintf("%s", err), ShouldContainSubstring, "Handlers: cannot be blank")
-		So(fmt.Sprintf("%s", err), ShouldContainSubstring, "Listeners: cannot be blank")
+		assert.Contains(t, fmt.Sprintf("%s", err), "Handlers: cannot be blank")
+		assert.Contains(t, fmt.Sprintf("%s", err), "Listeners: cannot be blank")
 	})
 
-	Convey("Loads a realistic configuration without errors", t, func() {
+	t.Run("Loads a realistic configuration without errors", func(t *testing.T) {
 		yaml := `
 listeners:
 - name: http_default
@@ -36,11 +36,11 @@ handlers:
 
 `
 		config, err := Load([]byte(yaml))
-		So(err, ShouldBeNil)
-		So(config.Services, ShouldHaveLength, 1)
+		assert.NoError(t, err)
+		assert.Len(t, config.Services, 1)
 	})
 
-	Convey("Allows listeners to have debug flag", t, func() {
+	t.Run("Allows listeners to have debug flag", func(t *testing.T) {
 		yaml := `
 listeners:
 - name: http_default
@@ -58,29 +58,29 @@ handlers:
 
 `
 		config, err := Load([]byte(yaml))
-		So(err, ShouldBeNil)
-		So(config.Services, ShouldHaveLength, 1)
+		assert.NoError(t, err)
+		assert.Len(t, config.Services, 1)
 	})
 
-	Convey("Reports an unnamed Listener definition", t, func() {
+	t.Run("Reports an unnamed Listener definition", func(t *testing.T) {
 		yaml := `
 listeners:
   - protocol: pg
 `
 		_, err := Load([]byte(yaml))
-		So(fmt.Sprintf("%s", err), ShouldContainSubstring, "Name: cannot be blank")
+		assert.Contains(t, fmt.Sprintf("%s", err), "Name: cannot be blank")
 	})
 
-	Convey("Reports an unknown protocol", t, func() {
+	t.Run("Reports an unknown protocol", func(t *testing.T) {
 		yaml := `
 listeners:
   - protocol: myapp
 `
 		_, err := Load([]byte(yaml))
-		So(fmt.Sprintf("%s", err), ShouldContainSubstring, "Name: cannot be blank.")
+		assert.Contains(t, fmt.Sprintf("%s", err), "Name: cannot be blank")
 	})
 
-	Convey("Reports a Handler which wants to use an undefined Listener", t, func() {
+	t.Run("Reports a Handler which wants to use an undefined Listener", func(t *testing.T) {
 		yaml := `
 listeners:
   - name: http_default
@@ -92,10 +92,10 @@ handlers:
     listener: none
 `
 		_, err := Load([]byte(yaml))
-		So(fmt.Sprintf("%s", err), ShouldContainSubstring, "Handlers: (0: has no associated listener.)")
+		assert.Contains(t, fmt.Sprintf("%s", err), "Handlers: (0: has no associated listener.)")
 	})
 
-	Convey("Reports a Listener without an address or socket", t, func() {
+	t.Run("Reports a Listener without an address or socket", func(t *testing.T) {
 		yaml := `
 listeners:
   - name: mylistener
@@ -105,10 +105,10 @@ handlers:
   - name: mylistener
 `
 		_, err := Load([]byte(yaml))
-		So(fmt.Sprintf("%s", err), ShouldContainSubstring, "address or socket is required")
+		assert.Contains(t, fmt.Sprintf("%s", err), "address or socket is required")
 	})
 
-	Convey("Reports an unnamed Handler definition", t, func() {
+	t.Run("Reports an unnamed Handler definition", func(t *testing.T) {
 		yaml := `
 listeners:
   - name: http_default
@@ -118,10 +118,10 @@ handlers:
   - listener: http_default
 `
 		_, err := Load([]byte(yaml))
-		So(fmt.Sprintf("%s", err), ShouldContainSubstring, "Name: cannot be blank")
+		assert.Contains(t, fmt.Sprintf("%s", err), "Name: cannot be blank")
 	})
 
-	Convey("Can serialize match fields", t, func() {
+	t.Run("Can serialize match fields", func(t *testing.T) {
 		yaml := `
 listeners:
   - name: http_default
@@ -139,11 +139,11 @@ handlers:
       - test_for_secretless_issues_216
 `
 		config, err := Load([]byte(yaml))
-		So(err, ShouldBeNil)
-		So(config.String(), ShouldContainSubstring, "test_for_secretless_issues_216")
+		assert.NoError(t, err)
+		assert.Contains(t, config.String(), "test_for_secretless_issues_216")
 	})
 
-	Convey("Can generate config from CRD configuration", t, func() {
+	t.Run("Can generate config from CRD configuration", func(t *testing.T) {
 		expectedConfigYaml := `
 listeners:
   - name: http_default
@@ -163,7 +163,7 @@ handlers:
 
 		// We implicitly rely on Load to work properly for this test to pass
 		expectedConfig, err := Load([]byte(expectedConfigYaml))
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 
 		// Create an API object that would be similar to one used to trigger a config reload
 		crdConfig := crd_api_v1.Configuration{
@@ -194,7 +194,7 @@ handlers:
 			},
 		}
 		config, err := LoadFromCRD(crdConfig)
-		So(err, ShouldBeNil)
-		So(config.String(), ShouldEqual, expectedConfig.String())
+		assert.NoError(t, err)
+		assert.Equal(t, expectedConfig.String(), config.String())
 	})
 }

--- a/pkg/secretless/plugin/sharedobj/checksum_verifier_test.go
+++ b/pkg/secretless/plugin/sharedobj/checksum_verifier_test.go
@@ -3,77 +3,77 @@ package sharedobj
 import (
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestChecksumVerifier(t *testing.T) {
-	Convey("Checksum verifier", t, func() {
-		Convey("Doesn't error if there's no plugins to check", func() {
+	t.Run("Checksum verifier", func(t *testing.T) {
+		t.Run("Doesn't error if there's no plugins to check", func(t *testing.T) {
 		})
 
-		Convey("Doesn't error if checksums match", func() {
+		t.Run("Doesn't error if checksums match", func(t *testing.T) {
 			checksumsFile := "./testdata/checksum/no_error_hashes.txt"
 			pluginDir := "./testdata/checksum/no_error"
 
 			_, err := VerifyPluginChecksums(pluginDir, checksumsFile)
 
-			So(err, ShouldBeNil)
+			assert.NoError(t, err)
 		})
 
-		Convey("Returns file list if checksums match", func() {
+		t.Run("Returns file list if checksums match", func(t *testing.T) {
 			checksumsFile := "./testdata/checksum/no_error_hashes.txt"
 			pluginDir := "./testdata/checksum/no_error"
 
 			pluginFiles, err := VerifyPluginChecksums(pluginDir, checksumsFile)
 
-			So(err, ShouldBeNil)
+			assert.NoError(t, err)
 
-			So(len(pluginFiles), ShouldEqual, 3)
-			So(pluginFiles[0].Name(), ShouldEqual, "bar.txt")
-			So(pluginFiles[1].Name(), ShouldEqual, "baz.txt")
-			So(pluginFiles[2].Name(), ShouldEqual, "foo.txt")
+			assert.Len(t, pluginFiles, 3)
+			assert.Equal(t, pluginFiles[0].Name(), "bar.txt")
+			assert.Equal(t, pluginFiles[1].Name(), "baz.txt")
+			assert.Equal(t, pluginFiles[2].Name(), "foo.txt")
 		})
 
-		Convey("Doesn't error if checksums match and checksums file prepends folder", func() {
+		t.Run("Doesn't error if checksums match and checksums file prepends folder", func(t *testing.T) {
 			checksumsFile := "./testdata/checksum/folder_prepended.txt"
 			pluginDir := "./testdata/checksum/no_error"
 
 			_, err := VerifyPluginChecksums(pluginDir, checksumsFile)
 
-			So(err, ShouldBeNil)
+			assert.NoError(t, err)
 		})
 
-		Convey("Returns error if checksums file doesn't exist", func() {
+		t.Run("Returns error if checksums file doesn't exist", func(t *testing.T) {
 			checksumsFile := "./testdata/checksum/doesntexist.txt"
 			pluginDir := "./testdata/checksum/no_error"
 
 			_, err := VerifyPluginChecksums(pluginDir, checksumsFile)
 
 			errorMsg := "ERROR: open ./testdata/checksum/doesntexist.txt: no such file or directory"
-			So(err.Error(), ShouldEqual, errorMsg)
+			assert.EqualError(t, err, errorMsg)
 		})
 
-		Convey("Returns error if checksums file is misformatted", func() {
+		t.Run("Returns error if checksums file is misformatted", func(t *testing.T) {
 			checksumsFile := "./testdata/checksum/misformatted_hashes.txt"
 			pluginDir := "./testdata/checksum/no_error"
 
 			_, err := VerifyPluginChecksums(pluginDir, checksumsFile)
 
 			errorMsg := "ERROR: checksum file contained a misformatted line: 'fooo bar baz'"
-			So(err.Error(), ShouldEqual, errorMsg)
+			assert.EqualError(t, err, errorMsg)
 		})
 
-		Convey("Returns error if unknown plugin is found in plugin list", func() {
+		t.Run("Returns error if unknown plugin is found in plugin list", func(t *testing.T) {
 			checksumsFile := "./testdata/checksum/unknown_plugin_hashes.txt"
 			pluginDir := "./testdata/checksum/unknown_plugin"
 
 			_, err := VerifyPluginChecksums(pluginDir, checksumsFile)
 
 			errorMsg := "ERROR: plugin 'unknown.txt' not found in checksums file"
-			So(err.Error(), ShouldEqual, errorMsg)
+			assert.EqualError(t, err, errorMsg)
 		})
 
-		Convey("Returns error if plugin checksum doesn't match", func() {
+		t.Run("Returns error if plugin checksum doesn't match", func(t *testing.T) {
 			checksumsFile := "./testdata/checksum/checksum_mismatch_hashes.txt"
 			pluginDir := "./testdata/checksum/checksum_mismatch"
 
@@ -82,7 +82,7 @@ func TestChecksumVerifier(t *testing.T) {
 			errorMsg := "ERROR: plugin 'testdata/checksum/checksum_mismatch/foo.txt' checksum " +
 				"'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c' did not match " +
 				"the expected 'DEADBEEFd4a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c'"
-			So(err.Error(), ShouldEqual, errorMsg)
+			assert.EqualError(t, err, errorMsg)
 		})
 	})
 }

--- a/test/connector/http/conjur/conjur_handler_test.go
+++ b/test/connector/http/conjur/conjur_handler_test.go
@@ -8,15 +8,15 @@ import (
 	"testing"
 
 	"github.com/cyberark/conjur-api-go/conjurapi/response"
+	"github.com/stretchr/testify/assert"
 
 	_ "github.com/joho/godotenv/autoload"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 // TestConjur_Handler verifies that Conjur API requests which are proxied through the Secretless
 // handler do not require authentication credentials.
 func TestConjur_Handler(t *testing.T) {
-	Convey("Can fetch a variable value", t, func() {
+	t.Run("Can fetch a variable value", func(t *testing.T) {
 		variableURL := fmt.Sprintf("%s/secrets/%s/variable/db/password", os.Getenv("CONJUR_APPLIANCE_URL"), os.Getenv("CONJUR_ACCOUNT"))
 
 		req, err := http.NewRequest(
@@ -24,7 +24,7 @@ func TestConjur_Handler(t *testing.T) {
 			variableURL,
 			nil,
 		)
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 
 		transport := &http.Transport{Proxy: func(req *http.Request) (proxyURL *url.URL, err error) {
 			proxyURL, err = http.ProxyFromEnvironment(req)
@@ -37,11 +37,11 @@ func TestConjur_Handler(t *testing.T) {
 		}}
 		client := &http.Client{Transport: transport}
 		resp, err := client.Do(req)
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 
 		value, err := response.DataResponse(resp)
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 
-		So(string(value), ShouldEqual, "secret")
+		assert.Equal(t, "secret", string(value))
 	})
 }

--- a/test/connector/http/conjur/conjur_provider_test.go
+++ b/test/connector/http/conjur/conjur_provider_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	_ "github.com/joho/godotenv/autoload"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
 	"github.com/cyberark/secretless-broker/internal/plugin/v1/testutils"
@@ -23,34 +23,32 @@ func TestConjur_Provider(t *testing.T) {
 		Name: name,
 	}
 
-	Convey("Can create the Conjur provider", t, func() {
+	t.Run("Can create the Conjur provider", func(t *testing.T) {
 		provider, err = providers.ProviderFactories[name](options)
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 	})
 
-	Convey("Has the expected provider name", t, func() {
-		So(provider.GetName(), ShouldEqual, "conjur")
+	t.Run("Has the expected provider name", func(t *testing.T) {
+		assert.Equal(t, "conjur", provider.GetName())
 	})
 
-	Convey("Can provide an access token", t, func() {
+	t.Run("Can provide an access token", func(t *testing.T) {
 		id := "accessToken"
 		values, err := provider.GetValues(id)
 
-		So(err, ShouldBeNil)
-		So(values[id], ShouldNotBeNil)
-		So(values[id].Error, ShouldBeNil)
-		So(values[id].Value, ShouldNotBeNil)
+		assert.NoError(t, err)
+		assert.NotNil(t, values[id])
+		assert.NoError(t, values[id].Error)
+		assert.NotNil(t, values[id].Value)
 
 		token := make(map[string]string)
 		err = json.Unmarshal(values[id].Value, &token)
-		So(err, ShouldBeNil)
-		So(token["protected"], ShouldNotBeNil)
-		So(token["payload"], ShouldNotBeNil)
+		assert.NoError(t, err)
+		assert.NotNil(t, token["protected"])
+		assert.NotNil(t, token["payload"])
 	})
 
-	Convey(
-		"Reports an unknown value",
-		t,
+	t.Run("Reports an unknown value",
 		testutils.Reports(
 			provider,
 			"foobar",
@@ -58,12 +56,9 @@ func TestConjur_Provider(t *testing.T) {
 		),
 	)
 
-	Convey("Provides", t, func() {
+	t.Run("Provides", func(t *testing.T) {
 		for _, testCase := range canProvideTestCases {
-			Convey(
-				testCase.Description,
-				testutils.CanProvide(provider, testCase.ID, testCase.ExpectedValue),
-			)
+			t.Run(testCase.Description, testutils.CanProvide(provider, testCase.ID, testCase.ExpectedValue))
 		}
 	})
 }

--- a/test/connector/tcp/mysql/pkg/run_test_case.go
+++ b/test/connector/tcp/mysql/pkg/run_test_case.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"github.com/cyberark/secretless-broker/test/util/testutil"
-
-	"github.com/smartystreets/goconvey/convey"
 )
 
 // RunQuery constructs a mysql cmdline command (which includes a sample query)
@@ -42,9 +40,9 @@ func RunQuery(
 	args = append(args, "--default-auth=mysql_clear_password")
 
 	// Pre command logs
-	convey.Println("")
-	convey.Println("---<< EXECUTED")
-	convey.Println(strings.Join(append([]string{"mysql"}, args...), " "))
+	println("")
+	println("---<< EXECUTED")
+	println(strings.Join(append([]string{"mysql"}, args...), " "))
 
 	cmdOut, err := exec.Command("mysql", args...).CombinedOutput()
 
@@ -52,15 +50,15 @@ func RunQuery(
 	//TODO: deal with verbose
 	if testutil.Verbose {
 		if err != nil {
-			convey.Println("--->> RESULTS")
-			convey.Println("----- ERROR: ")
-			convey.Println(err.Error())
+			println("--->> RESULTS")
+			println("----- ERROR: ")
+			println(err.Error())
 		}
-		convey.Println("----- OUTPUT: ")
-		convey.Println(string(cmdOut))
+		println("----- OUTPUT: ")
+		println(string(cmdOut))
 	}
-	convey.Println("---<< END")
-	convey.Println("")
+	println("---<< END")
+	println("")
 
 	return string(cmdOut), err
 }

--- a/test/connector/tcp/mysql/tests/essentials_test.go
+++ b/test/connector/tcp/mysql/tests/essentials_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	. "github.com/cyberark/secretless-broker/test/util/testutil"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestEssentials(t *testing.T) {
@@ -36,9 +35,9 @@ func TestEssentials(t *testing.T) {
 		},
 	}
 
-	Convey("Essentials", t, func() {
+	t.Run("Essentials", func(t *testing.T) {
 		for _, socketType := range AllSocketTypes() {
-			Convey(fmt.Sprintf("Connect over %s", socketType), func() {
+			t.Run(fmt.Sprintf("Connect over %s", socketType), func(t *testing.T) {
 
 				for _, testCaseData := range testCases {
 					tc := TestCase{
@@ -50,7 +49,7 @@ func TestEssentials(t *testing.T) {
 						},
 						Definition: testCaseData,
 					}
-					RunTestCase(tc)
+					RunTestCase(tc, t)
 				}
 			})
 		}
@@ -76,7 +75,7 @@ func TestEssentials(t *testing.T) {
 				},
 				CmdOutput: StringPointer("ERROR 2026 (HY000): SSL connection error: SSL is required, but the server does not support"),
 			},
-		})
+		}, t)
 
 		RunTestCase(TestCase{
 			AbstractConfiguration: AbstractConfiguration{
@@ -95,7 +94,7 @@ func TestEssentials(t *testing.T) {
 				},
 				CmdOutput: StringPointer("ERROR 2026 (HY000): SSL connection error: SSL is required, but the server does not support"),
 			},
-		})
+		}, t)
 
 		RunTestCase(TestCase{
 			AbstractConfiguration: AbstractConfiguration{
@@ -114,7 +113,7 @@ func TestEssentials(t *testing.T) {
 				},
 				CmdOutput: StringPointer("ERROR 1045 (28000): Access denied for user 'testuser'@"),
 			},
-		})
+		}, t)
 	})
 
 }

--- a/test/connector/tcp/mysql/tests/ssl_test.go
+++ b/test/connector/tcp/mysql/tests/ssl_test.go
@@ -1,9 +1,9 @@
 package tests
 
 import (
-	. "github.com/cyberark/secretless-broker/test/util/testutil"
-	. "github.com/smartystreets/goconvey/convey"
 	"testing"
+
+	. "github.com/cyberark/secretless-broker/test/util/testutil"
 )
 
 func TestSSL(t *testing.T) {
@@ -216,9 +216,9 @@ func TestSSL(t *testing.T) {
 		},
 	}
 
-	Convey("SSL functionality", t, func() {
+	t.Run("SSL functionality", func(t *testing.T) {
 		for _, testCase := range testCases {
-			RunTestCase(testCase)
+			RunTestCase(testCase, t)
 		}
 	})
 }

--- a/test/connector/tcp/pg/pkg/run_test_case.go
+++ b/test/connector/tcp/pg/pkg/run_test_case.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"github.com/cyberark/secretless-broker/test/util/testutil"
-
-	"github.com/smartystreets/goconvey/convey"
 )
 
 const jdbcJARPath = "/secretless/test/util/jdbc/jdbc.jar"
@@ -46,9 +44,9 @@ func RunQuery(
 	args = append(args, strings.Join(connectionParams, " "))
 
 	// Pre command logs
-	convey.Println("")
-	convey.Println("---<< EXECUTED")
-	convey.Println(strings.Join(append([]string{"psql"}, args...), " "))
+	println("")
+	println("---<< EXECUTED")
+	println(strings.Join(append([]string{"psql"}, args...), " "))
 
 	cmdOut, err := exec.Command("psql", args...).CombinedOutput()
 
@@ -56,15 +54,15 @@ func RunQuery(
 	//TODO: deal with verbose
 	if testutil.Verbose {
 		if err != nil {
-			convey.Println("--->> RESULTS")
-			convey.Println("----- ERROR: ")
-			convey.Println(err.Error())
+			println("--->> RESULTS")
+			println("----- ERROR: ")
+			println(err.Error())
 		}
-		convey.Println("----- OUTPUT: ")
-		convey.Println(string(cmdOut))
+		println("----- OUTPUT: ")
+		println(string(cmdOut))
 	}
-	convey.Println("---<< END")
-	convey.Println("")
+	println("---<< END")
+	println("")
 
 	return string(cmdOut), err
 }
@@ -86,26 +84,26 @@ func RunJDBCQuery(
 	}
 
 	// Pre command logs
-	convey.Println("")
-	convey.Println("---->> ARGS")
+	println("")
+	println("---->> ARGS")
 	fmt.Println(args)
 
-	convey.Println("---<< EXECUTED")
+	println("---<< EXECUTED")
 	cmdOut, err := exec.Command("java", args...).CombinedOutput()
 
 	// Post command logs
 	//TODO: deal with verbose
 	if testutil.Verbose {
 		if err != nil {
-			convey.Println("--->> RESULTS")
-			convey.Println("----- ERROR: ")
-			convey.Println(err.Error())
+			println("--->> RESULTS")
+			println("----- ERROR: ")
+			println(err.Error())
 		}
-		convey.Println("----- OUTPUT: ")
-		convey.Println(string(cmdOut))
+		println("----- OUTPUT: ")
+		println(string(cmdOut))
 	}
-	convey.Println("---<< END")
-	convey.Println("")
+	println("---<< END")
+	println("")
 
 	return string(cmdOut), err
 }

--- a/test/connector/tcp/pg/tests/essentials_test.go
+++ b/test/connector/tcp/pg/tests/essentials_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
-
 	"github.com/cyberark/secretless-broker/test/connector/tcp/pg/pkg"
 	. "github.com/cyberark/secretless-broker/test/util/testutil"
 )
@@ -41,9 +39,9 @@ func TestEssentials(t *testing.T) {
 		},
 	}
 
-	Convey("Essentials", t, func() {
+	t.Run("Essentials", func(t *testing.T) {
 		for _, listenerTypeValue := range AllSocketTypes() {
-			Convey(fmt.Sprintf("Connect over %s", listenerTypeValue), func() {
+			t.Run(fmt.Sprintf("Connect over %s", listenerTypeValue), func(t *testing.T) {
 
 				for _, testCaseData := range testCases {
 					tc := TestCase{
@@ -55,7 +53,7 @@ func TestEssentials(t *testing.T) {
 						},
 						Definition: testCaseData,
 					}
-					RunTestCase(tc)
+					RunTestCase(tc, t)
 				}
 			})
 		}
@@ -76,7 +74,7 @@ func TestEssentials(t *testing.T) {
 					SSL:      true,
 				},
 			},
-		})
+		}, t)
 
 		RunTestCase(TestCase{
 			AbstractConfiguration: AbstractConfiguration{
@@ -95,13 +93,13 @@ func TestEssentials(t *testing.T) {
 				},
 				CmdOutput: StringPointer("server does not support SSL, but SSL was required"),
 			},
-		})
+		}, t)
 	})
 
-	Convey("JDBC", t, func() {
+	t.Run("JDBC", func(t *testing.T) {
 		RunJDBCTestCase := NewRunTestCase(pkg.RunJDBCQuery)
 
-		Convey(fmt.Sprintf("Connect over %s", TCP), func() {
+		t.Run(fmt.Sprintf("Connect over %s", TCP), func(t *testing.T) {
 
 			for _, testCaseData := range testCases {
 				tc := TestCase{
@@ -113,7 +111,7 @@ func TestEssentials(t *testing.T) {
 					},
 					Definition: testCaseData,
 				}
-				RunJDBCTestCase(tc)
+				RunJDBCTestCase(tc, t)
 			}
 		})
 	})

--- a/test/connector/tcp/pg/tests/ssl_test.go
+++ b/test/connector/tcp/pg/tests/ssl_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	. "github.com/cyberark/secretless-broker/test/util/testutil"
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestSSL(t *testing.T) {
@@ -220,9 +219,9 @@ func TestSSL(t *testing.T) {
 		},
 	}
 
-	Convey("SSL functionality", t, func() {
+	t.Run("SSL functionality", func(t *testing.T) {
 		for _, testCase := range testCases {
-			RunTestCase(testCase)
+			RunTestCase(testCase, t)
 		}
 	})
 }

--- a/test/connector/tcp/pg/tests/sslmode_test.go
+++ b/test/connector/tcp/pg/tests/sslmode_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	. "github.com/cyberark/secretless-broker/test/util/testutil"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCustom(t *testing.T) {
@@ -29,14 +29,14 @@ func TestCustom(t *testing.T) {
 		"--host", connectPort.Host(),
 	}
 
-	Convey("sslmode=require", t, func() {
+	t.Run("sslmode=require", func(t *testing.T) {
 		cmdOut, _ := exec.Command("psql", append(args, strings.Join(append(connectionParams, "sslmode=require"), " "))...).CombinedOutput()
-		So(string(cmdOut), ShouldContainSubstring, "psql: server does not support SSL, but SSL was required")
+		assert.Contains(t, string(cmdOut), "psql: server does not support SSL, but SSL was required")
 	})
 
-	Convey("sslmode=prefer", t, func() {
+	t.Run("sslmode=prefer", func(t *testing.T) {
 		cmdOut, _ := exec.Command("psql", append(args, strings.Join(append(connectionParams, "sslmode=prefer"), " "))...).CombinedOutput()
-		So(string(cmdOut), ShouldContainSubstring, "count")
+		assert.Contains(t, string(cmdOut), "count")
 	})
 
 }

--- a/test/providers/awssecrets/aws_secrets_provider_test.go
+++ b/test/providers/awssecrets/aws_secrets_provider_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/joho/godotenv/autoload"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
 	"github.com/cyberark/secretless-broker/internal/providers"
@@ -20,12 +20,12 @@ func TestAWSSecrets_Provider(t *testing.T) {
 		Name: name,
 	}
 
-	Convey("Can create the AWS Secrets provider", t, func() {
+	t.Run("Can create the AWS Secrets provider", func(t *testing.T) {
 		provider, err = providers.ProviderFactories[name](options)
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 	})
 
-	Convey("Has the expected provider name", t, func() {
-		So(provider.GetName(), ShouldEqual, "aws")
+	t.Run("Has the expected provider name", func(t *testing.T) {
+		assert.Equal(t, "aws", provider.GetName())
 	})
 }

--- a/test/providers/keychain/keychain_provider_test.go
+++ b/test/providers/keychain/keychain_provider_test.go
@@ -6,8 +6,7 @@ import (
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
 	"github.com/cyberark/secretless-broker/internal/plugin/v1/testutils"
 	"github.com/cyberark/secretless-broker/internal/providers"
-
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestKeychainProvider(t *testing.T) {
@@ -37,13 +36,12 @@ func TestKeychainProvider(t *testing.T) {
 		t.FailNow()
 	}
 
-	Convey("Has the expected provider name", t, func() {
-		So(provider.GetName(), ShouldEqual, providerName)
+	t.Run("Has the expected provider name", func(t *testing.T) {
+		assert.Equal(t, providerName, provider.GetName())
 	})
 
-	Convey(
+	t.Run(
 		"Can provide a valid secret value",
-		t,
 		testutils.CanProvide(
 			provider,
 			getSecretPath(1),
@@ -51,9 +49,8 @@ func TestKeychainProvider(t *testing.T) {
 		),
 	)
 
-	Convey(
+	t.Run(
 		"Multiple Provides ",
-		t,
 		testutils.CanProvideMultiple(
 			provider,
 			map[string]string{
@@ -64,9 +61,8 @@ func TestKeychainProvider(t *testing.T) {
 		),
 	)
 
-	Convey(
+	t.Run(
 		"Returns an error for an invalid secret value",
-		t,
 		testutils.Reports(
 			provider,
 			"madeup#secret",

--- a/test/providers/kubernetessecrets/kubernetes_provider_test.go
+++ b/test/providers/kubernetessecrets/kubernetes_provider_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	testclient "k8s.io/client-go/kubernetes/fake"
@@ -14,6 +13,7 @@ import (
 	"github.com/cyberark/secretless-broker/internal/plugin/v1/testutils"
 	"github.com/cyberark/secretless-broker/internal/providers"
 	"github.com/cyberark/secretless-broker/internal/providers/kubernetessecrets"
+	"github.com/stretchr/testify/assert"
 )
 
 var mockSecrets = map[string]map[string][]byte{
@@ -59,42 +59,41 @@ func TestKubernetes_Provider(t *testing.T) {
 		Name: expectedName,
 	}
 
-	Convey("Can create the Kubernetes provider", t, func() {
+	t.Run("Can create the Kubernetes provider", func(t *testing.T) {
 		provider, err = providers.ProviderFactories[expectedName](options)
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 
 		var ok bool
 		kubernetesProvider, ok = provider.(*kubernetessecrets.Provider)
-		So(ok, ShouldBeTrue)
+		assert.True(t, ok)
 
 		kubernetesProvider.SecretsClient = testSecretsClient
 	})
 
-	Convey("Has the expected provider name", t, func() {
-		So(provider.GetName(), ShouldEqual, expectedName)
+	t.Run("Has the expected provider name", func(t *testing.T) {
+		assert.Equal(t, expectedName, provider.GetName())
 	})
 
-	Convey("Can provide a secret", t, func() {
+	t.Run("Can provide a secret", func(t *testing.T) {
 		id := "database#password"
 		values, err := provider.GetValues(id)
-		So(err, ShouldBeNil)
-		So(values, ShouldContainKey, id)
-		So(values[id].Error, ShouldBeNil)
-		So(string(values[id].Value), ShouldEqual, "secret-value")
+		assert.NoError(t, err)
+		assert.Contains(t, values, id)
+		assert.NoError(t, values[id].Error)
+		assert.Equal(t, "secret-value", string(values[id].Value))
 	})
 
-	Convey("Reports", t, func() {
+	t.Run("Reports", func(t *testing.T) {
 		for _, testCase := range reportsTestCases {
-			Convey(
+			t.Run(
 				testCase.Description,
 				testutils.Reports(provider, testCase.ID, testCase.ExpectedErrString),
 			)
 		}
 	})
 
-	Convey(
+	t.Run(
 		"Multiple Provides ",
-		t,
 		testutils.CanProvideMultiple(
 			provider,
 			map[string]string{

--- a/test/providers/vault/vault_provider_test.go
+++ b/test/providers/vault/vault_provider_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/joho/godotenv/autoload"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	plugin_v1 "github.com/cyberark/secretless-broker/internal/plugin/v1"
 	"github.com/cyberark/secretless-broker/internal/plugin/v1/testutils"
@@ -20,36 +20,35 @@ func TestVault_Provider(t *testing.T) {
 		Name: name,
 	}
 
-	Convey("Can create the Vault provider", t, func() {
+	t.Run("Can create the Vault provider", func(t *testing.T) {
 		provider, err = providers.ProviderFactories[name](options)
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 	})
 
-	Convey("Has the expected provider name", t, func() {
-		So(provider.GetName(), ShouldEqual, "vault")
+	t.Run("Has the expected provider name", func(t *testing.T) {
+		assert.Equal(t, "vault", provider.GetName())
 	})
 
-	Convey("Reports", t, func() {
+	t.Run("Reports", func(t *testing.T) {
 		for _, testCase := range reportsTestCases {
-			Convey(
+			t.Run(
 				testCase.Description,
 				testutils.Reports(provider, testCase.ID, testCase.ExpectedErrString),
 			)
 		}
 	})
 
-	Convey("Provides", t, func() {
+	t.Run("Provides", func(t *testing.T) {
 		for _, testCase := range canProvideTestCases {
-			Convey(
+			t.Run(
 				testCase.Description,
 				testutils.CanProvide(provider, testCase.ID, testCase.ExpectedValue),
 			)
 		}
 	})
 
-	Convey(
+	t.Run(
 		"Multiple Provides ",
-		t,
 		testutils.CanProvideMultiple(
 			provider,
 			map[string]string{

--- a/test/providers/vault/vault_summon_test.go
+++ b/test/providers/vault/vault_summon_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	_ "github.com/joho/godotenv/autoload"
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/cyberark/secretless-broker/internal/summon/command"
 )
@@ -35,14 +35,14 @@ SVC_API_KEY: !var secret/data/service#data.api-key
 		return
 	}
 
-	Convey("Can summon secrets from Vault", t, func() {
+	t.Run("Can summon secrets from Vault", func(t *testing.T) {
 		lines, err := runCommand(defaultArgs)
 
-		So(err, ShouldBeNil)
-		So(lines, ShouldContain, "FIRST_SECRET=one")
-		So(lines, ShouldContain, "SECOND_SECRET=two")
-		So(lines, ShouldContain, "DB_PASSWORD=db-secret")
-		So(lines, ShouldContain, "WEB_PASSWORD=web-secret")
-		So(lines, ShouldContain, "SVC_API_KEY=service-api-key")
+		assert.NoError(t, err)
+		assert.Contains(t, lines, "FIRST_SECRET=one")
+		assert.Contains(t, lines, "SECOND_SECRET=two")
+		assert.Contains(t, lines, "DB_PASSWORD=db-secret")
+		assert.Contains(t, lines, "WEB_PASSWORD=web-secret")
+		assert.Contains(t, lines, "SVC_API_KEY=service-api-key")
 	})
 }

--- a/test/summon2/summon2_cmd_test.go
+++ b/test/summon2/summon2_cmd_test.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
-
 	"github.com/cyberark/secretless-broker/internal/summon/command"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestSummon2_Run tests Summon at the CLI level, including argument parsing etc.
@@ -32,23 +31,23 @@ DB_PASSWORD: literal-password
 		return
 	}
 
-	Convey("Provides secrets to a subprocess environment", t, func() {
+	t.Run("Provides secrets to a subprocess environment", func(t *testing.T) {
 		args := []string{"summon2", "-p", "literal", "--yaml", secretsDescriptor, "env"}
 
 		lines, err := runCommand(args)
 
-		So(err, ShouldBeNil)
-		So(lines, ShouldContain, "DB_PASSWORD=literal-password")
+		assert.NoError(t, err)
+		assert.Contains(t, lines, "DB_PASSWORD=literal-password")
 	})
 
-	Convey("Provider can be specified as an environment variable", t, func() {
+	t.Run("Provider can be specified as an environment variable", func(t *testing.T) {
 		err := os.Setenv("SUMMON_PROVIDER", "literal")
-		So(err, ShouldBeNil)
+		assert.NoError(t, err)
 		defer os.Unsetenv("SUMMON_PROVIDER")
 
 		lines, err := runCommand(defaultArgs)
 
-		So(err, ShouldBeNil)
-		So(lines, ShouldContain, "DB_PASSWORD=literal-password")
+		assert.NoError(t, err)
+		assert.Contains(t, lines, "DB_PASSWORD=literal-password")
 	})
 }


### PR DESCRIPTION
### Desired Outcome

Rewrite test that used GoConvey to use a lightweight assertions library and native golang testing

### Implemented Changes

Removed GoConvey from:
- internal/plugin/resolver_test.go
- internal/plugin/v1/testutils/testutils.go
- internal/plugin/v1/provider_test.go
- internal/util/health_test.go
- internal/summon/command/temp_factory_test.go
- pkg/secretless/config/config_test.go
- pkg/secretless/plugin/sharedobj/checksum_verifier_test.go
- test/connector/tcp/mysql/pkg/run_test_case.go
- test/connector/tcp/pg/pkg/run_test_case.go
- test/summon2/summon2_run_test.go
- test/summon2/summon2_cmd_test.go
- test/connector/http/conjur/conjur_handler_test.go
- test/connector/http/conjur/conjur_provider_test.go
- test/connector/tcp/mysql/tests/essentials_test.go
- test/connector/tcp/mysql/tests/ssl_test.go
- test/connector/tcp/pg/tests/sslmode_test.go
- test/connector/tcp/pg/tests/ssl_test.go
- test/connector/tcp/pg/tests/essentials_test.go
- test/providers/awssecrets/aws_secrets_provider_test.go
- test/providers/keychain/keychain_provider_test.go
- test/providers/kubernetessecrets/kubernetes_provider_test.go
- test/providers/vault/vault_provider_test.go
- test/providers/vault/vault_summon_test.go

### Connected Issue/Story

N/A

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
