### PR TITLE
#1514 - Fix streaming response delivery for SSE in HTTP proxy

### DIFF
--- a/internal/plugin/connectors/http/proxy_service.go
+++ b/internal/plugin/connectors/http/proxy_service.go
@@ -9,6 +9,7 @@ import (
 	gohttp "net/http"
 	"os"
 	"regexp"
+	"strings"
 
 	"github.com/cyberark/secretless-broker/pkg/secretless/plugin/connector/http"
 	validation "github.com/go-ozzo/ozzo-validation"
@@ -254,9 +255,37 @@ func (proxy *proxyService) handleRequest(
 
 	w.WriteHeader(resp.StatusCode)
 
-	_, err = io.Copy(w, resp.Body)
-	if err != nil {
-		logger.Errorf("Can't write response to body: %s\n", err)
+	// For streaming responses (e.g. Server-Sent Events), flush after
+	// each write to ensure data is delivered to the client incrementally
+	// rather than buffered in Go's default ~4KB ResponseWriter buffer.
+	contentType := resp.Header.Get("Content-Type")
+	isStreaming := strings.Contains(contentType, "text/event-stream") ||
+		strings.Contains(contentType, "text/stream")
+
+	if flusher, ok := w.(gohttp.Flusher); ok && isStreaming {
+		buf := make([]byte, 32*1024)
+		for {
+			n, readErr := resp.Body.Read(buf)
+			if n > 0 {
+				_, writeErr := w.Write(buf[:n])
+				if writeErr != nil {
+					logger.Errorf("Can't write response to body: %s\n", writeErr)
+					break
+				}
+				flusher.Flush()
+			}
+			if readErr != nil {
+				if readErr != io.EOF {
+					logger.Errorf("Error reading response body: %s\n", readErr)
+				}
+				break
+			}
+		}
+	} else {
+		_, err = io.Copy(w, resp.Body)
+		if err != nil {
+			logger.Errorf("Can't write response to body: %s\n", err)
+		}
 	}
 
 	err = resp.Body.Close()


### PR DESCRIPTION
## Summary

Connected to #1514

The HTTP proxy's `handleRequest()` uses `io.Copy()` to relay upstream
responses to the client. For streaming responses (Server-Sent Events),
this causes complete buffering — clients receive zero data until either
~4KB accumulates or the stream ends.

This is a blocker for using the generic HTTP connector with LLM APIs
(OpenAI, Anthropic, Google, etc.) that use SSE for streaming chat
completions.

## Changes

**One file changed:** `internal/plugin/connectors/http/proxy_service.go`

- Detect `text/event-stream` in the upstream response `Content-Type`
- When streaming: use explicit read/write/flush loop via `http.Flusher`
- When not streaming: fall back to existing `io.Copy()` (no behavior change)

## Testing

Verified with a mock SSE server that sends one event per second:

**Before (upstream):** 0 bytes received in 15 seconds — fully buffered, client sees nothing

**After (patch):** Events arrive ~1 second apart, matching server timing:

```
13:46:05.915 data: chatcmpl-0
13:46:06.797 data: chatcmpl-2
13:46:07.798 data: chatcmpl-3
13:46:08.806 data: chatcmpl-4
13:46:09.803 data: chatcmpl-5
13:46:10.828 data: chatcmpl-6
13:46:11.800 data: chatcmpl-7
13:46:12.801 data: chatcmpl-8
13:46:13.801 data: chatcmpl-9
13:46:14.804 data: [DONE]
```

Credential injection (header replacement via generic_http connector) continues to work correctly.

## Non-streaming regression risk

Minimal. The flush path only activates when the upstream responds with
`Content-Type: text/event-stream` or `text/stream`. All other responses
(JSON, HTML, etc.) continue through the existing `io.Copy()` path unchanged.