### PR TITLE
Fix false positive unit test stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
+## [1.7.16] - 2022-12-27
+
 ## [1.7.15] - 2022-09-22
 
 ### Security

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,9 +102,14 @@ pipeline {
         stage('Unit tests') {
           steps {
             sh './bin/test_unit'
-            sh 'cp ./test/unit-test-output/c.out ./c.out'
+          }
+          post {
+            always {
+              sh './bin/coverage'
+              sh 'cp ./test/unit-test-output/c.out ./c.out'
 
-            junit 'test/unit-test-output/junit.xml'
+              junit 'test/unit-test-output/junit.xml'
+            }
           }
         }
       }

--- a/bin/coverage
+++ b/bin/coverage
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eo pipefail
+
+current_dir=$("$(dirname "$0")"/abspath)
+toplevel_dir=$current_dir/..
+junit_output_dir=test/unit-test-output
+
+function main() {
+  format_output
+}
+
+function format_output() {
+  # Format output
+  docker run --rm \
+    --volume "$toplevel_dir"/:/secretless \
+    --workdir "/secretless/$junit_output_dir" \
+    secretless-unit-test-runner:latest \
+      sh -exc "
+        rm -f junit.xml
+  
+        # Format test output XML
+        cat junit.output | go-junit-report > junit.xml
+  
+        # Format coverage output XML
+        gocov convert c.out | gocov-xml > coverage.xml"
+}
+
+main

--- a/bin/test_unit
+++ b/bin/test_unit
@@ -12,7 +12,6 @@ function main() {
   retrieve_cyberark_ca_cert
   build_ut_docker_image
   run_unit_tests
-  format_output
 }
 
 function build_ut_docker_image() {
@@ -24,7 +23,6 @@ function build_ut_docker_image() {
 
 function run_unit_tests() {
   echo "Running unit tests..."
-  set +e
     mkdir -p "$junit_output_dir"
     rm -f "$junit_output_dir/*"
 
@@ -46,23 +44,6 @@ function run_unit_tests() {
         ./pkg/... \
       | tee -a "./$junit_output_dir/junit.output"
     echo "Unit test exit status: $?"
-  set -e
-}
-
-function format_output() {
-  # Format output
-  docker run --rm \
-    --volume "$toplevel_dir"/:/secretless \
-    --workdir "/secretless/$junit_output_dir" \
-    secretless-unit-test-runner:latest \
-      sh -exc "
-        rm -f junit.xml
-  
-        # Format test output XML
-        cat junit.output | go-junit-report > junit.xml
-  
-        # Format coverage output XML
-        gocov convert c.out | gocov-xml > coverage.xml"
 }
 
 main


### PR DESCRIPTION
### Desired Outcome

Several of our CI pipelines follow [this pattern](https://github.com/cyberark/secrets-provider-for-k8s/blob/main/bin/test_unit#L31) where the script that runs unit tests sets +e to prevent unit test failure from stopping the script from running. I believe this was done to ensure that the junit tests would run even if the tests failed, but it's having the unfortunate side effect of showing the unit testing phase as green in Jenkins when a unit test fails, making it a bit unclear what's going on.

### Implemented Changes

Break the junit logic into a separate script that can be run independently from the unit tests in a "post-always" block in the Jenkinsfile and return the error code when unit test(s) fail.

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
