### PR TITLE
Publish RedHat images to new quay.io address

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -63,9 +63,11 @@ VERSION=$(<VERSION)
 FULL_VERSION_TAG="$(full_version_tag)"
 readonly VERSION
 readonly FULL_VERSION_TAG
-readonly REDHAT_IMAGE="scan.connect.redhat.com/ospid-18d9f51d-9c0c-4031-9f9e-ef08aa2ff409/secretless-broker"
+readonly REDHAT_REGISTRY="quay.io"
 readonly REDHAT_CERT_PID="5e61546e2c5f183d03415962"
 readonly REDHAT_LOCAL_IMAGE="secretless-broker-redhat"
+readonly REDHAT_IMAGE="${REDHAT_REGISTRY}/redhat-isv-containers/${REDHAT_CERT_PID}"
+readonly REDHAT_USER="redhat-isv-containers+${REDHAT_CERT_PID}-robot"
 readonly IMAGES=(
   "secretless-broker"
   "secretless-broker-quickstart"
@@ -128,7 +130,7 @@ if [[ ${PROMOTE} = true ]]; then
   docker tag "${LOCAL_REGISTRY}/${REDHAT_LOCAL_IMAGE}:${SOURCE_TAG}" "${REDHAT_IMAGE}:${REMOTE_TAG}"
 
   # Publish RedHat image to RedHat Registry
-  if docker login scan.connect.redhat.com -u unused -p "${REDHAT_API_KEY}"; then
+  if docker login "${REDHAT_REGISTRY}" -u "${REDHAT_USER}" -p "${REDHAT_API_KEY}"; then
     # you can't push the same tag twice to redhat registry, so ignore errors
     if ! docker push "${REDHAT_IMAGE}:${REMOTE_TAG}"; then
       echo 'RedHat push FAILED! (maybe the image was pushed already?)'
@@ -138,7 +140,7 @@ if [[ ${PROMOTE} = true ]]; then
     # scan image with preflight tool
     scan_redhat_image "${REDHAT_IMAGE}:${REMOTE_TAG}" "${REDHAT_CERT_PID}"
   else
-    echo 'Failed to log in to scan.connect.redhat.com'
+    echo "Failed to log in to ${REDHAT_REGISTRY}"
     exit 1
   fi
 


### PR DESCRIPTION
### Desired Outcome

Fix Redhat image pushing by updating the scanning registry on PROMOTE to quay.io (formerly scan.connect.redhat.com)

### Implemented Changes

Updates to `bin/publish` script

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
