### PR TITLE
Update Docker images used in test

### DIFF
--- a/test/connector/ssh_agent/Dockerfile.ssh_host
+++ b/test/connector/ssh_agent/Dockerfile.ssh_host
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:master-amd64
+FROM phusion/baseimage:jammy-1.0.1
 
 COPY ./id_insecure.pub /tmp/id_insecure.pub
 

--- a/test/providers/vault/docker-compose.yml
+++ b/test/providers/vault/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   vault:
-    image: vault
+    image: hashicorp/vault
     ports:
       - 8200
     volumes:


### PR DESCRIPTION
### Desired Outcome

Fix failing Jenkins build. Logs:

```
Error response from daemon: manifest for vault:latest not found: manifest unknown: manifest unknown
```

```
failed to solve: phusion/baseimage:master-amd64: docker.io/phusion/baseimage:master-amd64: not found
```

### Implemented Changes

- `vault` is deprecated in favor of hashicorp/vault
- `phusion/baseimage` `master` tag is obsolete, using `jammy-1.0.1` (Ubuntu 22.04)

### Connected Issue/Story

N/A

### Definition of Done
*At least 1 todo must be completed in the sections below for the PR to be
merged.*

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [x] There are no security aspects to these changes
