### PR TITLE
Fix failing mssql integration tests

### DIFF
--- a/test/connector/tcp/mssql/Dockerfile
+++ b/test/connector/tcp/mssql/Dockerfile
@@ -13,7 +13,7 @@ RUN curl --fail \
 	https://packages.microsoft.com/config/debian/10/prod.list | tee /etc/apt/sources.list.d/mssql-release.list
 
 # Install SQL Server drivers and tools
-RUN apt-get update && ACCEPT_EULA=Y apt-get install -y libodbc1 unixodbc msodbcsql17 mssql-tools unixodbc-dev
+RUN apt-get update && ACCEPT_EULA=Y apt-get install -y libodbc1 unixodbc-dev=2.3.7 unixodbc=2.3.7 odbcinst1debian2=2.3.7 odbcinst=2.3.7 msodbcsql17 mssql-tools
 ENV PATH $PATH:/opt/mssql-tools/bin
 
 # Install and set locale to en_US.UTF-8


### PR DESCRIPTION
### Desired Outcome

Fix failing builds due to errors when installing pyodbc in mssql integration tests

### Implemented Changes
Pin unixodbc dependencies to 2.3.7 until this is fixed in 2.3.11 (see: https://github.com/microsoft/linux-package-repositories/issues/36)

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
