### PR TITLE
Report combined coverage results to CodeClimate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,6 @@ pipeline {
             sh 'cp ./test/unit-test-output/c.out ./c.out'
 
             junit 'test/unit-test-output/junit.xml'
-            ccCoverage("gocov", "--prefix github.com/cyberark/secretless-broker")
           }
         }
       }
@@ -210,6 +209,8 @@ pipeline {
     stage('Cobertura') {
       steps {
         cobertura autoUpdateHealth: false, autoUpdateStability: false, coberturaReportFile: 'test/test-coverage/coverage.xml', conditionalCoverageTargets: '70, 0, 70', failUnhealthy: true, failUnstable: true, lineCoverageTargets: '70, 70, 70', maxNumberOfBuilds: 0, methodCoverageTargets: '70, 0, 70', onlyStable: false, sourceEncoding: 'ASCII', zoomCoverageChart: false
+        sh 'cp test/test-coverage/integ-and-ut-cover.out ./c.out'
+        ccCoverage("gocov", "--prefix github.com/cyberark/secretless-broker")
       }
     }
 


### PR DESCRIPTION
### Desired Outcome

After adding code coverage for integration tests and cleanup of false coverage when no tests - code coverage was around 65% with changes from @diverdane and @szh as reflected in Cobertura, but Code Climate still shows about 40%. We are not reporting the merged coverage data to Code Climate.

### Implemented Changes

Report combined coverage of unit and integration tests to Code Climate, as we do for Cobertura. To do this, we wait to upload results to Code Climate until after we run the integration tests and combine the coverage data.

### Connected Issue/Story

CyberArk internal issue link: [ONYX-17825](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-17825)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes 
