### PR TITLE
Bump version in changelog so that its higher then the previous promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.7.16] - 2022-12-02
+
 ## [1.7.15] - 2022-09-22
 
 ### Security


### PR DESCRIPTION
### Desired Outcome

The latest version in the changelog has to be higher then the latest promotion in jenkins or it will cause the Release builds to fail. This is currently causing the  OCP_NEXT pipeline to fail when testing secretless-broker
### Implemented Changes
Added new version in the changelog file. 