### PR TITLE
Fix incorrect Red Hat cert project ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
-## [1.7.14] - 2022-07-07
-
 ## [1.7.13] - 2022-07-07
 
 ### Changed

--- a/bin/publish
+++ b/bin/publish
@@ -64,7 +64,7 @@ FULL_VERSION_TAG="$(full_version_tag)"
 readonly VERSION
 readonly FULL_VERSION_TAG
 readonly REDHAT_IMAGE="scan.connect.redhat.com/ospid-18d9f51d-9c0c-4031-9f9e-ef08aa2ff409/secretless-broker"
-readonly REDHAT_CERT_PID="5e621f6502235d3f505f6093"
+readonly REDHAT_CERT_PID="5e61546e2c5f183d03415962"
 readonly REDHAT_LOCAL_IMAGE="secretless-broker-redhat"
 readonly IMAGES=(
   "secretless-broker"


### PR DESCRIPTION
Red Hat's preflight scan is now working thanks to #1470, but it's saving it to the wrong project. This fixes the project ID.
Additionally, this PR removes the empty `1.7.14` section of the CHANGELOG added in #1471 because that's meant to be added only after a release has been promoted.