### PR TITLE
Update website Dockerfiles for CVE-2022-0778

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.7.15] - 2022-09-22
+
+### Security
+- Upgrade website Dockerfiles to Ruby 3 to resolve CVE-2022-0778.
+  [cyberark/secretless-broker#1475](https://github.com/cyberark/secretless-broker/pull/1475)]
+
 ## [1.7.14] - 2022-08-17
 
 ### Security

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,7 +214,7 @@ The source includes:
 #### Prerequisites
 
 To get the site up and running locally on your computer, ensure you have:
-1. Ruby version 2.1.0 or higher (check by running `ruby -v`)
+1. Ruby version 3.0.0 or higher (check by running `ruby -v`)
 2. Bundler (`gem install bundler`)
 3. Jekyll (`gem install jekyll`)
 4. Once Bundler and Jekyll gems are installed, run `bundle install`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,24 +214,28 @@ The source includes:
 #### Prerequisites
 
 To get the site up and running locally on your computer, ensure you have:
+
 1. Ruby version 3.0.0 or higher (check by running `ruby -v`)
-2. Bundler (`gem install bundler`)
-3. Jekyll (`gem install jekyll`)
-4. Once Bundler and Jekyll gems are installed, run `bundle install`
+1. Bundler (`gem install bundler`)
+1. Jekyll (`gem install jekyll`)
+1. Once Bundler and Jekyll gems are installed, run `bundle install`
 
 #### Run Locally
 To construct:
+
 1. `git clone https://github.com/cyberark/secretless-broker`
-2. `cd docs`
-3. Run the following command:
-`bundle exec jekyll serve`
-4. Preview Jekyll site locally in web browser by either running `open localhost:4000` or manually navigating to http://localhost:4000
+1. `cd docs`
+1. Run the following command:
+   `bundle exec jekyll serve`
+1. Preview Jekyll site locally in web browser by either running
+   `open localhost:4000` or manually navigating to http://localhost:4000
 
 #### Run in Docker
 With `docker` and `docker-compose`:
 
 1. Run `docker-compose up -d` in the `docs` directory.
-2. Preview Jekyll site locally in web browser by either running `open localhost:4000` or manually navigating to http://localhost:4000
+1. Preview Jekyll site locally in web browser by either running
+   `open localhost:4000` or manually navigating to http://localhost:4000
 
 ### Documentation Website
 The [documentation website](https://docs.secretless.io) source is in the [secretless-docs repo](https://github.com/cyberark/secretless-docs); instructions for contributing are available there.

--- a/bin/Dockerfile.website
+++ b/bin/Dockerfile.website
@@ -1,6 +1,7 @@
-FROM ruby:2.5-alpine
+FROM ruby:3.0-slim-buster
 
-RUN apk add --update alpine-sdk && \
+RUN apt-get -y update && \
+    apt-get -y install build-essential && \
     mkdir -p /tmp/gems
 
 WORKDIR /tmp/gems

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.0
+FROM ruby:3.0
 RUN gem update --system
 RUN gem install bundler jekyll
 RUN mkdir /src

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -35,3 +35,5 @@ gem "rouge", "~> 3.23"
 gem 'jekyll-redirect-from'
 
 gem "kramdown", ">= 2.3.0"
+
+gem "webrick", "~> 1.7"

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
@@ -8,32 +8,32 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.1.1"
+gem 'jekyll', '~> 4.1.1'
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like.
-gem "minima", "~> 2.5"
+gem 'minima', '~> 2.5'
 
-# If you want to use GitHub Pages, remove the "gem "jekyll"" above and
+# If you want to use GitHub Pages, remove the 'gem 'jekyll'' above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.
-# gem "github-pages", group: :jekyll_plugins
+# gem 'github-pages', group: :jekyll_plugins
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem "jekyll-feed", "~> 0.15"
+  gem 'jekyll-feed', '~> 0.15'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Performance-booster for watching directories on Windows
-gem "wdm", "~> 0.1.1" if Gem.win_platform?
+gem 'wdm', '~> 0.1.1' if Gem.win_platform?
 
 # Rouge handles syntax highlighting for Markdown code blocks.
-gem "rouge", "~> 3.23"
+gem 'rouge', '~> 3.23'
 
 # Link redirection
 gem 'jekyll-redirect-from'
 
-gem "kramdown", ">= 2.3.0"
+gem 'kramdown', '>= 2.3.0'
 
-gem "webrick", "~> 1.7"
+gem 'webrick', '~> 1.7'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -44,7 +44,7 @@ GEM
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
-    listen (3.2.1)
+    listen (3.3.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
@@ -66,6 +66,7 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     unicode-display_width (1.7.0)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -78,6 +79,7 @@ DEPENDENCIES
   minima (~> 2.5)
   rouge (~> 3.23)
   tzinfo-data
+  webrick (~> 1.7)
 
 BUNDLED WITH
-   1.17.3
+   2.2.33

--- a/test/connector/tcp/mysql/tests/essentials_test.go
+++ b/test/connector/tcp/mysql/tests/essentials_test.go
@@ -73,7 +73,7 @@ func TestEssentials(t *testing.T) {
 					Password: "wrongpassword",
 					SSL:      true,
 				},
-				CmdOutput: StringPointer("ERROR 2026 (HY000): SSL connection error: SSL is required, but the server does not support"),
+				CmdOutput: StringPointer("ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it"),
 			},
 		}, t)
 
@@ -92,7 +92,7 @@ func TestEssentials(t *testing.T) {
 					Password: "wrongpassword",
 					SSL:      true,
 				},
-				CmdOutput: StringPointer("ERROR 2026 (HY000): SSL connection error: SSL is required, but the server does not support"),
+				CmdOutput: StringPointer("ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it"),
 			},
 		}, t)
 


### PR DESCRIPTION
### Desired Outcome

Upgrade website Docker images to address CVE-2022-0778.

### Implemented Changes

Upgrade website Docker images to their Ruby 3.0 counterparts.

### Connected Issue/Story

CyberArk internal issue link: [CONJSE-1317](https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJSE-1317)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [x] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [ ] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
