### PR TITLE
Fix CI failures

### DIFF
--- a/test/connector/http/conjur/docker-compose.yml
+++ b/test/connector/http/conjur/docker-compose.yml
@@ -40,8 +40,6 @@ services:
       CONJUR_ACCOUNT: dev
       CONJUR_AUTHN_LOGIN: admin
       CONJUR_AUTHN_API_KEY:
-    depends_on:
-      - conjur
     volumes:
       - ./secretless.yml:/secretless.yml
       - ./test-coverage:/test-coverage

--- a/test/connector/tcp/mssql/Dockerfile
+++ b/test/connector/tcp/mssql/Dockerfile
@@ -58,7 +58,7 @@ RUN apt-get update && \
     apt-get install -y ant \
                        software-properties-common \
                        ca-certificates-java && \
-    apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' && \
+    apt-add-repository 'deb http://archive.debian.org/debian-security stretch/updates main' && \
     apt-get update && \
     apt-get install -y openjdk-8-jdk && \
     apt-get clean && \

--- a/test/connector/tcp/pg/Dockerfile.dev
+++ b/test/connector/tcp/pg/Dockerfile.dev
@@ -13,7 +13,7 @@ RUN apt-get update && \
     apt-get install -y ant \
                        ca-certificates-java \
                        software-properties-common && \
-    apt-add-repository 'deb http://security.debian.org/debian-security stretch/updates main' && \
+    apt-add-repository 'deb http://archive.debian.org/debian-security stretch/updates main' && \
     apt-get update && \
     apt-get install -y openjdk-8-jdk && \
     apt-get clean && \


### PR DESCRIPTION
### Desired Outcome

CI tests should pass

### Implemented Changes

Updated the debian repositories and removed a 
conjur dependency from the conjur docker compose files to prevent rebuilding of Conjur for the test files.
### Connected Issue/Story

Resolves #[relevant GitHub issue(s), e.g. 76]

CyberArk internal issue ID: [insert issue ID]

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
