### PR TITLE
Fix goreleaser deprecations and release v1.7.17

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,8 +46,8 @@ builds:
   id: summon2-darwin-arm64
   env:
   - CGO_ENABLED=1
-  - CC=o64-clang
-  - CXX=o64-clang++
+  - CC=oa64-clang
+  - CXX=oa64-clang++
   goos:
   - darwin
   goarch:
@@ -114,8 +114,8 @@ builds:
   id: secretless-broker-arm
   env:
   - CGO_ENABLED=1
-  - CC=o64-clang
-  - CXX=o64-clang++
+  - CC=oa64-clang
+  - CXX=oa64-clang++
   flags:
   - -tags=netgo
   goos:
@@ -164,8 +164,9 @@ brews:
 nfpms:
   - bindir: /usr/bin
     description: Secures your apps by making them Secretless
-    empty_folders:
-    - /usr/local/lib/secretless
+    contents:
+    - dst: /usr/local/lib/secretless
+      type: dir
     formats:
     - deb
     - rpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nothing should go in this section, please add to the latest unreleased version
   (and update the corresponding date), or add a new version.
 
-## [1.7.17] - 2023-03-27
+## [1.7.17] - 2023-04-17
 
 ### Changed
 - Updated Go version to 1.19
@@ -689,7 +689,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - The first tagged version.
 
-[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.7.16...HEAD
+[Unreleased]: https://github.com/cyberark/secretless-broker/compare/v1.7.17...HEAD
 [0.2.0]: https://github.com/cyberark/secretless-broker/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/cyberark/secretless-broker/compare/v0.2.0...v0.3.0
 [0.4.0]: https://github.com/cyberark/secretless-broker/compare/v0.3.0...v0.4.0
@@ -731,3 +731,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 [1.7.13]: https://github.com/cyberark/secretless-broker/compare/v1.7.12...v1.7.13
 [1.7.14]: https://github.com/cyberark/secretless-broker/compare/v1.7.13...v1.7.14
 [1.7.16]: https://github.com/cyberark/secretless-broker/compare/v1.7.14...v1.7.16
+[1.7.17]: https://github.com/cyberark/secretless-broker/compare/v1.7.16...v1.7.17

--- a/bin/build_release
+++ b/bin/build_release
@@ -23,21 +23,24 @@ VERSION="${VERSION/-*/}"
 # https://goreleaser.com/cookbooks/cgo-and-crosscompiling/
 GORELEASER_IMAGE="goreleaser/goreleaser-cross"
 
-# Get the latest tags
-GORELEASER_TAGS_JSON="$(curl --silent --show-error https://registry.hub.docker.com/v2/repositories/${GORELEASER_IMAGE}/tags?page_size=100)"
+# Currently there is an issue with the latest tag (v1.19.5) which
+# is breaking release builds of the Darwin ARM64 binary. For now,
+# pin to the previous tag (v1.19.4) until the issue is resolved.
+GORELEASER_LATEST_TAG="v1.19.4"
 
-# Get the latest tag matching the GO_VERSION
-GORELEASER_LATEST_TAG="$(echo "${GORELEASER_TAGS_JSON}" | \
-  jq \
-    --raw-output \
-    --arg GO_VERSION "${GO_VERSION}" \
-    '
-      .results |
-      map(select(.name | contains($GO_VERSION) and (contains("-") | not))) |
-      first |
-      .name
-    '
-)"
+# # Get the latest tag matching the GO_VERSION
+# GORELEASER_TAGS_JSON="$(curl --silent --show-error https://registry.hub.docker.com/v2/repositories/${GORELEASER_IMAGE}/tags?page_size=100)"
+# GORELEASER_LATEST_TAG="$(echo "${GORELEASER_TAGS_JSON}" | \
+#   jq \
+#     --raw-output \
+#     --arg GO_VERSION "${GO_VERSION}" \
+#     '
+#       .results |
+#       map(select(.name | contains($GO_VERSION) and (contains("-") | not))) |
+#       first |
+#       .name
+#     '
+# )"
 
 if [[ -z "${GORELEASER_LATEST_TAG}" ]]; then
   echo "Could not find tag for Docker image \"${GORELEASER_IMAGE}\" matching GO_VERSION=${GO_VERSION}"

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/cyberark/conjur-api-go v0.11.0 h1:LIkdS0zSi2o9AlOwqrIAowxg26kyPFG+XOZ
 github.com/cyberark/conjur-api-go v0.11.0/go.mod h1:AbU7bDVW6ygUdgTDCKkh4wyfIVrOtdEeE/r01OE1EYo=
 github.com/cyberark/conjur-authn-k8s-client v0.24.0 h1:M8Xd6+ztymxQiXUMfVdvpfsTQXJE059CfKVFMDyP1qo=
 github.com/cyberark/conjur-authn-k8s-client v0.24.0/go.mod h1:+Yeek99Ijq2IB3WYHx+Wp9aUfyMm42WjZshVlbtIKcg=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-915 h1:F9CQi6hoPkgpKzDZX7QgDmMBQV+alP3CeEeThxK/jyg=
-github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-915/go.mod h1:knGjmz7WYYptFxOwbMTHD56oslEQrNTq2mDW9qix0fc=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-936 h1:ykZLbjIzQHPfF5v3mYfXEUap5SqaV4EIXuG8PveygMk=
+github.com/cyberark/conjur-opentelemetry-tracer v0.0.1-936/go.mod h1:knGjmz7WYYptFxOwbMTHD56oslEQrNTq2mDW9qix0fc=
 github.com/cyberark/summon v0.9.5 h1:xV/bbI4G9wBOAhtcLCZEFF9ER/3AaTKSPRQyeumpwiI=
 github.com/cyberark/summon v0.9.5/go.mod h1:kT7+4i+d5xvv6HyBQfc2bAexaaZEyOF0XsmNlA/0jWQ=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=


### PR DESCRIPTION
### Desired Outcome

Fix failing release builds and prep for v1.7.17 release

### Implemented Changes

- Use dir content type instead of empty folders. See:  https://goreleaser.com/deprecations/#nfpmsempty_folders
- Pin goreleaser-cross version to v1.19.4 to fix Darwin ARM builds
- Update changelog

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
